### PR TITLE
feat(rescue): bounded index-first Codex discovery

### DIFF
--- a/.github/ISSUE_TEMPLATE/diagnostic-report.yml
+++ b/.github/ISSUE_TEMPLATE/diagnostic-report.yml
@@ -1,0 +1,104 @@
+name: Sanitized diagnostic report
+description: Report a redacted doctor, environment, or support-level result.
+title: "[diagnostic]: "
+labels: ["tester", "diagnostic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for a cross-cutting alpha result that is not a single
+        compatibility launch or rescue operation. Read docs/field-testing.md
+        first. Never attach raw sessions, SQLite databases, credentials,
+        prompts, source code, or an unreviewed home-directory path.
+  - type: input
+    id: vetto-version
+    attributes:
+      label: Vetto version
+      description: Copy only the version from `vetto --version`.
+      placeholder: 0.2.0-alpha.2
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - WSL
+    validations:
+      required: true
+  - type: input
+    id: architecture
+    attributes:
+      label: Architecture
+      placeholder: x86_64 or arm64
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Tested surface
+      options:
+        - vetto doctor
+        - Codex CLI
+        - Claude Code CLI
+        - Codex desktop
+        - Claude desktop
+        - Other desktop app
+        - Rescue adapter
+        - Other CLI
+    validations:
+      required: true
+  - type: input
+    id: agent-version
+    attributes:
+      label: Agent and version (if applicable)
+      placeholder: Codex CLI 1.2.3; or N/A
+    validations:
+      required: true
+  - type: dropdown
+    id: support-level
+    attributes:
+      label: Observed support level
+      description: Choose the strongest support claim; use unavailable when the runtime could not be tested or found.
+      options:
+        - protected
+        - rescue-only
+        - observe-only
+        - unsupported
+        - unavailable
+    validations:
+      required: true
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Sanitized doctor or JSON output
+      description: Remove paths, usernames, hostnames, prompts, and all secrets. The sanitizer is best-effort; review it yourself.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction and result
+      description: Include the redacted command, expected result, actual result, exit code, and whether the run was native or WSL.
+      placeholder: |
+        Command: vetto --profile strict --net off --tui none -- <agent> <redacted args>
+        Expected:
+        Actual:
+        Exit code:
+    validations:
+      required: true
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy confirmation
+      options:
+        - label: I removed raw sessions, SQLite/state files, auth/config files, tokens, keys, cookies, prompts, source code, private project names, and unreviewed paths.
+          required: true
+        - label: I understand that Vetto's sanitizer is best-effort and I reviewed every attached or pasted line.
+          required: true
+        - label: This is not a vulnerability report; if it is a security issue, I will use private reporting instead.
+          required: true

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ x64/Apple Silicon, and Windows x64. It selects the matching executable locally;
 there is no install-time binary downloader. To install this release exactly,
 use `npm install --global @shleddy/vetto@0.2.0-alpha.2`. Stable `0.1.x`
 remains on the npm `latest` tag while alpha builds use `next`.
-Alpha testers should follow the privacy and reporting checklist in
+The supported npm name is the scoped `@shleddy/vetto`; the unscoped `vetto`
+package is not the installation path. Alpha testers should follow the
+npm-only privacy, desktop-support, and reporting checklist in
 [docs/field-testing.md](docs/field-testing.md).
 
 The wrapper accepts any executable:
@@ -111,7 +113,13 @@ remains public as historical compatibility evidence; new user installations
 use only `npm install --global @shleddy/vetto@next`.
 
 ```console
+# Current published alpha: bounded session discovery
 vetto rescue --json scan
+# The commands below are on main and are not in 0.2.0-alpha.2 yet.
+# Codex: choose a different provider-index limit
+vetto rescue --json scan --limit 200
+# Codex: explicitly walk the bounded session roots, including unindexed files
+vetto rescue --json scan --all
 vetto rescue diagnose sessions/2026/08/23/session.jsonl
 mkdir recovery
 vetto rescue snapshot session.jsonl --output recovery/session.jsonl
@@ -119,6 +127,18 @@ vetto rescue snapshot session.jsonl --output recovery/session.jsonl
 # Claude: explicit root, read-only and copy-only
 vetto rescue --adapter claude --root ~/.claude --json scan
 ```
+
+On `main`, Codex `scan` is index-first by default and returns at most 50 verified index
+candidates. `--limit N` changes that cap; a missing, stale, or unreadable
+provider index fails closed instead of silently walking the state directory.
+Use `--all` when a bounded filesystem walk is intentional, for example with a
+synthetic fixture or a copied state tree that has no provider index. The JSON
+`discovery.complete` field describes completeness of the selected evidence
+source only: `true` means that all verified candidates from the selected index
+fit within the requested limit, or that the bounded session-root walk finished.
+It never proves that the provider index contains every file in the state root.
+These index-first flags require a later npm alpha; `0.2.0-alpha.2` remains the
+current published build and must not be represented as containing them.
 
 Rescue never reads `auth.json` or `config.toml`, follows session symlinks,
 overwrites an existing destination, writes inside the original agent state
@@ -129,6 +149,13 @@ emits bounded findings without exposing stored paths or rewriting derived
 state. See
 [ADR 0001](docs/adr/0001-universal-rescue-architecture.md) and the
 [Antigravity compatibility gate](docs/compatibility/antigravity.md).
+
+The rescue adapter is not an injector for an already-running desktop app. A
+Codex or Claude desktop process without a documented CLI remains
+`observe-only`/`unavailable`; it must not be reported as sandboxed by wrapping a
+different process. For the exact npm installation, support levels, safe
+Windows/PowerShell commands, and issue-report redaction rules, see
+[the field-testing checklist](docs/field-testing.md).
 
 ## Why an outer boundary?
 

--- a/docs/field-testing.md
+++ b/docs/field-testing.md
@@ -1,50 +1,183 @@
-# Vetto 0.2 field testing
+# Vetto alpha field testing
 
-The `0.2.0-alpha.*` line is an opt-in field test. Install a published build,
-never an arbitrary `main` commit:
+This checklist is for testing a published Vetto npm package on a real local
+machine. It is intentionally npm-only: testers do not need Rust, a checkout of
+the repository, or a build from `main`.
+
+The supported npm package name is the scoped package
+`@shleddy/vetto`. The unscoped `vetto` name is not the installation path.
+
+## Install one published build
+
+Use the `next` tag for the current alpha and record the exact version printed by
+the first command. Do not paste an npm token into an issue and do not install
+from a Git URL.
 
 ```console
 npm install --global @shleddy/vetto@next
+vetto --version
 vetto doctor
-vetto rescue --json scan
 ```
 
-## What to test
+The package contains the native executable for the host platform. It does not
+need a Rust toolchain or an install-time binary download. If npm reports an
+unsupported platform, record the platform and architecture and stop; do not
+work around the package selector by copying a binary from another platform.
 
-1. `vetto doctor` reports the actual backend and tier without claiming missing
-   capabilities.
-2. A normal agent launch still works under the selected policy.
-3. A secret/path/network probe is blocked according to the profile.
-4. `vetto rescue scan` lists only expected session JSONL files.
-5. `diagnose` reports malformed or unterminated records without changing the
-   source.
-6. `snapshot` creates a new verified copy and refuses a second write to the
-   same destination.
+For a repeatable test, pin the version shown by `vetto --version` in the issue
+and reinstall that exact version when reproducing. The alpha tag can move
+between test runs.
 
-## Safe reports
+## What is supported
 
-Use the GitHub issue forms and include:
+Support is a claim about the tested surface, not about the vendor application
+as a whole:
 
-- operating system and architecture;
-- Vetto and agent versions;
-- the exact command and expected/actual result;
-- `vetto doctor` output;
-- a sanitized Vetto report when available.
+| Surface | Current claim | Safe test path |
+| --- | --- | --- |
+| Codex CLI | `protected` when the process is launched through Vetto; persisted-session inspection is `rescue-only` | Wrap `codex` with `vetto -- ...`; use `vetto rescue` for copy-only inspection |
+| Claude Code CLI | `protected` when launched through Vetto; the explicit-root Claude adapter is `rescue-only` and opaque | Wrap `claude` with `vetto -- ...`; pass `--root` for Claude rescue |
+| Aider, OpenCode, Copilot, or another CLI | `protected` only for the process actually launched by Vetto | Use the executable command as the final argv after `--`; report the exact command and version |
+| Codex/Claude/Cursor/Antigravity desktop GUI | `observe-only` or `unavailable`; Vetto does not inject into an already-running GUI | Test only a documented CLI, if the product has one; never claim that an existing GUI process was sandboxed |
 
-Never upload raw agent sessions, `auth.json`, configuration files, API keys,
-cookies, access tokens, private keys, proprietary prompts, or an unreviewed
-home-directory path. The sanitizer is best-effort, so inspect every artifact
-yourself before sharing it.
+`integrated` is not a blanket claim for a provider. A provider adapter must
+earn that level through its adapter contract and fixtures. An unavailable
+desktop integration is an honest result, not a failed workaround to hide.
 
-Security vulnerabilities do not belong in public issues. Use GitHub private
-vulnerability reporting from the repository Security tab.
+## Baseline commands
 
-## Alpha quality gates
+Run these from a disposable project directory. The commands only launch a
+process through Vetto or inspect state read-only.
 
-An alpha advances only when its stated scope has:
+```console
+vetto doctor
+vetto doctor --probe
 
-- no unresolved P0/P1 regression;
-- green unit, integration, clippy and release-matrix checks;
-- a passing Gitleaks history and release-archive scan;
-- published checksums and known limitations;
-- a tested rollback or uninstall path.
+# Codex CLI, headless smoke test
+vetto --profile strict --net off --tui none -- codex exec "print one short test line"
+
+# Claude Code CLI, headless smoke test
+vetto --profile strict --net off --tui none -- claude -p "print one short test line"
+```
+
+Use the same wrapper for another local CLI, for example:
+
+```console
+vetto --profile strict --net off --tui none -- aider --version
+```
+
+If the agent needs network access for a test, state the exact allowlist in the
+issue. Keep the default `--net off` for the first run. Never pass a secret
+through the environment just to make a smoke test pass; Vetto rebuilds the
+child environment from an allowlist.
+
+On Windows PowerShell, the same commands work. A desktop application that has
+no CLI cannot be wrapped by typing its name into this command: an already
+running GUI process is outside this support claim.
+
+## Read-only rescue checks
+
+Rescue never edits the provider state root. Put output in a new directory that
+is outside `.codex`, `.claude`, or another agent state directory.
+
+Codex uses `CODEX_HOME`, then the platform home directory. An explicit root is
+useful for a fixture or a copied state tree:
+
+```console
+# Current published alpha
+vetto rescue --json scan
+vetto rescue --json diagnose "sessions/2026/08/23/session.jsonl"
+vetto rescue --json snapshot "sessions/2026/08/23/session.jsonl" --output "./recovery/session.jsonl"
+```
+
+The next unpublished code on `main` changes Codex scan to index-first, adds a
+default return cap of 50, `--limit N`, explicit `--all`, and the JSON
+`discovery` object. Do not put those commands in a public field-test result
+until a later npm alpha actually contains them. For that later build,
+`discovery.complete` will describe only the selected evidence source; it will
+not prove that the provider index covers every file under the state root.
+
+On Windows PowerShell, an explicit Claude root looks like this:
+
+```powershell
+vetto rescue --adapter claude --root "$env:USERPROFILE\.claude" --json scan
+vetto rescue --adapter claude --root "$env:USERPROFILE\.claude" --json diagnose "projects/example/session.jsonl"
+```
+
+The Claude adapter treats provider JSONL as opaque. It does not reconstruct
+provider state or write a vendor database. `snapshot` and `fork` are verified,
+exclusive copies; an existing destination, a symlink, a changing source, or a
+destination inside the source root must fail closed.
+
+For a rescue report, record the adapter, operation, exit code, and whether the
+source hash stayed unchanged. Do not use a real session as a public fixture.
+Use a synthetic JSONL fixture with fake names and fake content whenever a
+reproduction needs an input file.
+
+## Report a result safely
+
+Open the closest issue form:
+
+- **Alpha compatibility test** for a protected CLI launch or a desktop/IDE
+  compatibility result;
+- **Alpha recovery test** for `scan`, `diagnose`, `snapshot`, or `fork`;
+- **Sanitized diagnostic report** for a cross-cutting doctor, environment, or
+  support-level result that does not fit the two forms above.
+
+Include only the following, after review:
+
+- Vetto version from `vetto --version` and the agent name/version;
+- OS family, OS version, architecture, and whether the run was native or WSL;
+- the exact command with project names, usernames, hostnames, and secrets
+  replaced by placeholders;
+- expected result, actual result, exit code, and a short reproduction;
+- sanitized `vetto doctor` output and, when relevant, sanitized `--json` output;
+- the selected support level (`protected`, `rescue-only`, `observe-only`, or
+  `unsupported`) and why that level is appropriate. `unavailable` describes
+  runtime availability and is separate from the `unsupported` support claim;
+- for snapshot/fork, confirmation that the source was unchanged and the
+  destination did not already exist.
+
+The sanitizer is best-effort, not a guarantee. Inspect every line before
+posting. In particular, replace paths even when they look harmless:
+
+```text
+C:\Users\alice\project        -> <PROJECT>
+/home/alice/.codex             -> <CODEX_HOME>
+https://api.example.test/key   -> <URL>
+```
+
+Never attach or paste any of the following:
+
+- raw Codex/Claude/agent JSONL, SQLite databases, or copied state directories;
+- `auth.json`, `config.toml`, `.env`, shell history, SSH keys, certificates,
+  cookies, access tokens, API keys, npm credentials, or cloud credentials;
+- prompts, tool arguments, repository source, diffs, private project names, or
+  unreviewed home-directory paths;
+- a full environment dump, a full command transcript, or an unredacted report;
+- a security vulnerability proof-of-concept in a public issue.
+
+If a report may expose a vulnerability or a bypass, stop and use the private
+security reporting link in the repository instead of a public issue. Do not
+publish a working exploit while asking for a compatibility review.
+
+## Triage expectations
+
+One issue should describe one host, one Vetto version, one agent version, and
+one primary failure. Separate unrelated platform results. A result from a
+desktop GUI is not evidence that the corresponding CLI is broken, and a
+rescue-only finding is not evidence that the launch boundary failed.
+
+Maintainers may request a synthetic fixture or a second run with an explicit
+root. They should never request raw vendor state or credentials. A missing
+capability, a moving session, an opaque provider schema, and an unsupported
+desktop surface are valid bounded outcomes and should remain visible in the
+report.
+
+## Alpha gate
+
+The alpha line advances only after the scoped change has a green cross-platform
+CI run, focused regression coverage, and a documented limitation. Field tests
+can provide evidence, but they do not turn an unverified provider or desktop
+integration into a support claim. No tester should publish a release or modify
+the provider's state to qualify a result.

--- a/docs/schema/rescue-adapter-contract-v1.md
+++ b/docs/schema/rescue-adapter-contract-v1.md
@@ -23,10 +23,12 @@ fields with `additionalProperties: false`.
 ## Operations
 
 An adapter may implement `detect`, `discover_sessions`, `diagnose`,
-`snapshot`, and `fork`. `snapshot` and `fork` are copy-only operations. They
-never edit, delete, rename, replace, or reconstruct an original vendor
-session/database. A future adapter must explicitly document any additional
-capability before it is exposed.
+`snapshot`, and `fork`. `snapshot` and `fork` are copy-only operations. In the
+current CLI, `fork` is an alias of the `snapshot` implementation: it creates a
+new verified copy and does not claim provider-side resume, reconstruction, or
+database mutation. Both operations never edit, delete, rename, replace, or
+reconstruct an original vendor session/database. A future adapter must
+explicitly document any additional capability before it is exposed.
 
 Provider-derived inventory may be inspected only through a read-only/no-create
 database connection. Schema disagreement, a moving cursor, or unreadable
@@ -40,10 +42,17 @@ The reference Codex adapter enforces these defaults for every invocation:
 
 | Budget | Default |
 | --- | ---: |
-| discovered entries | 10,000 |
+| filesystem-walk discovered entries | 10,000 |
 | all discovered session bytes | 512 MiB |
 | one session | 64 MiB |
 | one JSONL record | 16 MiB |
+
+Codex `rescue scan` is index-first by default and returns at most 50 verified
+provider-index candidates. `--limit N` selects a different positive return
+limit, still subject to the bounded discovery and byte budgets. `--all` is the
+explicit bounded filesystem walk and is the only scan mode that enumerates
+unindexed session files. A missing or unreadable provider index is an error in
+index-first mode; it never causes an implicit partial filesystem fallback.
 
 Exceeding a discovery or session budget is an error. Oversized JSONL records
 are counted as corrupt and are not parsed. Adapters must not recurse through a
@@ -67,6 +76,24 @@ result types. Internal source paths are omitted. All user-derived strings are
 passed through Vetto's best-effort sanitizer before serialization. Consumers
 must treat unknown JSON fields as forward-compatible and must not infer a
 stronger support level from a missing capability.
+
+For `rescue scan`, the public result contains `sessions` and a `discovery`
+object with these fields:
+
+- `mode`: `index-first`, `filesystem-all` for Codex `--all`, or `filesystem`
+  for adapters whose normal discovery is filesystem-based (such as Claude);
+- `scope`: `provider-index` or `session-roots`;
+- `source`: a stable source label such as `sqlite`, `session-index`,
+  `session-index+sqlite`, or `session-roots`; it contains no user path;
+- `complete`: whether the selected evidence source was fully returned within
+  its limit/budget. For `provider-index`, `true` means all verified candidates
+  from that index fit within the selected limit. It never proves that the
+  provider index covers every file in the state root;
+- `limit`: the effective index return limit, or `null` for filesystem
+  discovery (including `--all`);
+- `candidate_count`: verified candidates from the selected source before the
+  return limit;
+- `returned_count`: sessions included in `sessions`.
 
 ## Conformance requirements
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,8 @@ Examples:
   vetto multi --agent lint=/usr/bin/cargo --agent test=/usr/bin/cargo
   vetto doctor
   vetto doctor --probe
-  vetto rescue --json scan
+  vetto rescue --json scan --limit 25
+  vetto rescue --json scan --all
   vetto rescue diagnose sessions/2026/08/23/session.jsonl
   vetto rescue snapshot session.jsonl --output ./recovery/session.jsonl
   vetto report compare session-a.json session-b.json
@@ -208,8 +209,18 @@ pub enum ReportCommand {
 
 #[derive(Subcommand, Debug)]
 pub enum RescueCommand {
-    /// Discover bounded regular JSONL sessions under the adapter state root.
-    Scan,
+    /// Discover sessions. Codex defaults to verified index-first (limit 50);
+    /// other adapters use their bounded filesystem discovery.
+    Scan {
+        /// For Codex, use a verified provider index and return at most COUNT
+        /// sessions. This never falls back to a filesystem walk.
+        #[arg(long, value_name = "COUNT", conflicts_with = "all")]
+        limit: Option<usize>,
+        /// Explicitly use the bounded recursive filesystem walk. For Codex,
+        /// this opts out of the default index-first scan.
+        #[arg(long, conflicts_with = "limit")]
+        all: bool,
+    },
     /// Diagnose one exact session key without changing agent state.
     Diagnose {
         #[arg(value_name = "SESSION")]
@@ -310,6 +321,48 @@ mod tests {
                 command: RescueCommand::Diagnose { ref session },
                 ..
             }) if adapter == "codex" && session == "sessions/example.jsonl"
+        ));
+    }
+
+    #[test]
+    fn rescue_scan_exposes_explicit_index_limit_and_full_walk_modes() {
+        let default = Cli::try_parse_from(["vetto", "rescue", "scan"])
+            .expect("default rescue scan syntax");
+        assert!(matches!(
+            default.command,
+            Some(Command::Rescue {
+                command: RescueCommand::Scan {
+                    limit: None,
+                    all: false,
+                },
+                ..
+            })
+        ));
+
+        let limited = Cli::try_parse_from(["vetto", "rescue", "scan", "--limit", "25"])
+            .expect("limited rescue scan syntax");
+        assert!(matches!(
+            limited.command,
+            Some(Command::Rescue {
+                command: RescueCommand::Scan {
+                    limit: Some(25),
+                    all: false,
+                },
+                ..
+            })
+        ));
+
+        let full = Cli::try_parse_from(["vetto", "rescue", "scan", "--all"])
+            .expect("full rescue scan syntax");
+        assert!(matches!(
+            full.command,
+            Some(Command::Rescue {
+                command: RescueCommand::Scan {
+                    limit: None,
+                    all: true,
+                },
+                ..
+            })
         ));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -326,8 +326,8 @@ mod tests {
 
     #[test]
     fn rescue_scan_exposes_explicit_index_limit_and_full_walk_modes() {
-        let default = Cli::try_parse_from(["vetto", "rescue", "scan"])
-            .expect("default rescue scan syntax");
+        let default =
+            Cli::try_parse_from(["vetto", "rescue", "scan"]).expect("default rescue scan syntax");
         assert!(matches!(
             default.command,
             Some(Command::Rescue {

--- a/src/rescue/codex_index.rs
+++ b/src/rescue/codex_index.rs
@@ -132,9 +132,8 @@ pub fn discover(context: &RescueContext, limit: usize) -> Result<IndexDiscovery>
 }
 
 fn canonical_root(root: &Path) -> Result<PathBuf> {
-    let metadata = fs::symlink_metadata(root).with_context(|| {
-        "Codex rescue root is unavailable; pass --root to a real Codex home"
-    })?;
+    let metadata = fs::symlink_metadata(root)
+        .with_context(|| "Codex rescue root is unavailable; pass --root to a real Codex home")?;
     if metadata.file_type().is_symlink() || !metadata.is_dir() {
         bail!("Codex rescue root must be a real directory");
     }
@@ -227,7 +226,10 @@ fn verify_index_path(
         bail!("Codex index references a non-JSONL rollout file");
     }
     let canonical = fs::canonicalize(&candidate).context("canonicalize indexed rollout")?;
-    if !roots.iter().any(|session_root| canonical.starts_with(session_root)) {
+    if !roots
+        .iter()
+        .any(|session_root| canonical.starts_with(session_root))
+    {
         bail!("Codex index references a rollout outside the session roots");
     }
     let (_file, canonical_metadata) = open_regular_file(&canonical, "indexed rollout")?;
@@ -299,7 +301,10 @@ fn read_session_index(
             continue;
         }
         if raw.len() > context.max_record_bytes {
-            bail!("Codex session index record {} exceeds the record budget", line_number + 1);
+            bail!(
+                "Codex session index record {} exceeds the record budget",
+                line_number + 1
+            );
         }
         let value: Value = serde_json::from_slice(raw).with_context(|| {
             format!(
@@ -665,10 +670,7 @@ mod tests {
         context.max_files = 1;
 
         let error = discover(&context, 10).expect_err("index row budget");
-        assert!(
-            error.to_string().contains("entry budget"),
-            "{error:#}"
-        );
+        assert!(error.to_string().contains("entry budget"), "{error:#}");
     }
 
     #[test]
@@ -682,7 +684,7 @@ mod tests {
 
         let error = discover(&context, 10).expect_err("oversized SQLite index");
         assert!(
-            error.to_string().contains("SQLite index exceeds"),
+            error.to_string().contains("SQLite") && error.to_string().contains("byte budget"),
             "{error:#}"
         );
     }
@@ -696,7 +698,9 @@ mod tests {
         let first_db = root.join("state_5.sqlite");
         let second_db = root.join("state.sqlite");
         fs::copy(&first_db, &second_db).expect("copy second SQLite index");
-        let first_size = fs::metadata(&first_db).expect("first SQLite metadata").len();
+        let first_size = fs::metadata(&first_db)
+            .expect("first SQLite metadata")
+            .len();
         let second_size = fs::metadata(&second_db)
             .expect("second SQLite metadata")
             .len();
@@ -708,8 +712,7 @@ mod tests {
 
         let error = discover(&context, 10).expect_err("aggregate SQLite size");
         assert!(
-            error.to_string().contains("aggregate")
-                && error.to_string().contains("SQLite indexes"),
+            error.to_string().contains("aggregate") && error.to_string().contains("SQLite indexes"),
             "{error:#}"
         );
     }
@@ -740,8 +743,7 @@ mod tests {
 
         let error = discover(&RescueContext::new(root), 10).expect_err("stale index");
         assert!(
-            error.to_string().contains("unavailable")
-                || error.to_string().contains("rollout"),
+            error.to_string().contains("unavailable") || error.to_string().contains("rollout"),
             "{error:#}"
         );
     }
@@ -753,7 +755,9 @@ mod tests {
         let _session = rollout(&root, "filesystem-only.jsonl");
 
         let error = discover(&RescueContext::new(root), 10).expect_err("missing index");
-        assert!(error.to_string().contains("requires a readable Codex index"));
+        assert!(error
+            .to_string()
+            .contains("requires a readable Codex index"));
     }
 
     #[test]
@@ -764,7 +768,10 @@ mod tests {
         fs::create_dir_all(&root).expect("codex root");
         fs::write(
             root.join(SESSION_INDEX_NAME),
-            format!("{{\"rollout_path\":\"{}\"}}\n", indexed.to_string_lossy()),
+            format!(
+                "{}\n",
+                serde_json::json!({ "rollout_path": indexed.to_string_lossy() })
+            ),
         )
         .expect("session index");
 
@@ -782,9 +789,9 @@ mod tests {
         fs::write(
             root.join(SESSION_INDEX_NAME),
             format!(
-                "{{\"rollout_path\":\"{}\"}}\n{{\"rollout_path\":\"{}\"}}\n",
-                first.to_string_lossy(),
-                second.to_string_lossy()
+                "{}\n{}\n",
+                serde_json::json!({ "rollout_path": first.to_string_lossy() }),
+                serde_json::json!({ "rollout_path": second.to_string_lossy() })
             ),
         )
         .expect("session index");
@@ -820,11 +827,8 @@ mod tests {
         let root = temp.codex_home();
         let indexed = rollout(&root, "indexed.jsonl");
         sqlite_index(&root, &[&indexed]);
-        fs::hard_link(
-            root.join("state_5.sqlite"),
-            root.join("state-alias.sqlite"),
-        )
-        .expect("hardlink SQLite index");
+        fs::hard_link(root.join("state_5.sqlite"), root.join("state-alias.sqlite"))
+            .expect("hardlink SQLite index");
 
         let error = discover(&RescueContext::new(root), 10).expect_err("hardlinked SQLite");
         assert!(error.to_string().contains("hardlinked"), "{error:#}");

--- a/src/rescue/codex_index.rs
+++ b/src/rescue/codex_index.rs
@@ -1,0 +1,832 @@
+//! Read-only, index-first discovery for Codex rollout files.
+//!
+//! The normal filesystem walk is intentionally kept as an explicit escape
+//! hatch (`vetto rescue scan --all`).  Large Codex homes can contain many
+//! thousands of rollout files, while the provider's SQLite state store (or a
+//! small `session_index.jsonl` file supplied by a future provider version)
+//! already identifies the sessions a user is likely trying to recover.  This
+//! module consumes those indexes without opening them for writing, verifies
+//! every path before returning it, and fails closed when the index cannot be
+//! trusted.  It never falls back to a partial directory walk.
+
+use std::collections::HashSet;
+use std::fs::{self, File, Metadata, OpenOptions};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use rusqlite::{types::ValueRef, Connection, OpenFlags};
+use serde_json::Value;
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+use super::types::{RescueContext, SessionRef};
+
+const MAX_INDEX_ROWS: usize = 100_000;
+const MAX_SQLITE_DATABASES: usize = 64;
+const SQLITE_NAMES: [&str; 3] = ["state_5.sqlite", "state.sqlite", "state.db"];
+const SESSION_INDEX_NAME: &str = "session_index.jsonl";
+const PATH_COLUMNS: [&str; 3] = ["rollout_path", "session_path", "path"];
+
+/// Result of a verified index-first discovery pass.
+#[derive(Debug)]
+pub struct IndexDiscovery {
+    pub sessions: Vec<SessionRef>,
+    /// Number of unique index records verified before applying `--limit`.
+    pub candidate_count: usize,
+    pub truncated: bool,
+    /// Stable source label; this intentionally contains no user paths.
+    pub source: String,
+}
+
+#[derive(Debug, Clone)]
+struct IndexPath {
+    raw: String,
+}
+
+/// Discover sessions from provider indexes, with an optional caller limit.
+///
+/// A missing or unreadable index is an error.  In particular, this function
+/// does not silently switch to the recursive filesystem walker: a successful
+/// limited scan must mean that the requested result came from a verified
+/// index.  The caller can request the bounded filesystem walk explicitly with
+/// `--all`.
+pub fn discover(context: &RescueContext, limit: usize) -> Result<IndexDiscovery> {
+    if limit == 0 {
+        bail!("rescue scan --limit must be greater than zero");
+    }
+
+    let root = canonical_root(&context.root)?;
+    let max_index_rows = context.max_files.min(MAX_INDEX_ROWS);
+    if max_index_rows == 0 {
+        bail!("limited rescue scan requires a positive max_files budget");
+    }
+    let mut paths = Vec::new();
+    let mut sources = Vec::new();
+
+    if let Some(index_paths) = read_session_index(&root, context, max_index_rows)? {
+        sources.push("session-index");
+        paths.extend(index_paths);
+    }
+
+    if let Some(sqlite_paths) = read_sqlite_indexes(context, &root, max_index_rows)? {
+        sources.push("sqlite");
+        paths.extend(sqlite_paths);
+    }
+
+    if sources.is_empty() {
+        bail!(
+            "limited rescue scan requires a readable Codex index (state SQLite or session_index.jsonl); use `vetto rescue scan --all` for an explicit filesystem walk"
+        );
+    }
+    if paths.is_empty() {
+        bail!(
+            "Codex index was found but contained no rollout paths; refusing to return a misleading empty limited scan"
+        );
+    }
+    if paths.len() > max_index_rows {
+        bail!(
+            "Codex index exceeded the configured {} entry budget",
+            context.max_files
+        );
+    }
+
+    let roots = session_roots(&root)?;
+    let mut seen = HashSet::new();
+    let mut sessions = Vec::with_capacity(paths.len());
+    for index_path in paths {
+        let session = verify_index_path(context, &root, &roots, &index_path.raw)?;
+        if seen.insert(session.source_path.clone()) {
+            sessions.push(session);
+        }
+    }
+
+    sessions.sort_by(|left, right| {
+        right
+            .modified_unix_secs
+            .cmp(&left.modified_unix_secs)
+            .then_with(|| left.key.cmp(&right.key))
+    });
+    let candidate_count = sessions.len();
+    let truncated = candidate_count > limit;
+    let total_bytes = sessions.iter().try_fold(0u64, |total, session| {
+        total
+            .checked_add(session.bytes)
+            .context("indexed session byte counter overflow")
+    })?;
+    if total_bytes > context.max_total_bytes {
+        bail!(
+            "limited rescue scan exceeded the {} byte budget",
+            context.max_total_bytes
+        );
+    }
+    sessions.truncate(limit);
+
+    Ok(IndexDiscovery {
+        sessions,
+        candidate_count,
+        truncated,
+        source: sources.join("+"),
+    })
+}
+
+fn canonical_root(root: &Path) -> Result<PathBuf> {
+    let metadata = fs::symlink_metadata(root).with_context(|| {
+        "Codex rescue root is unavailable; pass --root to a real Codex home"
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!("Codex rescue root must be a real directory");
+    }
+    fs::canonicalize(root).context("Codex rescue root cannot be canonicalized")
+}
+
+fn session_roots(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut roots = Vec::new();
+    for name in ["sessions", "archived_sessions"] {
+        let path = root.join(name);
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error).context("inspect Codex session root"),
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            continue;
+        }
+        let canonical = fs::canonicalize(path).context("canonicalize Codex session root")?;
+        if canonical.starts_with(root) {
+            roots.push(canonical);
+        }
+    }
+    if roots.is_empty() {
+        bail!("Codex index is present but no real sessions directory exists");
+    }
+    Ok(roots)
+}
+
+/// Open a read-only regular file and validate the metadata of the acquired
+/// handle. Unix uses O_NOFOLLOW for the final path component and rejects
+/// hardlinks. Windows has no safe, stable std-only equivalent for every
+/// reparse-point type; callers still reject an observed symlink before open
+/// and re-check the canonical identity after the handle is acquired.
+fn open_regular_file(path: &Path, label: &str) -> Result<(File, Metadata)> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    let file = options
+        .open(path)
+        .with_context(|| format!("open {label}"))?;
+    let metadata = file.metadata().with_context(|| format!("stat {label}"))?;
+    if !metadata.is_file() {
+        bail!("{label} is not a regular file");
+    }
+    #[cfg(unix)]
+    if metadata.nlink() != 1 {
+        bail!("{label} must not be hardlinked");
+    }
+    Ok((file, metadata))
+}
+
+fn ensure_path_unchanged(path: &Path, before: &Metadata, label: &str) -> Result<()> {
+    let after = fs::symlink_metadata(path).with_context(|| format!("recheck {label}"))?;
+    if after.file_type().is_symlink() || !after.is_file() {
+        bail!("{label} changed to a non-regular file");
+    }
+    #[cfg(unix)]
+    if after.dev() != before.dev() || after.ino() != before.ino() {
+        bail!("{label} changed while being verified");
+    }
+    #[cfg(not(unix))]
+    if after.len() != before.len() || after.modified().ok() != before.modified().ok() {
+        bail!("{label} changed while being verified");
+    }
+    Ok(())
+}
+
+fn verify_index_path(
+    context: &RescueContext,
+    root: &Path,
+    roots: &[PathBuf],
+    raw: &str,
+) -> Result<SessionRef> {
+    if raw.is_empty() || raw.contains('\0') {
+        bail!("Codex index contains an invalid rollout path");
+    }
+    let candidate = if Path::new(raw).is_absolute() {
+        PathBuf::from(raw)
+    } else {
+        root.join(raw)
+    };
+    let candidate_metadata = fs::symlink_metadata(&candidate)
+        .context("Codex index references an unavailable rollout")?;
+    if candidate_metadata.file_type().is_symlink() || !candidate_metadata.is_file() {
+        bail!("Codex index references a non-regular rollout file");
+    }
+    if candidate.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+        bail!("Codex index references a non-JSONL rollout file");
+    }
+    let canonical = fs::canonicalize(&candidate).context("canonicalize indexed rollout")?;
+    if !roots.iter().any(|session_root| canonical.starts_with(session_root)) {
+        bail!("Codex index references a rollout outside the session roots");
+    }
+    let (_file, canonical_metadata) = open_regular_file(&canonical, "indexed rollout")?;
+    ensure_path_unchanged(&canonical, &canonical_metadata, "indexed rollout")?;
+    if canonical_metadata.len() > context.max_session_bytes {
+        bail!(
+            "Codex index references a rollout over the {} byte inspection budget",
+            context.max_session_bytes
+        );
+    }
+    // The canonical path was checked before opening. Re-canonicalizing after
+    // the handle is acquired detects a parent-directory replacement on all
+    // platforms. Unix additionally uses O_NOFOLLOW for the final component;
+    // Windows reparse-point races cannot be made atomic with safe std APIs,
+    // so a changed identity is rejected and no recovery action is performed.
+    let rechecked = fs::canonicalize(&canonical).context("recheck indexed rollout")?;
+    if rechecked != canonical {
+        bail!("indexed rollout changed while being verified");
+    }
+    let relative = canonical
+        .strip_prefix(root)
+        .context("indexed rollout is outside the Codex root")?
+        .to_string_lossy()
+        .replace('\\', "/");
+    let modified_unix_secs = canonical_metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_secs());
+    Ok(SessionRef {
+        adapter: "codex".to_string(),
+        key: relative.clone(),
+        relative_path: relative,
+        bytes: canonical_metadata.len(),
+        modified_unix_secs,
+        source_path: canonical,
+    })
+}
+
+fn read_session_index(
+    root: &Path,
+    context: &RescueContext,
+    max_index_rows: usize,
+) -> Result<Option<Vec<IndexPath>>> {
+    let path = root.join(SESSION_INDEX_NAME);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).context("inspect Codex session index"),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!("Codex session index is not a regular file");
+    }
+    if metadata.len() > context.max_session_bytes {
+        bail!(
+            "Codex session index exceeds the {} byte inspection budget",
+            context.max_session_bytes
+        );
+    }
+    let first = read_bounded(&path, context.max_session_bytes)?;
+    let second = read_bounded(&path, context.max_session_bytes)?;
+    if first != second {
+        bail!("Codex session index changed while being read; retry after the writer stops");
+    }
+    let mut paths = Vec::new();
+    for (line_number, raw) in first.split(|byte| *byte == b'\n').enumerate() {
+        let raw = raw.strip_suffix(b"\r").unwrap_or(raw);
+        if raw.is_empty() {
+            continue;
+        }
+        if raw.len() > context.max_record_bytes {
+            bail!("Codex session index record {} exceeds the record budget", line_number + 1);
+        }
+        let value: Value = serde_json::from_slice(raw).with_context(|| {
+            format!(
+                "Codex session index record {} is not valid JSON",
+                line_number + 1
+            )
+        })?;
+        for path in extract_paths(&value, 0) {
+            paths.push(IndexPath { raw: path });
+        }
+        if paths.len() > max_index_rows {
+            bail!(
+                "Codex session index exceeded the configured {} entry budget",
+                context.max_files
+            );
+        }
+    }
+    Ok(Some(paths))
+}
+
+fn extract_paths(value: &Value, depth: usize) -> Vec<String> {
+    if depth > 2 {
+        return Vec::new();
+    }
+    let Some(object) = value.as_object() else {
+        return Vec::new();
+    };
+    let mut paths = Vec::new();
+    for key in PATH_COLUMNS {
+        if let Some(path) = object
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|path| !path.is_empty())
+        {
+            paths.push(path.to_string());
+        }
+    }
+    for key in ["thread", "session", "rollout"] {
+        if let Some(nested) = object.get(key) {
+            paths.extend(extract_paths(nested, depth + 1));
+        }
+    }
+    paths
+}
+
+fn read_sqlite_indexes(
+    context: &RescueContext,
+    root: &Path,
+    max_index_rows: usize,
+) -> Result<Option<Vec<IndexPath>>> {
+    let max_database_candidates = max_index_rows.min(MAX_SQLITE_DATABASES);
+    if max_database_candidates == 0 {
+        bail!("limited rescue scan requires a positive SQLite candidate budget");
+    }
+    let mut candidates = Vec::new();
+    for name in SQLITE_NAMES.iter().copied() {
+        let path = root.join(name);
+        match fs::symlink_metadata(&path) {
+            Ok(_) => {
+                if candidates.len() >= max_database_candidates {
+                    bail!(
+                        "Codex SQLite index fanout exceeded the configured {} entry budget",
+                        context.max_files
+                    );
+                }
+                candidates.push(path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error).context("inspect Codex root for SQLite indexes"),
+        }
+    }
+
+    // Keep support for provider schema revisions that use a different state
+    // filename, but inspect only direct children and only database suffixes.
+    // This stays streaming and bounded: a hostile Codex root cannot make us
+    // collect an unbounded list of arbitrary database filenames.
+    let mut known_names = SQLITE_NAMES
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect::<HashSet<_>>();
+    for entry in fs::read_dir(root).context("inspect Codex root for SQLite indexes")? {
+        let entry = entry.context("inspect Codex root for SQLite indexes")?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        let lower = name.to_ascii_lowercase();
+        if (lower.ends_with(".sqlite") || lower.ends_with(".sqlite3") || lower.ends_with(".db"))
+            && known_names.insert(name.to_string())
+        {
+            if candidates.len() >= max_database_candidates {
+                bail!(
+                    "Codex SQLite index fanout exceeded the configured {} entry budget",
+                    context.max_files
+                );
+            }
+            candidates.push(path);
+        }
+    }
+
+    // Preflight every bounded candidate before opening any SQLite connection.
+    // This makes the aggregate byte budget meaningful even when several state
+    // databases are present: one large file cannot consume the full budget
+    // and leave later candidates unchecked.
+    let mut verified_candidates = Vec::with_capacity(candidates.len());
+    let mut sqlite_total_bytes = 0u64;
+    for path in candidates {
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error).context("inspect Codex SQLite index"),
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            bail!("Codex SQLite index is not a regular file");
+        }
+        #[cfg(unix)]
+        if metadata.nlink() != 1 {
+            bail!("Codex SQLite index must not be hardlinked");
+        }
+        sqlite_total_bytes = sqlite_total_bytes
+            .checked_add(metadata.len())
+            .context("Codex SQLite index byte counter overflow")?;
+        if sqlite_total_bytes > context.max_total_bytes {
+            bail!(
+                "Codex SQLite indexes exceed the aggregate {} byte budget",
+                context.max_total_bytes
+            );
+        }
+        verified_candidates.push((path, metadata));
+    }
+
+    let mut found = false;
+    let mut paths = Vec::new();
+    for (path, metadata) in verified_candidates {
+        found = true;
+        let canonical = fs::canonicalize(&path).context("canonicalize Codex SQLite index")?;
+        let connection = open_read_only(&canonical)?;
+        ensure_path_unchanged(&path, &metadata, "Codex SQLite index")?;
+        let tables = table_names(&connection)?;
+        if !tables.iter().any(|table| table == "threads") {
+            continue;
+        }
+        let columns = table_columns(&connection, "threads")?;
+        let Some(path_column) = PATH_COLUMNS.iter().find(|name| columns.contains(**name)) else {
+            continue;
+        };
+        let sql = format!(
+            "SELECT {} FROM \"threads\" LIMIT {}",
+            quote_identifier(path_column),
+            max_index_rows + 1
+        );
+        let mut statement = connection
+            .prepare(&sql)
+            .context("read Codex SQLite rollout index")?;
+        let rows = statement
+            .query_map([], |row| row.get_ref(0).map(value_text))
+            .context("read Codex SQLite rollout index")?;
+        let mut local_count = 0usize;
+        for row in rows {
+            local_count = local_count
+                .checked_add(1)
+                .context("Codex SQLite index row counter overflow")?;
+            if local_count > max_index_rows {
+                bail!(
+                    "Codex SQLite index exceeded the configured {} entry budget",
+                    context.max_files
+                );
+            }
+            if let Some(path) = row
+                .context("read Codex SQLite rollout path")?
+                .filter(|path| !path.is_empty())
+            {
+                paths.push(IndexPath { raw: path });
+                if paths.len() > max_index_rows {
+                    bail!(
+                        "Codex SQLite index exceeded the configured {} entry budget",
+                        context.max_files
+                    );
+                }
+            }
+        }
+    }
+    if found {
+        Ok(Some(paths))
+    } else {
+        Ok(None)
+    }
+}
+
+fn open_read_only(path: &Path) -> Result<Connection> {
+    // rusqlite's portable path API cannot be given an already-open std::fs
+    // handle. The caller therefore performs regular-file, hardlink, size,
+    // and post-open identity checks around this read-only open. This is a
+    // bounded diagnostic path, not an atomic no-follow guarantee on Windows
+    // reparse points.
+    let connection = Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|_| anyhow::anyhow!("Codex SQLite index could not be opened read-only"))?;
+    connection
+        .execute_batch("PRAGMA query_only=ON; PRAGMA busy_timeout=250;")
+        .map_err(|_| anyhow::anyhow!("Codex SQLite index could not be configured read-only"))?;
+    Ok(connection)
+}
+
+fn table_names(connection: &Connection) -> Result<Vec<String>> {
+    let mut statement = connection
+        .prepare("SELECT name FROM sqlite_schema WHERE type='table'")
+        .context("read Codex SQLite schema")?;
+    let rows = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .context("read Codex SQLite schema")?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .context("read Codex SQLite schema")
+}
+
+fn table_columns(connection: &Connection, table: &str) -> Result<HashSet<String>> {
+    let sql = format!("PRAGMA table_info({})", quote_identifier(table));
+    let mut statement = connection
+        .prepare(&sql)
+        .context("read Codex SQLite table schema")?;
+    let rows = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .context("read Codex SQLite table schema")?;
+    Ok(rows
+        .collect::<rusqlite::Result<Vec<_>>>()?
+        .into_iter()
+        .collect())
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn value_text(value: ValueRef<'_>) -> Option<String> {
+    match value {
+        ValueRef::Text(value) => std::str::from_utf8(value).ok().map(ToOwned::to_owned),
+        ValueRef::Integer(value) => Some(value.to_string()),
+        ValueRef::Real(value) => Some(value.to_string()),
+        ValueRef::Null | ValueRef::Blob(_) => None,
+    }
+}
+
+fn read_bounded(path: &Path, limit: u64) -> Result<Vec<u8>> {
+    let (mut file, metadata) = open_regular_file(path, "Codex session index")?;
+    ensure_path_unchanged(path, &metadata, "Codex session index")?;
+    if metadata.len() > limit {
+        bail!("Codex session index exceeds the inspection budget");
+    }
+    let mut bytes = Vec::new();
+    file.by_ref()
+        .take(limit.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .context("read Codex session index")?;
+    if bytes.len() as u64 > limit {
+        bail!("Codex session index exceeds the inspection budget");
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEMP_ROOT: AtomicU64 = AtomicU64::new(0);
+
+    struct TempRoot(PathBuf);
+
+    impl TempRoot {
+        fn new(tag: &str) -> Self {
+            let nonce = NEXT_TEMP_ROOT.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "vetto-index-test-{tag}-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("create temp root");
+            Self(path)
+        }
+
+        fn codex_home(&self) -> PathBuf {
+            self.0.join("codex-home")
+        }
+    }
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn rollout(root: &Path, name: &str) -> PathBuf {
+        let path = root.join("sessions").join(name);
+        fs::create_dir_all(path.parent().expect("rollout parent")).expect("rollout parent");
+        fs::write(&path, b"{\"type\":\"turn\"}\n").expect("rollout");
+        path
+    }
+
+    fn sqlite_index(root: &Path, paths: &[&Path]) {
+        let path = root.join("state_5.sqlite");
+        let connection = Connection::open(&path).expect("create SQLite fixture");
+        connection
+            .execute(
+                "CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT)",
+                [],
+            )
+            .expect("create threads table");
+        for (index, rollout) in paths.iter().enumerate() {
+            connection
+                .execute(
+                    "INSERT INTO threads (id, rollout_path) VALUES (?1, ?2)",
+                    rusqlite::params![index.to_string(), rollout.to_string_lossy().to_string()],
+                )
+                .expect("insert index row");
+        }
+    }
+
+    #[test]
+    fn sqlite_index_verifies_candidates_without_walking_unindexed_files() {
+        let temp = TempRoot::new("sqlite");
+        let root = temp.codex_home();
+        let indexed = rollout(&root, "indexed.jsonl");
+        let unindexed = rollout(&root, "unindexed.jsonl");
+        sqlite_index(&root, &[&indexed]);
+
+        let result = discover(&RescueContext::new(root), 10).expect("index discovery");
+        assert_eq!(result.source, "sqlite");
+        assert_eq!(result.candidate_count, 1);
+        assert!(!result.truncated);
+        assert_eq!(
+            result.sessions[0].source_path,
+            fs::canonicalize(indexed).unwrap()
+        );
+        assert_ne!(
+            result.sessions[0].source_path,
+            fs::canonicalize(unindexed).unwrap()
+        );
+    }
+
+    #[test]
+    fn explicit_limit_is_reported_as_truncation() {
+        let temp = TempRoot::new("limit");
+        let root = temp.codex_home();
+        let first = rollout(&root, "first.jsonl");
+        let second = rollout(&root, "second.jsonl");
+        sqlite_index(&root, &[&first, &second]);
+
+        let result = discover(&RescueContext::new(root), 1).expect("limited discovery");
+        assert_eq!(result.candidate_count, 2);
+        assert_eq!(result.sessions.len(), 1);
+        assert!(result.truncated);
+    }
+
+    #[test]
+    fn index_rows_respect_the_context_file_budget() {
+        let temp = TempRoot::new("max-files");
+        let root = temp.codex_home();
+        let first = rollout(&root, "first.jsonl");
+        let second = rollout(&root, "second.jsonl");
+        sqlite_index(&root, &[&first, &second]);
+        let mut context = RescueContext::new(root);
+        context.max_files = 1;
+
+        let error = discover(&context, 10).expect_err("index row budget");
+        assert!(
+            error.to_string().contains("entry budget"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn sqlite_size_is_rejected_before_the_read_only_open() {
+        let temp = TempRoot::new("sqlite-size");
+        let root = temp.codex_home();
+        let indexed = rollout(&root, "indexed.jsonl");
+        sqlite_index(&root, &[&indexed]);
+        let mut context = RescueContext::new(root);
+        context.max_total_bytes = 1;
+
+        let error = discover(&context, 10).expect_err("oversized SQLite index");
+        assert!(
+            error.to_string().contains("SQLite index exceeds"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn aggregate_sqlite_size_is_checked_across_candidates_before_opening() {
+        let temp = TempRoot::new("sqlite-aggregate-size");
+        let root = temp.codex_home();
+        let indexed = rollout(&root, "indexed.jsonl");
+        sqlite_index(&root, &[&indexed]);
+        let first_db = root.join("state_5.sqlite");
+        let second_db = root.join("state.sqlite");
+        fs::copy(&first_db, &second_db).expect("copy second SQLite index");
+        let first_size = fs::metadata(&first_db).expect("first SQLite metadata").len();
+        let second_size = fs::metadata(&second_db)
+            .expect("second SQLite metadata")
+            .len();
+        let mut context = RescueContext::new(root);
+        context.max_total_bytes = first_size
+            .checked_add(second_size)
+            .expect("fixture byte sum")
+            .saturating_sub(1);
+
+        let error = discover(&context, 10).expect_err("aggregate SQLite size");
+        assert!(
+            error.to_string().contains("aggregate")
+                && error.to_string().contains("SQLite indexes"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn sqlite_database_fanout_is_bounded_before_opening_each_candidate() {
+        let temp = TempRoot::new("sqlite-fanout");
+        let root = temp.codex_home();
+        fs::create_dir_all(&root).expect("Codex root");
+        fs::write(root.join("a.sqlite"), b"").expect("first database candidate");
+        fs::write(root.join("b.sqlite"), b"").expect("second database candidate");
+        let mut context = RescueContext::new(root);
+        context.max_files = 1;
+
+        let error = discover(&context, 10).expect_err("SQLite fanout budget");
+        assert!(
+            error.to_string().contains("fanout") || error.to_string().contains("SQLite index"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn stale_index_fails_closed() {
+        let temp = TempRoot::new("stale");
+        let root = temp.codex_home();
+        fs::create_dir_all(root.join("sessions")).expect("sessions");
+        sqlite_index(&root, &[&root.join("sessions/missing.jsonl")]);
+
+        let error = discover(&RescueContext::new(root), 10).expect_err("stale index");
+        assert!(
+            error.to_string().contains("unavailable")
+                || error.to_string().contains("rollout"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn limited_scan_does_not_fallback_to_the_filesystem() {
+        let temp = TempRoot::new("no-index");
+        let root = temp.codex_home();
+        let _session = rollout(&root, "filesystem-only.jsonl");
+
+        let error = discover(&RescueContext::new(root), 10).expect_err("missing index");
+        assert!(error.to_string().contains("requires a readable Codex index"));
+    }
+
+    #[test]
+    fn session_index_is_supported_and_is_read_twice() {
+        let temp = TempRoot::new("jsonl");
+        let root = temp.codex_home();
+        let indexed = rollout(&root, "indexed.jsonl");
+        fs::create_dir_all(&root).expect("codex root");
+        fs::write(
+            root.join(SESSION_INDEX_NAME),
+            format!("{{\"rollout_path\":\"{}\"}}\n", indexed.to_string_lossy()),
+        )
+        .expect("session index");
+
+        let result = discover(&RescueContext::new(root), 10).expect("session index discovery");
+        assert_eq!(result.source, "session-index");
+        assert_eq!(result.sessions.len(), 1);
+    }
+
+    #[test]
+    fn session_index_rows_respect_the_context_file_budget() {
+        let temp = TempRoot::new("session-index-max-files");
+        let root = temp.codex_home();
+        let first = rollout(&root, "first.jsonl");
+        let second = rollout(&root, "second.jsonl");
+        fs::write(
+            root.join(SESSION_INDEX_NAME),
+            format!(
+                "{{\"rollout_path\":\"{}\"}}\n{{\"rollout_path\":\"{}\"}}\n",
+                first.to_string_lossy(),
+                second.to_string_lossy()
+            ),
+        )
+        .expect("session index");
+        let mut context = RescueContext::new(root);
+        context.max_files = 1;
+
+        let error = discover(&context, 10).expect_err("session index row budget");
+        assert!(error.to_string().contains("entry budget"), "{error:#}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hardlinked_session_index_is_rejected() {
+        let temp = TempRoot::new("session-index-hardlink");
+        let root = temp.codex_home();
+        let indexed = rollout(&root, "indexed.jsonl");
+        let index = root.join(SESSION_INDEX_NAME);
+        fs::write(
+            &index,
+            format!("{{\"rollout_path\":\"{}\"}}\n", indexed.to_string_lossy()),
+        )
+        .expect("session index");
+        fs::hard_link(&index, root.join("session-index-alias.jsonl")).expect("hardlink index");
+
+        let error = discover(&RescueContext::new(root), 10).expect_err("hardlinked index");
+        assert!(error.to_string().contains("hardlinked"), "{error:#}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hardlinked_sqlite_index_is_rejected() {
+        let temp = TempRoot::new("sqlite-hardlink");
+        let root = temp.codex_home();
+        let indexed = rollout(&root, "indexed.jsonl");
+        sqlite_index(&root, &[&indexed]);
+        fs::hard_link(
+            root.join("state_5.sqlite"),
+            root.join("state-alias.sqlite"),
+        )
+        .expect("hardlink SQLite index");
+
+        let error = discover(&RescueContext::new(root), 10).expect_err("hardlinked SQLite");
+        assert!(error.to_string().contains("hardlinked"), "{error:#}");
+    }
+}

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -191,17 +191,18 @@ pub fn inspect_session(
     extend_unique(&mut report.findings, projection_result.findings);
     extend_unique(&mut report.notices, projection_result.notices);
 
-    report.status = if report.projection.status == "unknown" || report.thread_store.status == "unknown" {
-        InventoryStatus::Unknown
-    } else if !report.findings.is_empty() {
-        InventoryStatus::Findings
-    } else if report.thread_store.status == "not_applicable"
-        && report.projection.status == "not_applicable"
-    {
-        InventoryStatus::NotApplicable
-    } else {
-        InventoryStatus::Consistent
-    };
+    report.status =
+        if report.projection.status == "unknown" || report.thread_store.status == "unknown" {
+            InventoryStatus::Unknown
+        } else if !report.findings.is_empty() {
+            InventoryStatus::Findings
+        } else if report.thread_store.status == "not_applicable"
+            && report.projection.status == "not_applicable"
+        {
+            InventoryStatus::NotApplicable
+        } else {
+            InventoryStatus::Consistent
+        };
     Ok(report)
 }
 

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -191,10 +191,10 @@ pub fn inspect_session(
     extend_unique(&mut report.findings, projection_result.findings);
     extend_unique(&mut report.notices, projection_result.notices);
 
-    report.status = if !report.findings.is_empty() {
-        InventoryStatus::Findings
-    } else if report.projection.status == "unknown" || report.thread_store.status == "unknown" {
+    report.status = if report.projection.status == "unknown" || report.thread_store.status == "unknown" {
         InventoryStatus::Unknown
+    } else if !report.findings.is_empty() {
+        InventoryStatus::Findings
     } else if report.thread_store.status == "not_applicable"
         && report.projection.status == "not_applicable"
     {
@@ -297,9 +297,7 @@ fn parse_session_id(bytes: &[u8]) -> Option<String> {
 }
 
 fn validate_session_id(value: &str) -> Option<String> {
-    if value.is_empty()
-        || value.len() > MAX_SESSION_ID_BYTES
-        || value.chars().any(char::is_control)
+    if value.is_empty() || value.len() > MAX_SESSION_ID_BYTES || value.chars().any(char::is_control)
     {
         return None;
     }
@@ -462,7 +460,10 @@ fn database_candidates(
             rejected: true,
         };
     }
-    DatabaseCandidates { paths, rejected: false }
+    DatabaseCandidates {
+        paths,
+        rejected: false,
+    }
 }
 
 fn open_read_only(path: &Path) -> Result<Connection> {
@@ -1610,7 +1611,8 @@ mod tests {
         let temp = TempRoot::new("candidate-single-budget");
         let path = temp.0.join("a.sqlite");
         fs::write(&path, b"sqlite-placeholder").unwrap();
-        let candidates = database_candidates(&temp.0, 1, MAX_SQLITE_BYTES);
+        let canonical_root = fs::canonicalize(&temp.0).unwrap();
+        let candidates = database_candidates(&canonical_root, 1, MAX_SQLITE_BYTES);
         assert!(!candidates.rejected);
         assert_eq!(candidates.paths, vec![fs::canonicalize(path).unwrap()]);
     }
@@ -1637,10 +1639,9 @@ mod tests {
         let oversized = "x".repeat(MAX_SESSION_ID_BYTES + 1);
         assert_eq!(validate_session_id(&oversized), None);
         assert_eq!(validate_session_id("session\n1"), None);
-        let bytes = format!(
-            "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{oversized}\"}}}}\n"
-        )
-        .into_bytes();
+        let bytes =
+            format!("{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{oversized}\"}}}}\n")
+                .into_bytes();
         assert_eq!(parse_session_id(&bytes), None);
     }
 

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -6,6 +6,13 @@
 //! every diagnostic is bounded by the caller's [`RescueContext`].  The public
 //! report contains only classifications and numeric cursor evidence; provider
 //! paths read from SQLite are never serialized or included in errors.
+//!
+//! Residual boundary: path validation and the later file/SQLite open are still
+//! separate operations.  A concurrent writer can replace a validated path
+//! between those operations.  Closing that TOCTOU window requires a shared,
+//! platform-specific no-follow/handle-based opener used by all rescue
+//! adapters; this module therefore fails closed on unstable byte snapshots but
+//! does not claim atomic path authorization yet.
 
 use std::collections::HashSet;
 use std::fs::{self, File};
@@ -30,6 +37,8 @@ const THREAD_TABLE: &str = "threads";
 const PROJECTION_TABLE: &str = "thread_history_projection_state";
 const MAX_SQLITE_CANDIDATES: usize = 32;
 const MAX_SQLITE_ROWS: usize = 100_000;
+const MAX_SQLITE_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_SESSION_ID_BYTES: usize = 256;
 
 /// Optional identity/path metadata supplied by a caller that already parsed
 /// the session.  The values are used only for matching; they are not exposed
@@ -142,7 +151,8 @@ pub fn inspect_session(
         .transpose()?;
     let session_id = metadata
         .session_id
-        .clone()
+        .as_deref()
+        .and_then(validate_session_id)
         .or_else(|| bytes.as_deref().and_then(parse_session_id))
         .or_else(|| {
             canonical_session_path
@@ -163,6 +173,7 @@ pub fn inspect_session(
         canonical_session_path.as_deref(),
         session_id.as_deref(),
         context.max_files,
+        context.max_total_bytes.min(MAX_SQLITE_BYTES),
     );
     report.thread_store = thread_result.evidence;
     extend_unique(&mut report.findings, thread_result.findings);
@@ -174,6 +185,7 @@ pub fn inspect_session(
         session_id.as_deref(),
         context.max_files,
         context.max_record_bytes,
+        context.max_total_bytes.min(MAX_SQLITE_BYTES),
     );
     report.projection = projection_result.evidence;
     extend_unique(&mut report.findings, projection_result.findings);
@@ -284,12 +296,21 @@ fn parse_session_id(bytes: &[u8]) -> Option<String> {
     None
 }
 
+fn validate_session_id(value: &str) -> Option<String> {
+    if value.is_empty()
+        || value.len() > MAX_SESSION_ID_BYTES
+        || value.chars().any(char::is_control)
+    {
+        return None;
+    }
+    Some(value.to_owned())
+}
+
 fn value_string(value: &serde_json::Value, key: &str) -> Option<String> {
     value
         .get(key)
         .and_then(|value| value.as_str())
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
+        .and_then(validate_session_id)
 }
 
 fn session_id_from_path(path: &Path) -> Option<String> {
@@ -320,26 +341,58 @@ fn extend_unique(target: &mut Vec<String>, values: Vec<String>) {
     }
 }
 
-fn database_candidates(root: &Path, max_files: usize) -> Vec<PathBuf> {
-    let limit = max_files.clamp(1, MAX_SQLITE_CANDIDATES);
-    let mut names = vec![
-        "state_5.sqlite".to_string(),
-        "state.sqlite".to_string(),
-        "state.db".to_string(),
-    ];
-    if let Ok(entries) = fs::read_dir(root) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
-                continue;
-            };
-            let lower = name.to_ascii_lowercase();
-            if (lower.ends_with(".sqlite") || lower.ends_with(".sqlite3") || lower.ends_with(".db"))
-                && !names.iter().any(|known| known == name)
-            {
-                names.push(name.to_string());
+#[derive(Debug, Default)]
+struct DatabaseCandidates {
+    paths: Vec<PathBuf>,
+    rejected: bool,
+}
+
+fn database_candidates(
+    root: &Path,
+    max_files: usize,
+    max_database_bytes: u64,
+) -> DatabaseCandidates {
+    let limit = max_files.min(MAX_SQLITE_CANDIDATES);
+    if limit == 0 {
+        return DatabaseCandidates {
+            paths: Vec::new(),
+            rejected: true,
+        };
+    }
+    // Only real directory entries belong in the candidate list.  Seeding
+    // missing defaults would consume a small caller budget before reaching a
+    // real provider database such as `a.sqlite`.
+    let mut names = Vec::new();
+    let mut rejected = false;
+    match fs::read_dir(root) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = match entry {
+                    Ok(entry) => entry,
+                    Err(_) => {
+                        rejected = true;
+                        break;
+                    }
+                };
+                let path = entry.path();
+                let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+                    continue;
+                };
+                let lower = name.to_ascii_lowercase();
+                if (lower.ends_with(".sqlite")
+                    || lower.ends_with(".sqlite3")
+                    || lower.ends_with(".db"))
+                    && !names.iter().any(|known| known == name)
+                {
+                    if names.len() >= limit {
+                        rejected = true;
+                        break;
+                    }
+                    names.push(name.to_string());
+                }
             }
         }
+        Err(_) => rejected = true,
     }
     names.sort_by_key(|name| {
         if name == "state_5.sqlite" {
@@ -352,25 +405,64 @@ fn database_candidates(root: &Path, max_files: usize) -> Vec<PathBuf> {
             3
         }
     });
-    names
-        .into_iter()
-        .take(limit)
-        .filter_map(|name| {
-            let path = root.join(name);
-            let metadata = fs::symlink_metadata(&path).ok()?;
-            if metadata.file_type().is_symlink() || !metadata.is_file() {
-                return None;
+    let mut paths = Vec::new();
+    let mut total_bytes = 0u64;
+    for name in names.into_iter().take(limit) {
+        let path = root.join(name);
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                rejected = true;
+                continue;
             }
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::MetadataExt;
-                if metadata.nlink() != 1 {
-                    return None;
-                }
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            rejected = true;
+            continue;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            if metadata.nlink() != 1 {
+                rejected = true;
+                continue;
             }
-            fs::canonicalize(path).ok()
-        })
-        .collect()
+        }
+        let size = metadata.len();
+        if size > max_database_bytes {
+            rejected = true;
+            continue;
+        }
+        let Some(next_total) = total_bytes.checked_add(size) else {
+            return DatabaseCandidates {
+                paths: Vec::new(),
+                rejected: true,
+            };
+        };
+        if next_total > max_database_bytes {
+            // No earlier path may be opened after aggregate preflight fails.
+            return DatabaseCandidates {
+                paths: Vec::new(),
+                rejected: true,
+            };
+        }
+        total_bytes = next_total;
+        let canonical = match fs::canonicalize(&path) {
+            Ok(canonical) if canonical.starts_with(root) => canonical,
+            Ok(_) | Err(_) => {
+                rejected = true;
+                continue;
+            }
+        };
+        paths.push(canonical);
+    }
+    if rejected {
+        return DatabaseCandidates {
+            paths: Vec::new(),
+            rejected: true,
+        };
+    }
+    DatabaseCandidates { paths, rejected: false }
 }
 
 fn open_read_only(path: &Path) -> Result<Connection> {
@@ -531,11 +623,71 @@ fn normalize_path(raw: &str) -> Option<(String, bool)> {
     Some((value, extended))
 }
 
-fn stored_path_exists(stored: &str) -> Option<bool> {
+/// Check a stored rollout path only when every component is lexically inside
+/// the already-canonicalized rescue root.  SQLite is provider-derived input;
+/// its path column must never turn diagnosis into an arbitrary filesystem or
+/// UNC/network metadata probe.
+fn stored_path_exists_within_root(root: &Path, stored: &str) -> Option<bool> {
+    if stored.is_empty() || stored.contains('\0') {
+        return None;
+    }
     if cfg!(not(windows)) && looks_windows_path(stored) {
         return None;
     }
-    let metadata = fs::symlink_metadata(stored).ok()?;
+    let raw = Path::new(stored);
+    if raw
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return None;
+    }
+    if !raw.is_absolute()
+        && raw.components().any(|component| {
+            matches!(
+                component,
+                std::path::Component::RootDir | std::path::Component::Prefix(_)
+            )
+        })
+    {
+        return None;
+    }
+    let candidate = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        root.join(raw)
+    };
+    if !candidate.starts_with(root) {
+        return None;
+    }
+
+    let relative = candidate.strip_prefix(root).ok()?;
+    let components = relative.components().collect::<Vec<_>>();
+    let mut current = root.to_path_buf();
+    for (index, component) in components.iter().enumerate() {
+        let std::path::Component::Normal(name) = *component else {
+            return None;
+        };
+        current.push(name);
+        let metadata = match fs::symlink_metadata(&current) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Some(false),
+            Err(_) => return None,
+        };
+        if metadata.file_type().is_symlink() {
+            return None;
+        }
+        if index + 1 < components.len() && !metadata.is_dir() {
+            return Some(false);
+        }
+        #[cfg(unix)]
+        if index + 1 == components.len() {
+            use std::os::unix::fs::MetadataExt;
+            if metadata.nlink() != 1 {
+                return None;
+            }
+        }
+    }
+    let metadata = fs::symlink_metadata(&candidate).ok()?;
     Some(metadata.is_file() && !metadata.file_type().is_symlink())
 }
 
@@ -549,26 +701,30 @@ fn inspect_thread_store(
     session_path: Option<&Path>,
     session_id: Option<&str>,
     max_files: usize,
+    max_database_bytes: u64,
 ) -> ThreadStoreResult {
     let mut result = ThreadStoreResult::default();
-    let candidates = database_candidates(root, max_files);
-    if candidates.is_empty() {
+    let candidate_set = database_candidates(root, max_files, max_database_bytes);
+    if candidate_set.paths.is_empty() {
+        if candidate_set.rejected {
+            result.evidence.status = "unknown".to_string();
+            result
+                .notices
+                .push("a SQLite candidate exceeded the safe inspection boundary".to_string());
+            return result;
+        }
         result
             .notices
             .push("no compatible Codex SQLite store was found".to_string());
         return result;
     }
+    let candidates = candidate_set.paths;
     let mut compatible_store = false;
     let mut read_error = false;
+    let mut schema_unknown = false;
     for db_path in candidates {
         let Ok(connection) = open_read_only(&db_path) else {
-            if db_path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.to_ascii_lowercase().contains("state"))
-            {
-                read_error = true;
-            }
+            read_error = true;
             continue;
         };
         let Ok(tables) = table_names(&connection) else {
@@ -588,6 +744,10 @@ fn inspect_thread_store(
         };
         compatible_store = true;
         let id_column = first_column(&columns, &["id", "thread_id", "session_id"]);
+        if id_column.is_none() && session_id.is_some() {
+            schema_unknown = true;
+            continue;
+        }
         let preview_column = first_column(&columns, &["preview"]);
         let first_user_column = first_column(&columns, &["first_user_message"]);
         let sql = format!(
@@ -635,10 +795,36 @@ fn inspect_thread_store(
             continue;
         };
         let mut matched = false;
-        while let Ok(Some(row)) = rows.next() {
-            let stored = value_text(row.get_ref(1).unwrap_or(ValueRef::Null));
-            let preview = value_text(row.get_ref(2).unwrap_or(ValueRef::Null));
-            let first_user = value_text(row.get_ref(3).unwrap_or(ValueRef::Null));
+        loop {
+            let row = match rows.next() {
+                Ok(Some(row)) => row,
+                Ok(None) => break,
+                Err(_) => {
+                    read_error = true;
+                    break;
+                }
+            };
+            let stored = match row.get_ref(1) {
+                Ok(value) => value_text(value),
+                Err(_) => {
+                    read_error = true;
+                    break;
+                }
+            };
+            let preview = match row.get_ref(2) {
+                Ok(value) => value_text(value),
+                Err(_) => {
+                    read_error = true;
+                    break;
+                }
+            };
+            let first_user = match row.get_ref(3) {
+                Ok(value) => value_text(value),
+                Err(_) => {
+                    read_error = true;
+                    break;
+                }
+            };
             let relation = match (&stored, session_path) {
                 (Some(stored), Some(session_path)) => path_relation(stored, session_path),
                 _ => PathRelation::Unknown,
@@ -699,7 +885,7 @@ fn inspect_thread_store(
                         PathRelation::Different => {
                             result.evidence.status = "diverged".to_string();
                             result.evidence.path_relation = "different".to_string();
-                            match stored_path_exists(&stored) {
+                            match stored_path_exists_within_root(root, &stored) {
                                 Some(true) => {
                                     result.evidence.rollout_present = Some(true);
                                     result.findings.push(INDEX_DIVERGENCE.to_string());
@@ -742,6 +928,19 @@ fn inspect_thread_store(
             break;
         }
     }
+    if candidate_set.rejected || read_error || schema_unknown {
+        result.evidence.status = "unknown".to_string();
+        result.evidence.path_relation = "unknown".to_string();
+        result.evidence.row_present = None;
+        result.evidence.rollout_present = None;
+        result.evidence.windows_namespace_divergence = false;
+        result.findings.clear();
+        result.notices.push(
+            "SQLite inventory evidence was incomplete or could not be correlated safely"
+                .to_string(),
+        );
+        return result;
+    }
     if !matched_or_row(&result.evidence) {
         if compatible_store && session_path.is_some() {
             result.evidence.status = "diverged".to_string();
@@ -751,11 +950,6 @@ fn inspect_thread_store(
             result.notices.push(
                 "rollout exists on disk but no matching thread index row was found".to_string(),
             );
-        } else if read_error {
-            result.evidence.status = "unknown".to_string();
-            result
-                .notices
-                .push("a state SQLite store could not be inspected read-only".to_string());
         } else if compatible_store {
             result.evidence.status = "not_recorded".to_string();
             result.evidence.row_present = Some(false);
@@ -784,45 +978,72 @@ struct RecordBoundary {
     end: usize,
 }
 
-fn record_boundaries(bytes: &[u8], max_record_bytes: usize) -> Vec<RecordBoundary> {
-    let mut result = Vec::new();
-    let mut start = 0usize;
-    for (index, byte) in bytes.iter().enumerate() {
-        if *byte != b'\n' {
-            continue;
-        }
-        let end = index + 1;
-        let raw = &bytes[start..index];
-        let raw = raw.strip_suffix(b"\r").unwrap_or(raw);
-        let ordinal = if raw.len() <= max_record_bytes {
-            serde_json::from_slice::<serde_json::Value>(raw)
-                .ok()
-                .and_then(|value| value.get("ordinal").and_then(|value| value.as_u64()))
-        } else {
-            None
-        };
-        if !raw.iter().all(|byte| byte.is_ascii_whitespace()) {
-            result.push(RecordBoundary { ordinal, end });
-        }
-        start = end;
-    }
-    if start < bytes.len() {
-        let raw = &bytes[start..];
-        let ordinal = if raw.len() <= max_record_bytes {
-            serde_json::from_slice::<serde_json::Value>(raw)
-                .ok()
-                .and_then(|value| value.get("ordinal").and_then(|value| value.as_u64()))
-        } else {
-            None
-        };
-        if !raw.iter().all(|byte| byte.is_ascii_whitespace()) {
-            result.push(RecordBoundary {
-                ordinal,
-                end: bytes.len(),
-            });
+struct RecordBoundaryIter<'a> {
+    bytes: &'a [u8],
+    start: usize,
+    max_record_bytes: usize,
+}
+
+impl<'a> RecordBoundaryIter<'a> {
+    fn new(bytes: &'a [u8], max_record_bytes: usize) -> Self {
+        Self {
+            bytes,
+            start: 0,
+            max_record_bytes,
         }
     }
-    result
+}
+
+impl Iterator for RecordBoundaryIter<'_> {
+    type Item = RecordBoundary;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.start < self.bytes.len() {
+            let start = self.start;
+            let bytes = self.bytes;
+            let relative_end = bytes[start..].iter().position(|byte| *byte == b'\n');
+            let (index, end) = match relative_end {
+                Some(relative_end) => {
+                    let index = start + relative_end;
+                    (index, index + 1)
+                }
+                None => (bytes.len(), bytes.len()),
+            };
+            let raw = bytes[start..index]
+                .strip_suffix(b"\r")
+                .unwrap_or(&bytes[start..index]);
+            self.start = end;
+            if raw.iter().all(|byte| byte.is_ascii_whitespace()) {
+                continue;
+            }
+            let ordinal = if raw.len() <= self.max_record_bytes {
+                serde_json::from_slice::<serde_json::Value>(raw)
+                    .ok()
+                    .and_then(|value| value.get("ordinal").and_then(|value| value.as_u64()))
+            } else {
+                None
+            };
+            return Some(RecordBoundary { ordinal, end });
+        }
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct BoundarySummary {
+    last_ordinal: Option<u64>,
+    invalid_record: bool,
+}
+
+fn boundary_summary(bytes: &[u8], max_record_bytes: usize) -> BoundarySummary {
+    let mut summary = BoundarySummary::default();
+    for boundary in RecordBoundaryIter::new(bytes, max_record_bytes) {
+        match boundary.ordinal {
+            Some(ordinal) => summary.last_ordinal = Some(ordinal),
+            None => summary.invalid_record = true,
+        }
+    }
+    summary
 }
 
 fn boundary_at(
@@ -833,25 +1054,19 @@ fn boundary_at(
     if offset >= bytes.len() || (offset > 0 && bytes[offset - 1] != b'\n') {
         return None;
     }
-    let boundaries = record_boundaries(bytes, max_record_bytes);
-    let index = boundaries
-        .iter()
-        .position(|boundary| boundary.end > offset && boundary.end - offset > 0)?;
-    let current_start = boundaries
-        .get(index.wrapping_sub(1))
-        .map(|boundary| boundary.end)
-        .unwrap_or(0);
-    if current_start != offset {
-        return None;
+    let mut current_start = 0usize;
+    let mut boundaries = RecordBoundaryIter::new(bytes, max_record_bytes);
+    while let Some(boundary) = boundaries.next() {
+        if boundary.end <= offset {
+            current_start = boundary.end;
+            continue;
+        }
+        if current_start != offset {
+            return None;
+        }
+        return Some((boundary, boundaries.next()));
     }
-    Some((boundaries[index], boundaries.get(index + 1).copied()))
-}
-
-fn last_ordinal(bytes: &[u8], max_record_bytes: usize) -> Option<u64> {
-    record_boundaries(bytes, max_record_bytes)
-        .into_iter()
-        .rev()
-        .find_map(|boundary| boundary.ordinal)
+    None
 }
 
 fn inspect_projection(
@@ -860,6 +1075,7 @@ fn inspect_projection(
     session_id: Option<&str>,
     max_files: usize,
     max_record_bytes: usize,
+    max_database_bytes: u64,
 ) -> ProjectionResult {
     let mut result = ProjectionResult::default();
     let Some(session_id) = session_id else {
@@ -868,18 +1084,13 @@ fn inspect_projection(
             .push("projection inspection requires a stable session identity".to_string());
         return result;
     };
-    let candidates = database_candidates(root, max_files);
+    let candidate_set = database_candidates(root, max_files, max_database_bytes);
+    let candidates = candidate_set.paths;
     let mut states = Vec::new();
-    let mut relevant_error = false;
+    let mut relevant_error = candidate_set.rejected;
     for db_path in candidates {
         let Ok(connection) = open_read_only(&db_path) else {
-            if db_path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.to_ascii_lowercase().contains("thread"))
-            {
-                relevant_error = true;
-            }
+            relevant_error = true;
             continue;
         };
         let Ok(tables) = table_names(&connection) else {
@@ -937,34 +1148,54 @@ fn inspect_projection(
                     continue;
                 }
             };
-            while let Ok(Some(row)) = rows.next() {
-                let offset = value_i64(row.get_ref(0).unwrap_or(ValueRef::Null));
-                let ordinal = value_i64(row.get_ref(1).unwrap_or(ValueRef::Null));
+            loop {
+                let row = match rows.next() {
+                    Ok(Some(row)) => row,
+                    Ok(None) => break,
+                    Err(_) => {
+                        relevant_error = true;
+                        break;
+                    }
+                };
+                let offset = match row.get_ref(0) {
+                    Ok(value) => value_i64(value),
+                    Err(_) => {
+                        relevant_error = true;
+                        break;
+                    }
+                };
+                let ordinal = match row.get_ref(1) {
+                    Ok(value) => value_i64(value),
+                    Err(_) => {
+                        relevant_error = true;
+                        break;
+                    }
+                };
                 let (Some(offset), Some(ordinal)) = (offset, ordinal) else {
                     relevant_error = true;
-                    continue;
+                    break;
                 };
                 if offset < 0 || ordinal < 0 {
                     relevant_error = true;
-                    continue;
+                    break;
                 }
                 states.push((offset as u64, ordinal as u64));
             }
         }
     }
+    if relevant_error {
+        result.evidence.status = "unknown".to_string();
+        result.evidence.confidence = "unknown".to_string();
+        result.findings.push(PROJECTION_STATE_UNKNOWN.to_string());
+        result
+            .notices
+            .push("projection database/schema could not be read safely".to_string());
+        return result;
+    }
     if states.is_empty() {
-        if relevant_error {
-            result.evidence.status = "unknown".to_string();
-            result.evidence.confidence = "unknown".to_string();
-            result.findings.push(PROJECTION_STATE_UNKNOWN.to_string());
-            result
-                .notices
-                .push("projection database/schema could not be read safely".to_string());
-        } else {
-            result
-                .notices
-                .push("no readable projection row was found for this session".to_string());
-        }
+        result
+            .notices
+            .push("no readable projection row was found for this session".to_string());
         return result;
     }
     if states.windows(2).any(|window| window[0] != window[1]) {
@@ -989,6 +1220,17 @@ fn inspect_projection(
         return result;
     };
     result.evidence.canonical_size = Some(bytes.len() as u64);
+    let summary = boundary_summary(bytes, max_record_bytes);
+    if summary.invalid_record {
+        result.evidence.status = "unknown".to_string();
+        result.evidence.confidence = "unknown".to_string();
+        result.findings.push(PROJECTION_STATE_UNKNOWN.to_string());
+        result.notices.push(
+            "rollout contains a malformed or ordinal-less record; projection parity is unknown"
+                .to_string(),
+        );
+        return result;
+    }
     if next_offset > bytes.len() as u64 {
         result.evidence.status = "unknown".to_string();
         result.evidence.confidence = "unknown".to_string();
@@ -998,7 +1240,7 @@ fn inspect_projection(
             .push("projection byte cursor is beyond the rollout".to_string());
         return result;
     }
-    let final_ordinal = last_ordinal(bytes, max_record_bytes);
+    let final_ordinal = summary.last_ordinal;
     if next_offset == bytes.len() as u64 {
         if let Some(final_ordinal) = final_ordinal {
             if next_ordinal == final_ordinal.saturating_add(1) {
@@ -1071,6 +1313,7 @@ fn inspect_projection(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rescue::types::DEFAULT_MAX_RECORD_BYTES;
     use sha2::{Digest, Sha256};
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -1138,6 +1381,19 @@ mod tests {
                 "INSERT INTO threads VALUES (?1, ?2, '', '')",
                 (id, stored_path),
             )
+            .unwrap();
+        drop(connection);
+        path
+    }
+
+    fn create_threads_db_without_id(root: &Path, stored_path: &str) -> PathBuf {
+        let path = root.join("state_5.sqlite");
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute("CREATE TABLE threads (rollout_path TEXT)", [])
+            .unwrap();
+        connection
+            .execute("INSERT INTO threads VALUES (?1)", [stored_path])
             .unwrap();
         drop(connection);
         path
@@ -1230,6 +1486,136 @@ mod tests {
     }
 
     #[test]
+    fn external_sqlite_path_is_not_probed() {
+        let temp = TempRoot::new("external-path");
+        let root = fs::canonicalize(&temp.0).unwrap();
+        let external = if cfg!(windows) {
+            r"\\127.0.0.1\vetto\outside.jsonl"
+        } else {
+            "/etc/passwd"
+        };
+        assert_eq!(stored_path_exists_within_root(&root, external), None);
+    }
+
+    #[test]
+    fn schema_without_id_is_unknown_when_session_id_is_present() {
+        let temp = TempRoot::new("schema-without-id");
+        let id = "019fffff-5555-7555-8555-555555555555";
+        let (path, bytes) = rollout(&temp.0, id);
+        create_threads_db_without_id(&temp.0, &path.to_string_lossy());
+        let report = inspect_session(
+            &RescueContext::new(temp.0.clone()),
+            Some(&path),
+            Some(&bytes),
+            None,
+        )
+        .unwrap();
+        assert_eq!(report.thread_store.status, "unknown");
+        assert!(!report.findings.contains(&INDEX_DIVERGENCE.to_string()));
+    }
+
+    #[test]
+    fn malformed_projection_tail_is_unknown_at_eof() {
+        let temp = TempRoot::new("malformed-tail");
+        let id = "019fffff-6666-7666-8666-666666666666";
+        let (path, _) = rollout(&temp.0, id);
+        let bytes = format!(
+            "{{\"type\":\"session_meta\",\"ordinal\":0,\"payload\":{{\"id\":\"{id}\"}}}}\nnot-json\n"
+        )
+        .into_bytes();
+        fs::write(&path, &bytes).unwrap();
+        create_projection_db(&temp.0, id, bytes.len() as u64, 1);
+        let report = inspect_session(
+            &RescueContext::new(temp.0.clone()),
+            Some(&path),
+            Some(&bytes),
+            None,
+        )
+        .unwrap();
+        assert_eq!(report.projection.status, "unknown");
+        assert!(report
+            .findings
+            .contains(&PROJECTION_STATE_UNKNOWN.to_string()));
+    }
+
+    #[test]
+    fn boundary_summary_is_stream_like_for_many_short_records() {
+        let mut bytes = Vec::with_capacity(100_000 * 3);
+        for _ in 0..100_000 {
+            bytes.extend_from_slice(b"{}\n");
+        }
+        let summary = boundary_summary(&bytes, DEFAULT_MAX_RECORD_BYTES);
+        assert!(summary.invalid_record);
+        assert_eq!(summary.last_ordinal, None);
+    }
+
+    #[test]
+    fn oversized_sqlite_is_unknown_not_index_divergence() {
+        let temp = TempRoot::new("oversized-db");
+        let id = "019fffff-7777-7777-8777-777777777777";
+        let (path, bytes) = rollout(&temp.0, id);
+        create_empty_sidebar_db(&temp.0, id, &path.to_string_lossy());
+        let context = RescueContext {
+            max_total_bytes: 1,
+            ..RescueContext::new(temp.0.clone())
+        };
+        let report = inspect_session(&context, Some(&path), Some(&bytes), None).unwrap();
+        assert_eq!(report.status, InventoryStatus::Unknown);
+        assert!(!report.findings.contains(&INDEX_DIVERGENCE.to_string()));
+        assert!(report
+            .findings
+            .contains(&PROJECTION_STATE_UNKNOWN.to_string()));
+    }
+
+    #[test]
+    fn malformed_sqlite_is_unknown_not_index_divergence() {
+        let temp = TempRoot::new("malformed-db");
+        let id = "019fffff-8888-7888-8888-888888888888";
+        let (path, bytes) = rollout(&temp.0, id);
+        fs::write(temp.0.join("state_5.sqlite"), b"not a sqlite database").unwrap();
+        let report = inspect_session(
+            &RescueContext::new(temp.0.clone()),
+            Some(&path),
+            Some(&bytes),
+            None,
+        )
+        .unwrap();
+        assert_eq!(report.thread_store.status, "unknown");
+        assert!(!report.findings.contains(&INDEX_DIVERGENCE.to_string()));
+    }
+
+    #[test]
+    fn sqlite_candidate_enumeration_is_bounded() {
+        let temp = TempRoot::new("candidate-bound");
+        for index in 0..(MAX_SQLITE_CANDIDATES + 8) {
+            fs::write(temp.0.join(format!("candidate-{index}.sqlite")), b"").unwrap();
+        }
+        let candidates = database_candidates(&temp.0, 10_000, MAX_SQLITE_BYTES);
+        assert!(candidates.paths.is_empty());
+        assert!(candidates.rejected);
+    }
+
+    #[test]
+    fn cumulative_sqlite_size_is_preflighted_before_open() {
+        let temp = TempRoot::new("candidate-total-size");
+        fs::write(temp.0.join("a.sqlite"), [0u8; 16]).unwrap();
+        fs::write(temp.0.join("b.sqlite"), [0u8; 16]).unwrap();
+        let candidates = database_candidates(&temp.0, 10_000, 24);
+        assert!(candidates.paths.is_empty());
+        assert!(candidates.rejected);
+    }
+
+    #[test]
+    fn one_file_budget_selects_existing_non_default_database() {
+        let temp = TempRoot::new("candidate-single-budget");
+        let path = temp.0.join("a.sqlite");
+        fs::write(&path, b"sqlite-placeholder").unwrap();
+        let candidates = database_candidates(&temp.0, 1, MAX_SQLITE_BYTES);
+        assert!(!candidates.rejected);
+        assert_eq!(candidates.paths, vec![fs::canonicalize(path).unwrap()]);
+    }
+
+    #[test]
     fn filename_identity_uses_the_complete_uuid_suffix() {
         let path = Path::new(
             "sessions/2026/08/19/rollout-2026-08-19T00-00-00-019fffff-1111-7111-8111-111111111111.jsonl",
@@ -1244,6 +1630,18 @@ mod tests {
     fn unrelated_record_id_is_not_used_as_session_identity() {
         let bytes = b"{\"type\":\"response_item\",\"payload\":{\"type\":\"reasoning\",\"id\":\"rs_not_a_session\"}}\n";
         assert_eq!(parse_session_id(bytes), None);
+    }
+
+    #[test]
+    fn session_identity_is_bounded_and_rejects_control_bytes() {
+        let oversized = "x".repeat(MAX_SESSION_ID_BYTES + 1);
+        assert_eq!(validate_session_id(&oversized), None);
+        assert_eq!(validate_session_id("session\n1"), None);
+        let bytes = format!(
+            "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{oversized}\"}}}}\n"
+        )
+        .into_bytes();
+        assert_eq!(parse_session_id(&bytes), None);
     }
 
     #[test]

--- a/src/rescue/mod.rs
+++ b/src/rescue/mod.rs
@@ -2,6 +2,7 @@ mod adapter;
 mod claude;
 mod codex;
 mod codex_inventory;
+mod codex_index;
 pub mod types;
 
 use std::path::{Path, PathBuf};
@@ -16,6 +17,8 @@ use adapter::RescueAdapter;
 use claude::ClaudeAdapter;
 use codex::CodexAdapter;
 use types::{Availability, RescueContext, SessionRef};
+
+const DEFAULT_INDEX_SCAN_LIMIT: usize = 50;
 
 fn adapter_by_id(id: &str) -> Result<Box<dyn RescueAdapter>> {
     match id {
@@ -88,6 +91,22 @@ fn print_json<T: Serialize>(value: &T) -> Result<()> {
     Ok(())
 }
 
+#[derive(Debug, Serialize)]
+struct ScanDiscovery {
+    /// `filesystem-all` is the bounded recursive walker. `index-first` means
+    /// every returned candidate came from a verified provider index.
+    mode: &'static str,
+    /// The evidence set whose completeness is described by `complete`.
+    /// Index completeness never proves that the provider indexed every file
+    /// in the state root.
+    scope: &'static str,
+    source: String,
+    complete: bool,
+    limit: Option<usize>,
+    candidate_count: usize,
+    returned_count: usize,
+}
+
 pub fn run_cli(
     adapter_id: &str,
     root: Option<&Path>,
@@ -97,17 +116,83 @@ pub fn run_cli(
     let adapter = adapter_by_id(adapter_id)?;
     let context = RescueContext::new(default_root(adapter_id, root)?);
     match command {
-        RescueCommand::Scan => {
+        RescueCommand::Scan { limit, all } => {
+            if *limit == Some(0) {
+                bail!("rescue scan --limit must be greater than zero");
+            }
+            if limit.is_some() && adapter_id != "codex" {
+                bail!("`rescue scan --limit` is supported only by the Codex index-first adapter");
+            }
+
             let status = adapter.detect(&context)?;
-            let sessions = if status.availability == Availability::Available {
-                adapter.discover_sessions(&context)?
+            let use_index = adapter_id == "codex" && !*all;
+            let effective_limit =
+                use_index.then_some((*limit).unwrap_or(DEFAULT_INDEX_SCAN_LIMIT));
+            let filesystem_mode = if *all {
+                "filesystem-all"
             } else {
-                Vec::new()
+                "filesystem"
+            };
+            let (sessions, discovery) = if status.availability == Availability::Available {
+                if let Some(limit) = effective_limit {
+                    let indexed = codex_index::discover(&context, limit)?;
+                    let returned_count = indexed.sessions.len();
+                    let complete = !indexed.truncated;
+                    (
+                        indexed.sessions,
+                        ScanDiscovery {
+                            mode: "index-first",
+                            scope: "provider-index",
+                            source: indexed.source,
+                            complete,
+                            limit: Some(limit),
+                            candidate_count: indexed.candidate_count,
+                            returned_count,
+                        },
+                    )
+                } else {
+                    let sessions = adapter.discover_sessions(&context)?;
+                    let returned_count = sessions.len();
+                    (
+                        sessions,
+                        ScanDiscovery {
+                            mode: filesystem_mode,
+                            scope: "session-roots",
+                            source: "session-roots".to_string(),
+                            complete: true,
+                            limit: None,
+                            candidate_count: returned_count,
+                            returned_count,
+                        },
+                    )
+                }
+            } else {
+                (
+                    Vec::new(),
+                    ScanDiscovery {
+                        mode: if use_index {
+                            "index-first"
+                        } else {
+                            filesystem_mode
+                        },
+                        scope: if use_index {
+                            "provider-index"
+                        } else {
+                            "session-roots"
+                        },
+                        source: "unavailable".to_string(),
+                        complete: false,
+                        limit: effective_limit,
+                        candidate_count: 0,
+                        returned_count: 0,
+                    },
+                )
             };
             if json {
                 print_json(&serde_json::json!({
                     "status": status,
                     "sessions": sessions,
+                    "discovery": discovery,
                 }))
             } else {
                 println!("adapter: {} ({})", adapter.id(), status.support_level);
@@ -115,6 +200,20 @@ pub fn run_cli(
                     println!("status: unavailable ({})", report::clean(&reason));
                 } else {
                     println!("status: available");
+                }
+                println!(
+                    "discovery: {} ({}, {} candidate(s), {} returned)",
+                    discovery.mode,
+                    discovery.source,
+                    discovery.candidate_count,
+                    discovery.returned_count
+                );
+                if let Some(limit) = discovery.limit {
+                    if !discovery.complete {
+                        println!(
+                            "notice: result is limited to {limit}; use a larger --limit or `--all` for the bounded filesystem walk"
+                        );
+                    }
                 }
                 println!("sessions: {}", sessions.len());
                 for session in sessions {

--- a/src/rescue/mod.rs
+++ b/src/rescue/mod.rs
@@ -1,8 +1,8 @@
 mod adapter;
 mod claude;
 mod codex;
-mod codex_inventory;
 mod codex_index;
+mod codex_inventory;
 pub mod types;
 
 use std::path::{Path, PathBuf};
@@ -126,13 +126,8 @@ pub fn run_cli(
 
             let status = adapter.detect(&context)?;
             let use_index = adapter_id == "codex" && !*all;
-            let effective_limit =
-                use_index.then_some((*limit).unwrap_or(DEFAULT_INDEX_SCAN_LIMIT));
-            let filesystem_mode = if *all {
-                "filesystem-all"
-            } else {
-                "filesystem"
-            };
+            let effective_limit = use_index.then_some((*limit).unwrap_or(DEFAULT_INDEX_SCAN_LIMIT));
+            let filesystem_mode = if *all { "filesystem-all" } else { "filesystem" };
             let (sessions, discovery) = if status.availability == Availability::Available {
                 if let Some(limit) = effective_limit {
                     let indexed = codex_index::discover(&context, limit)?;

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -2,6 +2,7 @@
 //! sandbox tier. These tests run on every supported platform.
 
 use crate::common::*;
+use rusqlite::Connection;
 use std::fs;
 use std::process::Command;
 
@@ -25,6 +26,25 @@ fn run_rescue_with_adapter(
         .args(trailing)
         .output()
         .expect("spawn rescue command")
+}
+
+fn create_codex_sqlite_index(root: &std::path::Path, paths: &[&std::path::Path]) {
+    let database = root.join("state_5.sqlite");
+    let connection = Connection::open(database).expect("create synthetic Codex index");
+    connection
+        .execute(
+            "CREATE TABLE threads (id TEXT PRIMARY KEY, rollout_path TEXT)",
+            [],
+        )
+        .expect("create synthetic threads table");
+    for (index, path) in paths.iter().enumerate() {
+        connection
+            .execute(
+                "INSERT INTO threads (id, rollout_path) VALUES (?1, ?2)",
+                rusqlite::params![index.to_string(), path.to_string_lossy().to_string()],
+            )
+            .expect("insert synthetic rollout index row");
+    }
 }
 
 #[test]
@@ -103,7 +123,7 @@ fn scan_and_diagnose_are_bounded_to_codex_session_roots() {
         "{\"secret\":true}\n",
     );
 
-    let scan = run_rescue(&root, &["scan"]);
+    let scan = run_rescue(&root, &["scan", "--all"]);
     assert!(scan.status.success(), "scan stderr: {}", stderr(&scan));
     let scan_json: serde_json::Value =
         serde_json::from_slice(&scan.stdout).expect("scan JSON output");
@@ -143,7 +163,7 @@ fn scan_discovers_nested_sessions_beyond_the_legacy_twenty_item_window() {
         );
     }
 
-    let scan = run_rescue(&root, &["scan"]);
+    let scan = run_rescue(&root, &["scan", "--all"]);
     assert!(scan.status.success(), "scan stderr: {}", stderr(&scan));
     let value: serde_json::Value = serde_json::from_slice(&scan.stdout).expect("scan JSON output");
     let sessions = value["sessions"].as_array().expect("session array");
@@ -151,6 +171,99 @@ fn scan_discovers_nested_sessions_beyond_the_legacy_twenty_item_window() {
     assert!(sessions
         .iter()
         .any(|session| { session["key"] == "sessions/2026/08/25/rollout-24.jsonl" }));
+}
+
+#[test]
+fn codex_default_scan_uses_index_first_with_a_fifty_session_limit() {
+    let project = TempProject::new("rescue-index-default");
+    let root = project.path().join("codex-home");
+    let paths = (0..3)
+        .map(|index| {
+            let path = root.join(format!("sessions/2026/08/rollout-{index:02}.jsonl"));
+            write_file(&path, "{\"type\":\"turn\"}\n");
+            path
+        })
+        .collect::<Vec<_>>();
+    let path_refs = paths
+        .iter()
+        .map(std::path::PathBuf::as_path)
+        .collect::<Vec<_>>();
+    create_codex_sqlite_index(&root, &path_refs);
+
+    let output = run_rescue(&root, &["scan"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("scan JSON");
+    let discovery = &value["discovery"];
+    assert_eq!(discovery["mode"], "index-first");
+    assert_eq!(discovery["scope"], "provider-index");
+    assert_eq!(discovery["source"], "sqlite");
+    assert_eq!(discovery["limit"], 50);
+    assert_eq!(discovery["complete"], true);
+    assert_eq!(discovery["candidate_count"], 3);
+    assert_eq!(discovery["returned_count"], 3);
+    assert_eq!(value["sessions"].as_array().map(Vec::len), Some(3));
+}
+
+#[test]
+fn codex_index_scan_reports_truncation_without_claiming_state_root_completeness() {
+    let project = TempProject::new("rescue-index-limit");
+    let root = project.path().join("codex-home");
+    let paths = (0..55)
+        .map(|index| {
+            let path = root.join(format!("sessions/2026/08/rollout-{index:02}.jsonl"));
+            write_file(&path, "{\"type\":\"turn\"}\n");
+            path
+        })
+        .collect::<Vec<_>>();
+    let path_refs = paths
+        .iter()
+        .map(std::path::PathBuf::as_path)
+        .collect::<Vec<_>>();
+    create_codex_sqlite_index(&root, &path_refs);
+
+    let output = run_rescue(&root, &["scan", "--limit", "2"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("scan JSON");
+    let discovery = &value["discovery"];
+    assert_eq!(discovery["mode"], "index-first");
+    assert_eq!(discovery["scope"], "provider-index");
+    assert_eq!(discovery["source"], "sqlite");
+    assert_eq!(discovery["limit"], 2);
+    assert_eq!(discovery["complete"], false);
+    assert_eq!(discovery["candidate_count"], 55);
+    assert_eq!(discovery["returned_count"], 2);
+    assert_eq!(value["sessions"].as_array().map(Vec::len), Some(2));
+}
+
+#[test]
+fn codex_all_scan_uses_the_bounded_filesystem_source() {
+    let project = TempProject::new("rescue-index-all");
+    let root = project.path().join("codex-home");
+    let indexed = root.join("sessions/indexed.jsonl");
+    let unindexed = root.join("sessions/unindexed.jsonl");
+    write_file(&indexed, "{\"type\":\"turn\"}\n");
+    write_file(&unindexed, "{\"type\":\"turn\"}\n");
+    create_codex_sqlite_index(&root, &[&indexed]);
+
+    let output = run_rescue(&root, &["scan", "--all"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("scan JSON");
+    let discovery = &value["discovery"];
+    assert_eq!(discovery["mode"], "filesystem-all");
+    assert_eq!(discovery["scope"], "session-roots");
+    assert_eq!(discovery["source"], "session-roots");
+    assert_eq!(discovery["limit"], serde_json::Value::Null);
+    assert_eq!(discovery["complete"], true);
+    assert_eq!(discovery["candidate_count"], 2);
+    assert_eq!(discovery["returned_count"], 2);
+    let sessions = value["sessions"].as_array().expect("session array");
+    assert_eq!(sessions.len(), 2);
+    assert!(sessions
+        .iter()
+        .any(|session| session["key"] == "sessions/indexed.jsonl"));
+    assert!(sessions
+        .iter()
+        .any(|session| session["key"] == "sessions/unindexed.jsonl"));
 }
 
 #[test]
@@ -245,8 +358,8 @@ fn json_scan_is_repeatable_and_sanitizes_user_derived_session_names() {
         "{\"type\":\"turn\"}\n",
     );
 
-    let first = run_rescue(&root, &["scan"]);
-    let second = run_rescue(&root, &["scan"]);
+    let first = run_rescue(&root, &["scan", "--all"]);
+    let second = run_rescue(&root, &["scan", "--all"]);
     assert!(first.status.success(), "stderr: {}", stderr(&first));
     assert!(second.status.success(), "stderr: {}", stderr(&second));
     assert_eq!(
@@ -294,7 +407,7 @@ fn scan_does_not_follow_session_symlinks() {
     write_file(&outside, "{\"type\":\"outside\"}\n");
     symlink(&outside, sessions.join("linked.jsonl")).expect("session symlink");
 
-    let output = run_rescue(&root, &["scan"]);
+    let output = run_rescue(&root, &["scan", "--all"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
     let value: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("scan JSON output");
@@ -312,7 +425,7 @@ fn scan_does_not_accept_hardlinked_session_aliases() {
     write_file(&outside, "{\"type\":\"outside\"}\n");
     fs::hard_link(&outside, sessions.join("linked.jsonl")).expect("session hardlink");
 
-    let output = run_rescue(&root, &["scan"]);
+    let output = run_rescue(&root, &["scan", "--all"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
     let value: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("scan JSON output");


### PR DESCRIPTION
## What changed
- make Codex rescue scan index-first by default with an explicit bounded limit
- add explicit --all filesystem discovery and structured discovery metadata
- harden read-only SQLite inventory against external path probes, malformed rows, oversized stores, and unbounded boundary allocation
- add cross-platform integration tests plus a privacy-safe tester workflow

## Safety
- read-only/no-create SQLite only
- no provider-state mutation or release changes
- no npm publication

## Verification
- legacy Python suite: 335 passed, 1 expected skip
- npm launcher syntax test: passed
- Rust fmt/clippy/test/release and ARM/macOS/Windows: delegated to this PR CI