### PR TITLE
security(rescue): centralize safe read-only source opening

### DIFF
--- a/src/rescue/codex.rs
+++ b/src/rescue/codex.rs
@@ -458,6 +458,7 @@ impl CodexAdapter {
         Ok(first)
     }
 
+    #[allow(dead_code)]
     fn read_bounded(path: &Path, limit: u64) -> Result<Vec<u8>> {
         safe_fs::read_bounded_existing(path, limit, "session").map_err(|error| {
             anyhow::anyhow!("session grew beyond the inspection budget while reading: {error}")

--- a/src/rescue/codex.rs
+++ b/src/rescue/codex.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::fs::{self, File};
-use std::io::Read;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
@@ -14,6 +13,7 @@ use crate::report;
 
 use super::adapter::RescueAdapter;
 use super::codex_inventory;
+use super::safe_fs;
 use super::types::{
     AdapterStatus, Availability, RescueContext, SessionHealth, SessionRef, SessionView,
     SnapshotReceipt,
@@ -381,16 +381,8 @@ impl CodexAdapter {
     }
 
     fn validate_root(context: &RescueContext) -> Result<PathBuf> {
-        let metadata = fs::symlink_metadata(&context.root)
-            .with_context(|| format!("inspect rescue root {}", context.root.display()))?;
-        if metadata.file_type().is_symlink() || !metadata.is_dir() {
-            bail!(
-                "rescue root must be a real directory, not a symlink: {}",
-                context.root.display()
-            );
-        }
-        fs::canonicalize(&context.root)
-            .with_context(|| format!("canonicalize rescue root {}", context.root.display()))
+        safe_fs::canonical_root(&context.root)
+            .with_context(|| format!("inspect rescue root {}", context.root.display()))
     }
 
     fn canonical_session_roots(context: &RescueContext) -> Result<Vec<PathBuf>> {
@@ -415,27 +407,19 @@ impl CodexAdapter {
     }
 
     fn validate_session_path(context: &RescueContext, path: &Path) -> Result<PathBuf> {
-        let metadata = fs::symlink_metadata(path)
-            .with_context(|| format!("inspect session {}", path.display()))?;
-        if metadata.file_type().is_symlink() || !metadata.is_file() {
-            bail!("session must be a regular non-symlink file");
-        }
-        #[cfg(unix)]
-        if metadata.nlink() != 1 {
-            bail!("session hardlinks are not accepted");
-        }
-        if metadata.len() > context.max_session_bytes {
+        let verified = safe_fs::open_regular(&context.root, path, "session")?;
+        if verified.len() > context.max_session_bytes {
             bail!(
                 "session exceeds the {} byte inspection budget",
                 context.max_session_bytes
             );
         }
-        let canonical = fs::canonicalize(path)
-            .with_context(|| format!("canonicalize session {}", path.display()))?;
+        let canonical = verified.path().to_path_buf();
         let roots = Self::canonical_session_roots(context)?;
         if !roots.iter().any(|root| canonical.starts_with(root)) {
             bail!("session is outside the configured Codex session roots");
         }
+        verified.ensure_unchanged("session")?;
         Ok(canonical)
     }
 
@@ -454,7 +438,9 @@ impl CodexAdapter {
     }
 
     fn read_stable(context: &RescueContext, path: &Path) -> Result<Vec<u8>> {
-        Self::read_stable_with(context, path, Self::read_bounded)
+        Self::read_stable_with(context, path, |path, limit| {
+            safe_fs::read_bounded(&context.root, path, limit, "session")
+        })
     }
 
     fn read_stable_with<F>(context: &RescueContext, path: &Path, mut read: F) -> Result<Vec<u8>>
@@ -473,13 +459,12 @@ impl CodexAdapter {
     }
 
     fn read_bounded(path: &Path, limit: u64) -> Result<Vec<u8>> {
-        let file = File::open(path)?;
-        let mut bytes = Vec::new();
-        file.take(limit.saturating_add(1)).read_to_end(&mut bytes)?;
-        if bytes.len() as u64 > limit {
-            bail!("session grew beyond the inspection budget while reading");
-        }
-        Ok(bytes)
+        safe_fs::read_bounded_existing(path, limit, "session")
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "session grew beyond the inspection budget while reading: {error}"
+                )
+            })
     }
 
     fn scan_directory(

--- a/src/rescue/codex.rs
+++ b/src/rescue/codex.rs
@@ -459,12 +459,9 @@ impl CodexAdapter {
     }
 
     fn read_bounded(path: &Path, limit: u64) -> Result<Vec<u8>> {
-        safe_fs::read_bounded_existing(path, limit, "session")
-            .map_err(|error| {
-                anyhow::anyhow!(
-                    "session grew beyond the inspection budget while reading: {error}"
-                )
-            })
+        safe_fs::read_bounded_existing(path, limit, "session").map_err(|error| {
+            anyhow::anyhow!("session grew beyond the inspection budget while reading: {error}")
+        })
     }
 
     fn scan_directory(

--- a/src/rescue/codex_index.rs
+++ b/src/rescue/codex_index.rs
@@ -17,6 +17,9 @@ use anyhow::{bail, Context, Result};
 use rusqlite::{types::ValueRef, Connection};
 use serde_json::Value;
 
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
 use super::{
     safe_fs,
     types::{RescueContext, SessionRef},

--- a/src/rescue/codex_index.rs
+++ b/src/rescue/codex_index.rs
@@ -10,20 +10,20 @@
 //! trusted.  It never falls back to a partial directory walk.
 
 use std::collections::HashSet;
-use std::fs::{self, File, Metadata, OpenOptions};
-use std::io::Read;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
-use rusqlite::{types::ValueRef, Connection, OpenFlags};
+use rusqlite::{types::ValueRef, Connection};
 use serde_json::Value;
 
-#[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-
-use super::types::{RescueContext, SessionRef};
+use super::{
+    safe_fs,
+    types::{RescueContext, SessionRef},
+};
 
 const MAX_INDEX_ROWS: usize = 100_000;
+const MAX_SQLITE_CELL_BYTES: usize = 64 * 1024;
 const MAX_SQLITE_DATABASES: usize = 64;
 const SQLITE_NAMES: [&str; 3] = ["state_5.sqlite", "state.sqlite", "state.db"];
 const SESSION_INDEX_NAME: &str = "session_index.jsonl";
@@ -132,12 +132,8 @@ pub fn discover(context: &RescueContext, limit: usize) -> Result<IndexDiscovery>
 }
 
 fn canonical_root(root: &Path) -> Result<PathBuf> {
-    let metadata = fs::symlink_metadata(root)
-        .with_context(|| "Codex rescue root is unavailable; pass --root to a real Codex home")?;
-    if metadata.file_type().is_symlink() || !metadata.is_dir() {
-        bail!("Codex rescue root must be a real directory");
-    }
-    fs::canonicalize(root).context("Codex rescue root cannot be canonicalized")
+    safe_fs::canonical_root(root)
+        .with_context(|| "Codex rescue root is unavailable; pass --root to a real Codex home")
 }
 
 fn session_roots(root: &Path) -> Result<Vec<PathBuf>> {
@@ -163,46 +159,6 @@ fn session_roots(root: &Path) -> Result<Vec<PathBuf>> {
     Ok(roots)
 }
 
-/// Open a read-only regular file and validate the metadata of the acquired
-/// handle. Unix uses O_NOFOLLOW for the final path component and rejects
-/// hardlinks. Windows has no safe, stable std-only equivalent for every
-/// reparse-point type; callers still reject an observed symlink before open
-/// and re-check the canonical identity after the handle is acquired.
-fn open_regular_file(path: &Path, label: &str) -> Result<(File, Metadata)> {
-    let mut options = OpenOptions::new();
-    options.read(true);
-    #[cfg(unix)]
-    options.custom_flags(libc::O_NOFOLLOW);
-    let file = options
-        .open(path)
-        .with_context(|| format!("open {label}"))?;
-    let metadata = file.metadata().with_context(|| format!("stat {label}"))?;
-    if !metadata.is_file() {
-        bail!("{label} is not a regular file");
-    }
-    #[cfg(unix)]
-    if metadata.nlink() != 1 {
-        bail!("{label} must not be hardlinked");
-    }
-    Ok((file, metadata))
-}
-
-fn ensure_path_unchanged(path: &Path, before: &Metadata, label: &str) -> Result<()> {
-    let after = fs::symlink_metadata(path).with_context(|| format!("recheck {label}"))?;
-    if after.file_type().is_symlink() || !after.is_file() {
-        bail!("{label} changed to a non-regular file");
-    }
-    #[cfg(unix)]
-    if after.dev() != before.dev() || after.ino() != before.ino() {
-        bail!("{label} changed while being verified");
-    }
-    #[cfg(not(unix))]
-    if after.len() != before.len() || after.modified().ok() != before.modified().ok() {
-        bail!("{label} changed while being verified");
-    }
-    Ok(())
-}
-
 fn verify_index_path(
     context: &RescueContext,
     root: &Path,
@@ -217,38 +173,26 @@ fn verify_index_path(
     } else {
         root.join(raw)
     };
-    let candidate_metadata = fs::symlink_metadata(&candidate)
+    let verified = safe_fs::open_regular(root, &candidate, "indexed rollout")
         .context("Codex index references an unavailable rollout")?;
-    if candidate_metadata.file_type().is_symlink() || !candidate_metadata.is_file() {
-        bail!("Codex index references a non-regular rollout file");
-    }
-    if candidate.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+    let canonical = verified.path().to_path_buf();
+    if canonical.extension().and_then(|value| value.to_str()) != Some("jsonl") {
         bail!("Codex index references a non-JSONL rollout file");
     }
-    let canonical = fs::canonicalize(&candidate).context("canonicalize indexed rollout")?;
     if !roots
         .iter()
         .any(|session_root| canonical.starts_with(session_root))
     {
         bail!("Codex index references a rollout outside the session roots");
     }
-    let (_file, canonical_metadata) = open_regular_file(&canonical, "indexed rollout")?;
-    ensure_path_unchanged(&canonical, &canonical_metadata, "indexed rollout")?;
+    let canonical_metadata = verified.metadata().context("stat indexed rollout")?;
     if canonical_metadata.len() > context.max_session_bytes {
         bail!(
             "Codex index references a rollout over the {} byte inspection budget",
             context.max_session_bytes
         );
     }
-    // The canonical path was checked before opening. Re-canonicalizing after
-    // the handle is acquired detects a parent-directory replacement on all
-    // platforms. Unix additionally uses O_NOFOLLOW for the final component;
-    // Windows reparse-point races cannot be made atomic with safe std APIs,
-    // so a changed identity is rejected and no recovery action is performed.
-    let rechecked = fs::canonicalize(&canonical).context("recheck indexed rollout")?;
-    if rechecked != canonical {
-        bail!("indexed rollout changed while being verified");
-    }
+    verified.ensure_unchanged("indexed rollout")?;
     let relative = canonical
         .strip_prefix(root)
         .context("indexed rollout is outside the Codex root")?
@@ -275,22 +219,23 @@ fn read_session_index(
     max_index_rows: usize,
 ) -> Result<Option<Vec<IndexPath>>> {
     let path = root.join(SESSION_INDEX_NAME);
-    let metadata = match fs::symlink_metadata(&path) {
-        Ok(metadata) => metadata,
+    match fs::symlink_metadata(&path) {
+        Ok(_) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error).context("inspect Codex session index"),
-    };
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
-        bail!("Codex session index is not a regular file");
     }
-    if metadata.len() > context.max_session_bytes {
-        bail!(
-            "Codex session index exceeds the {} byte inspection budget",
-            context.max_session_bytes
-        );
-    }
-    let first = read_bounded(&path, context.max_session_bytes)?;
-    let second = read_bounded(&path, context.max_session_bytes)?;
+    let first = safe_fs::read_bounded(
+        root,
+        &path,
+        context.max_session_bytes,
+        "Codex session index",
+    )?;
+    let second = safe_fs::read_bounded(
+        root,
+        &path,
+        context.max_session_bytes,
+        "Codex session index",
+    )?;
     if first != second {
         bail!("Codex session index changed while being read; retry after the writer stops");
     }
@@ -433,16 +378,15 @@ fn read_sqlite_indexes(
                 context.max_total_bytes
             );
         }
-        verified_candidates.push((path, metadata));
+        let canonical = safe_fs::canonical_regular_path(root, &path, "Codex SQLite index")?;
+        verified_candidates.push(canonical);
     }
 
     let mut found = false;
     let mut paths = Vec::new();
-    for (path, metadata) in verified_candidates {
+    for path in verified_candidates {
         found = true;
-        let canonical = fs::canonicalize(&path).context("canonicalize Codex SQLite index")?;
-        let connection = open_read_only(&canonical)?;
-        ensure_path_unchanged(&path, &metadata, "Codex SQLite index")?;
+        let connection = safe_fs::open_sqlite_read_only(root, &path, "Codex SQLite index")?;
         let tables = table_names(&connection)?;
         if !tables.iter().any(|table| table == "threads") {
             continue;
@@ -494,32 +438,30 @@ fn read_sqlite_indexes(
     }
 }
 
-fn open_read_only(path: &Path) -> Result<Connection> {
-    // rusqlite's portable path API cannot be given an already-open std::fs
-    // handle. The caller therefore performs regular-file, hardlink, size,
-    // and post-open identity checks around this read-only open. This is a
-    // bounded diagnostic path, not an atomic no-follow guarantee on Windows
-    // reparse points.
-    let connection = Connection::open_with_flags(
-        path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )
-    .map_err(|_| anyhow::anyhow!("Codex SQLite index could not be opened read-only"))?;
-    connection
-        .execute_batch("PRAGMA query_only=ON; PRAGMA busy_timeout=250;")
-        .map_err(|_| anyhow::anyhow!("Codex SQLite index could not be configured read-only"))?;
-    Ok(connection)
-}
-
 fn table_names(connection: &Connection) -> Result<Vec<String>> {
     let mut statement = connection
         .prepare("SELECT name FROM sqlite_schema WHERE type='table'")
         .context("read Codex SQLite schema")?;
     let rows = statement
-        .query_map([], |row| row.get::<_, String>(0))
+        .query_map([], |row| {
+            let value = row.get_ref(0)?;
+            Ok(bounded_text_value(value))
+        })
         .context("read Codex SQLite schema")?;
-    rows.collect::<rusqlite::Result<Vec<_>>>()
-        .context("read Codex SQLite schema")
+    let mut names = Vec::new();
+    let mut rows_seen = 0usize;
+    for row in rows {
+        rows_seen = rows_seen
+            .checked_add(1)
+            .context("Codex SQLite schema row counter overflow")?;
+        if rows_seen > MAX_INDEX_ROWS {
+            bail!("Codex SQLite schema exceeded the configured row budget");
+        }
+        if let Some(value) = row.context("read Codex SQLite schema")? {
+            names.push(value);
+        }
+    }
+    Ok(names)
 }
 
 fn table_columns(connection: &Connection, table: &str) -> Result<HashSet<String>> {
@@ -528,12 +470,25 @@ fn table_columns(connection: &Connection, table: &str) -> Result<HashSet<String>
         .prepare(&sql)
         .context("read Codex SQLite table schema")?;
     let rows = statement
-        .query_map([], |row| row.get::<_, String>(1))
+        .query_map([], |row| {
+            let value = row.get_ref(1)?;
+            Ok(bounded_text_value(value))
+        })
         .context("read Codex SQLite table schema")?;
-    Ok(rows
-        .collect::<rusqlite::Result<Vec<_>>>()?
-        .into_iter()
-        .collect())
+    let mut columns = HashSet::new();
+    let mut rows_seen = 0usize;
+    for row in rows {
+        rows_seen = rows_seen
+            .checked_add(1)
+            .context("Codex SQLite table schema row counter overflow")?;
+        if rows_seen > MAX_INDEX_ROWS {
+            bail!("Codex SQLite table schema exceeded the configured row budget");
+        }
+        if let Some(value) = row.context("read Codex SQLite table schema")? {
+            columns.insert(value);
+        }
+    }
+    Ok(columns)
 }
 
 fn quote_identifier(value: &str) -> String {
@@ -542,28 +497,24 @@ fn quote_identifier(value: &str) -> String {
 
 fn value_text(value: ValueRef<'_>) -> Option<String> {
     match value {
-        ValueRef::Text(value) => std::str::from_utf8(value).ok().map(ToOwned::to_owned),
+        ValueRef::Text(value) if value.len() <= MAX_SQLITE_CELL_BYTES => {
+            std::str::from_utf8(value).ok().map(ToOwned::to_owned)
+        }
+        ValueRef::Text(_) => None,
         ValueRef::Integer(value) => Some(value.to_string()),
         ValueRef::Real(value) => Some(value.to_string()),
         ValueRef::Null | ValueRef::Blob(_) => None,
     }
 }
 
-fn read_bounded(path: &Path, limit: u64) -> Result<Vec<u8>> {
-    let (mut file, metadata) = open_regular_file(path, "Codex session index")?;
-    ensure_path_unchanged(path, &metadata, "Codex session index")?;
-    if metadata.len() > limit {
-        bail!("Codex session index exceeds the inspection budget");
+fn bounded_text_value(value: ValueRef<'_>) -> Option<String> {
+    let ValueRef::Text(value) = value else {
+        return None;
+    };
+    if value.len() > MAX_SQLITE_CELL_BYTES {
+        return None;
     }
-    let mut bytes = Vec::new();
-    file.by_ref()
-        .take(limit.saturating_add(1))
-        .read_to_end(&mut bytes)
-        .context("read Codex session index")?;
-    if bytes.len() as u64 > limit {
-        bail!("Codex session index exceeds the inspection budget");
-    }
-    Ok(bytes)
+    std::str::from_utf8(value).ok().map(ToOwned::to_owned)
 }
 
 #[cfg(test)]

--- a/src/rescue/codex_index.rs
+++ b/src/rescue/codex_index.rs
@@ -60,7 +60,8 @@ pub fn discover(context: &RescueContext, limit: usize) -> Result<IndexDiscovery>
         bail!("rescue scan --limit must be greater than zero");
     }
 
-    let root = canonical_root(&context.root)?;
+    let configured_root = context.root.clone();
+    let root = canonical_root(&configured_root)?;
     let max_index_rows = context.max_files.min(MAX_INDEX_ROWS);
     if max_index_rows == 0 {
         bail!("limited rescue scan requires a positive max_files budget");
@@ -99,7 +100,7 @@ pub fn discover(context: &RescueContext, limit: usize) -> Result<IndexDiscovery>
     let mut seen = HashSet::new();
     let mut sessions = Vec::with_capacity(paths.len());
     for index_path in paths {
-        let session = verify_index_path(context, &root, &roots, &index_path.raw)?;
+        let session = verify_index_path(context, &configured_root, &root, &roots, &index_path.raw)?;
         if seen.insert(session.source_path.clone()) {
             sessions.push(session);
         }
@@ -164,7 +165,8 @@ fn session_roots(root: &Path) -> Result<Vec<PathBuf>> {
 
 fn verify_index_path(
     context: &RescueContext,
-    root: &Path,
+    configured_root: &Path,
+    canonical_root: &Path,
     roots: &[PathBuf],
     raw: &str,
 ) -> Result<SessionRef> {
@@ -174,9 +176,9 @@ fn verify_index_path(
     let candidate = if Path::new(raw).is_absolute() {
         PathBuf::from(raw)
     } else {
-        root.join(raw)
+        configured_root.join(raw)
     };
-    let verified = safe_fs::open_regular(root, &candidate, "indexed rollout")
+    let verified = safe_fs::open_regular(configured_root, &candidate, "indexed rollout")
         .context("Codex index references an unavailable rollout")?;
     let canonical = verified.path().to_path_buf();
     if canonical.extension().and_then(|value| value.to_str()) != Some("jsonl") {
@@ -197,7 +199,7 @@ fn verify_index_path(
     }
     verified.ensure_unchanged("indexed rollout")?;
     let relative = canonical
-        .strip_prefix(root)
+        .strip_prefix(canonical_root)
         .context("indexed rollout is outside the Codex root")?
         .to_string_lossy()
         .replace('\\', "/");

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -485,8 +485,8 @@ fn table_columns(connection: &Connection, table: &str) -> Result<HashSet<String>
                 "SQLite table schema exceeded the configured row budget"
             ));
         }
-        if let Some(column) = row
-            .map_err(|_| anyhow::anyhow!("SQLite table schema could not be read"))?
+        if let Some(column) =
+            row.map_err(|_| anyhow::anyhow!("SQLite table schema could not be read"))?
         {
             columns.insert(column);
         }
@@ -732,11 +732,8 @@ fn inspect_thread_store(
     let mut read_error = false;
     let mut schema_unknown = false;
     for db_path in candidates {
-        let Ok(connection) = safe_fs::open_sqlite_read_only(
-            root,
-            &db_path,
-            "SQLite database",
-        ) else {
+        let Ok(connection) = safe_fs::open_sqlite_read_only(root, &db_path, "SQLite database")
+        else {
             read_error = true;
             continue;
         };
@@ -1102,11 +1099,8 @@ fn inspect_projection(
     let mut states = Vec::new();
     let mut relevant_error = candidate_set.rejected;
     for db_path in candidates {
-        let Ok(connection) = safe_fs::open_sqlite_read_only(
-            root,
-            &db_path,
-            "SQLite database",
-        ) else {
+        let Ok(connection) = safe_fs::open_sqlite_read_only(root, &db_path, "SQLite database")
+        else {
             relevant_error = true;
             continue;
         };

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -7,23 +7,21 @@
 //! report contains only classifications and numeric cursor evidence; provider
 //! paths read from SQLite are never serialized or included in errors.
 //!
-//! Residual boundary: path validation and the later file/SQLite open are still
-//! separate operations.  A concurrent writer can replace a validated path
-//! between those operations.  Closing that TOCTOU window requires a shared,
-//! platform-specific no-follow/handle-based opener used by all rescue
-//! adapters; this module therefore fails closed on unstable byte snapshots but
-//! does not claim atomic path authorization yet.
+//! The shared [`super::safe_fs`] opener keeps source/handle identity checks in
+//! one place.  It is intentionally fail-closed when a path or acquired handle
+//! changes; on Windows the stable std API cannot expose file-index/hard-link
+//! identity, so the helper documents that remaining limitation instead of
+//! claiming an atomic guarantee it cannot provide.
 
 use std::collections::HashSet;
-use std::fs::{self, File};
-use std::io::Read;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
-use rusqlite::{types::ValueRef, Connection, OpenFlags};
+use rusqlite::{types::ValueRef, Connection};
 use serde::Serialize;
 
-use super::types::RescueContext;
+use super::{safe_fs, types::RescueContext};
 
 pub const INDEX_DIVERGENCE: &str = "INDEX_DIVERGENCE";
 pub const ROLLOUT_MISSING: &str = "ROLLOUT_MISSING";
@@ -37,6 +35,7 @@ const THREAD_TABLE: &str = "threads";
 const PROJECTION_TABLE: &str = "thread_history_projection_state";
 const MAX_SQLITE_CANDIDATES: usize = 32;
 const MAX_SQLITE_ROWS: usize = 100_000;
+const MAX_SQLITE_CELL_BYTES: usize = 64 * 1024;
 const MAX_SQLITE_BYTES: u64 = 512 * 1024 * 1024;
 const MAX_SESSION_ID_BYTES: usize = 256;
 
@@ -221,57 +220,26 @@ struct ProjectionResult {
 }
 
 fn canonical_root(root: &Path) -> Result<PathBuf> {
-    let metadata =
-        fs::symlink_metadata(root).map_err(|_| anyhow::anyhow!("rescue root is unavailable"))?;
-    if metadata.file_type().is_symlink() || !metadata.is_dir() {
-        bail!("rescue root must be a real directory");
-    }
-    fs::canonicalize(root).map_err(|_| anyhow::anyhow!("rescue root cannot be canonicalized"))
+    safe_fs::canonical_root(root)
+        .map_err(|_| anyhow::anyhow!("rescue root cannot be canonicalized"))
 }
 
 fn validate_session_path(root: &Path, path: &Path) -> Result<PathBuf> {
-    let metadata = fs::symlink_metadata(path)
-        .map_err(|_| anyhow::anyhow!("session evidence is unavailable"))?;
-    if metadata.file_type().is_symlink() || !metadata.is_file() {
-        bail!("session evidence must be a regular file");
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        if metadata.nlink() != 1 {
-            bail!("session hardlinks are not accepted");
-        }
-    }
-    let canonical = fs::canonicalize(path)
-        .map_err(|_| anyhow::anyhow!("session evidence cannot be canonicalized"))?;
-    if !canonical.starts_with(root) {
-        bail!("session evidence is outside the configured rescue root");
-    }
-    Ok(canonical)
+    let verified = safe_fs::open_regular(root, path, "session evidence")
+        .map_err(|_| anyhow::anyhow!("session evidence cannot be opened safely"))?;
+    verified
+        .ensure_unchanged("session evidence")
+        .map_err(|_| anyhow::anyhow!("session evidence changed while being inspected"))?;
+    Ok(verified.path().to_path_buf())
 }
 
 fn read_stable_session(root: &Path, path: &Path, limit: u64) -> Result<Vec<u8>> {
-    let canonical = validate_session_path(root, path)?;
-    let first = read_bounded(&canonical, limit)?;
-    let second = read_bounded(&canonical, limit)?;
+    let first = safe_fs::read_bounded(root, path, limit, "session evidence")?;
+    let second = safe_fs::read_bounded(root, path, limit, "session evidence")?;
     if first != second {
         bail!("session changed while being read; retry after the writer stops");
     }
     Ok(first)
-}
-
-fn read_bounded(path: &Path, limit: u64) -> Result<Vec<u8>> {
-    let mut file =
-        File::open(path).map_err(|_| anyhow::anyhow!("session evidence cannot be opened"))?;
-    let mut bytes = Vec::new();
-    file.by_ref()
-        .take(limit.saturating_add(1))
-        .read_to_end(&mut bytes)
-        .map_err(|_| anyhow::anyhow!("session evidence cannot be read"))?;
-    if bytes.len() as u64 > limit {
-        bail!("session evidence exceeds the inspection budget");
-    }
-    Ok(bytes)
 }
 
 fn parse_session_id(bytes: &[u8]) -> Option<String> {
@@ -446,7 +414,7 @@ fn database_candidates(
             };
         }
         total_bytes = next_total;
-        let canonical = match fs::canonicalize(&path) {
+        let canonical = match safe_fs::canonical_regular_path(root, &path, "SQLite database") {
             Ok(canonical) if canonical.starts_with(root) => canonical,
             Ok(_) | Err(_) => {
                 rejected = true;
@@ -467,28 +435,30 @@ fn database_candidates(
     }
 }
 
-fn open_read_only(path: &Path) -> Result<Connection> {
-    let connection = Connection::open_with_flags(
-        path,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-    )
-    .map_err(|_| anyhow::anyhow!("SQLite database could not be opened read-only"))?;
-    connection
-        .execute_batch("PRAGMA query_only=ON; PRAGMA busy_timeout=250;")
-        .map_err(|_| anyhow::anyhow!("SQLite database could not be configured read-only"))?;
-    Ok(connection)
-}
-
 fn table_names(connection: &Connection) -> Result<Vec<String>> {
     let mut statement = connection
         .prepare("SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name")
         .map_err(|_| anyhow::anyhow!("SQLite schema could not be read"))?;
     let rows = statement
-        .query_map([], |row| row.get::<_, String>(0))
+        .query_map([], |row| {
+            let value = row.get_ref(0)?;
+            Ok(bounded_text_value(value))
+        })
         .map_err(|_| anyhow::anyhow!("SQLite schema could not be read"))?;
     let mut names = Vec::new();
-    for row in rows.take(MAX_SQLITE_ROWS) {
-        names.push(row.map_err(|_| anyhow::anyhow!("SQLite schema could not be read"))?);
+    let mut rows_seen = 0usize;
+    for row in rows {
+        rows_seen = rows_seen
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("SQLite schema row counter overflow"))?;
+        if rows_seen > MAX_SQLITE_ROWS {
+            return Err(anyhow::anyhow!(
+                "SQLite schema exceeded the configured row budget"
+            ));
+        }
+        if let Some(name) = row.map_err(|_| anyhow::anyhow!("SQLite schema could not be read"))? {
+            names.push(name);
+        }
     }
     Ok(names)
 }
@@ -499,11 +469,27 @@ fn table_columns(connection: &Connection, table: &str) -> Result<HashSet<String>
         .prepare(&sql)
         .map_err(|_| anyhow::anyhow!("SQLite table schema could not be read"))?;
     let rows = statement
-        .query_map([], |row| row.get::<_, String>(1))
+        .query_map([], |row| {
+            let value = row.get_ref(1)?;
+            Ok(bounded_text_value(value))
+        })
         .map_err(|_| anyhow::anyhow!("SQLite table schema could not be read"))?;
     let mut columns = HashSet::new();
+    let mut rows_seen = 0usize;
     for row in rows {
-        columns.insert(row.map_err(|_| anyhow::anyhow!("SQLite table schema could not be read"))?);
+        rows_seen = rows_seen
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("SQLite table schema row counter overflow"))?;
+        if rows_seen > MAX_SQLITE_ROWS {
+            return Err(anyhow::anyhow!(
+                "SQLite table schema exceeded the configured row budget"
+            ));
+        }
+        if let Some(column) = row
+            .map_err(|_| anyhow::anyhow!("SQLite table schema could not be read"))?
+        {
+            columns.insert(column);
+        }
     }
     Ok(columns)
 }
@@ -521,10 +507,24 @@ fn first_column(columns: &HashSet<String>, names: &[&str]) -> Option<String> {
 
 fn value_text(value: ValueRef<'_>) -> Option<String> {
     match value {
-        ValueRef::Text(value) => std::str::from_utf8(value).ok().map(ToOwned::to_owned),
+        ValueRef::Text(value) if value.len() <= MAX_SQLITE_CELL_BYTES => {
+            std::str::from_utf8(value).ok().map(ToOwned::to_owned)
+        }
+        ValueRef::Text(_) => None,
         ValueRef::Integer(value) => Some(value.to_string()),
         ValueRef::Real(value) => Some(value.to_string()),
         ValueRef::Null | ValueRef::Blob(_) => None,
+    }
+}
+
+fn bounded_text_value(value: ValueRef<'_>) -> Option<String> {
+    match value {
+        ValueRef::Text(value) if value.len() <= MAX_SQLITE_CELL_BYTES => {
+            std::str::from_utf8(value).ok().map(ToOwned::to_owned)
+        }
+        ValueRef::Text(_) | ValueRef::Null | ValueRef::Blob(_) => None,
+        ValueRef::Integer(value) => Some(value.to_string()),
+        ValueRef::Real(value) => Some(value.to_string()),
     }
 }
 
@@ -690,7 +690,14 @@ fn stored_path_exists_within_root(root: &Path, stored: &str) -> Option<bool> {
         }
     }
     let metadata = fs::symlink_metadata(&candidate).ok()?;
-    Some(metadata.is_file() && !metadata.file_type().is_symlink())
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Some(false);
+    }
+    // Re-run the shared final-component/reparse policy before treating a
+    // provider-supplied alternate path as present.  Any unestablished
+    // identity is deliberately reported as unknown rather than true.
+    safe_fs::canonical_regular_path(root, &candidate, "stored rollout").ok()?;
+    Some(true)
 }
 
 fn looks_windows_path(value: &str) -> bool {
@@ -725,7 +732,11 @@ fn inspect_thread_store(
     let mut read_error = false;
     let mut schema_unknown = false;
     for db_path in candidates {
-        let Ok(connection) = open_read_only(&db_path) else {
+        let Ok(connection) = safe_fs::open_sqlite_read_only(
+            root,
+            &db_path,
+            "SQLite database",
+        ) else {
             read_error = true;
             continue;
         };
@@ -1091,7 +1102,11 @@ fn inspect_projection(
     let mut states = Vec::new();
     let mut relevant_error = candidate_set.rejected;
     for db_path in candidates {
-        let Ok(connection) = open_read_only(&db_path) else {
+        let Ok(connection) = safe_fs::open_sqlite_read_only(
+            root,
+            &db_path,
+            "SQLite database",
+        ) else {
             relevant_error = true;
             continue;
         };

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -126,6 +126,7 @@ pub fn inspect_session(
     session_bytes: Option<&[u8]>,
     metadata: Option<&SessionMetadata>,
 ) -> Result<CodexInventoryReport> {
+    let configured_root = context.root.clone();
     let root = canonical_root(&context.root)?;
     let metadata = metadata.cloned().unwrap_or_default();
     let requested_path = session_path
@@ -141,12 +142,12 @@ pub fn inspect_session(
             Some(bytes.to_vec())
         }
         None => requested_path
-            .map(|path| read_stable_session(&root, path, context.max_session_bytes))
+            .map(|path| read_stable_session(&configured_root, path, context.max_session_bytes))
             .transpose()?,
     };
 
     let canonical_session_path = requested_path
-        .map(|path| validate_session_path(&root, path))
+        .map(|path| validate_session_path(&configured_root, path))
         .transpose()?;
     let session_id = metadata
         .session_id

--- a/src/rescue/mod.rs
+++ b/src/rescue/mod.rs
@@ -39,23 +39,19 @@ fn default_root(adapter: &str, explicit: Option<&Path>) -> Result<PathBuf> {
         } else {
             std::env::current_dir()?.join(path)
         };
-        return Ok(fs_canonical_or_original(candidate));
+        return Ok(candidate);
     }
     if adapter != "codex" {
         bail!("adapter {adapter:?} requires an explicit --root");
     }
     if let Some(path) = std::env::var_os("CODEX_HOME") {
-        return Ok(fs_canonical_or_original(PathBuf::from(path)));
+        return Ok(PathBuf::from(path));
     }
     let home = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)
         .context("neither CODEX_HOME, HOME nor USERPROFILE is set; pass --root")?;
-    Ok(fs_canonical_or_original(home.join(".codex")))
-}
-
-fn fs_canonical_or_original(path: PathBuf) -> PathBuf {
-    std::fs::canonicalize(&path).unwrap_or(path)
+    Ok(home.join(".codex"))
 }
 
 fn select_session(

--- a/src/rescue/mod.rs
+++ b/src/rescue/mod.rs
@@ -3,6 +3,7 @@ mod claude;
 mod codex;
 mod codex_index;
 mod codex_inventory;
+mod safe_fs;
 pub mod types;
 
 use std::path::{Path, PathBuf};

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -1,0 +1,578 @@
+//! Bounded, read-only filesystem primitives for rescue diagnostics.
+//!
+//! Rescue consumes provider-owned files.  A provider path is untrusted input,
+//! even when it was discovered below the configured state root: the path can
+//! be replaced by a symlink, junction, or another file between validation and
+//! the eventual open.  This module centralises the checks used by the rescue
+//! adapters so that every byte read follows the same boundary.
+//!
+//! The checks are deliberately conservative.  Unix uses `O_NOFOLLOW` for the
+//! final component and compares device/inode identity from the path with the
+//! acquired handle.  Windows has no stable, safe-std API for obtaining the
+//! file-index and hard-link count on the minimum supported toolchain.  We
+//! reject observable reparse points and perform a post-open path/handle
+//! identity check using the stable metadata available there.  A replacement
+//! observed by those checks is an error; an undetectable Windows hard-link
+//! race remains an explicit limitation rather than a claimed guarantee.  This
+//! helper never mutates a source file.
+
+use std::fs::{self, File, Metadata, OpenOptions};
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use rusqlite::{Connection, OpenFlags};
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+#[cfg(windows)]
+use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+
+#[cfg(test)]
+use std::io::{Seek, SeekFrom};
+
+#[cfg(windows)]
+const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+
+/// An identity which is stable for the lifetime of an opened source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FileIdentity {
+    #[cfg(unix)]
+    Unix { device: u64, inode: u64 },
+    #[cfg(windows)]
+    // `MetadataExt::{volume_serial_number,file_index,number_of_links}` are
+    // still unstable on the minimum supported Rust toolchain.  The stable
+    // metadata fingerprint is therefore intentionally conservative: any
+    // observed mismatch fails closed, while the API does not claim that it
+    // closes an undetectable Windows hard-link race.
+    Windows {
+        length: u64,
+        modified: u64,
+        created: u64,
+        attributes: u32,
+    },
+    #[cfg(not(any(unix, windows)))]
+    Portable {
+        length: u64,
+        modified_nanos: Option<u128>,
+    },
+}
+
+/// A file opened after root and identity validation.
+///
+/// The underlying handle remains open while the caller consumes it.  Call
+/// [`VerifiedFile::ensure_unchanged`] after reading to detect replacement,
+/// truncation, or a path race observed by the platform metadata APIs.
+pub(crate) struct VerifiedFile {
+    file: File,
+    canonical_path: PathBuf,
+    identity: FileIdentity,
+    length: u64,
+}
+
+impl std::fmt::Debug for VerifiedFile {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("VerifiedFile")
+            .field("canonical_path", &self.canonical_path)
+            .field("length", &self.length)
+            .finish_non_exhaustive()
+    }
+}
+
+impl VerifiedFile {
+    pub(crate) fn path(&self) -> &Path {
+        &self.canonical_path
+    }
+
+    pub(crate) fn len(&self) -> u64 {
+        self.length
+    }
+
+    pub(crate) fn metadata(&self) -> Result<Metadata> {
+        self.file
+            .metadata()
+            .context("stat verified file handle")
+    }
+
+    pub(crate) fn file_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+
+    /// Verify that both the open handle and the pathname still identify the
+    /// same regular file.  This is intentionally required after every read.
+    pub(crate) fn ensure_unchanged(&self, label: &str) -> Result<()> {
+        let handle_metadata = self
+            .file
+            .metadata()
+            .with_context(|| format!("stat {label} handle"))?;
+        validate_regular_metadata(&handle_metadata, label)?;
+        let handle_identity = identity(&handle_metadata, label)?;
+        if handle_identity != self.identity || handle_metadata.len() != self.length {
+            bail!("{label} changed while being inspected");
+        }
+
+        let path_metadata = fs::symlink_metadata(&self.canonical_path)
+            .with_context(|| format!("recheck {label}"))?;
+        validate_regular_metadata(&path_metadata, label)?;
+        let path_identity = identity(&path_metadata, label)?;
+        if path_identity != self.identity || path_metadata.len() != self.length {
+            bail!("{label} path changed while being inspected");
+        }
+        let canonical = fs::canonicalize(&self.canonical_path)
+            .with_context(|| format!("re-canonicalize {label}"))?;
+        if canonical != self.canonical_path {
+            bail!("{label} path changed while being inspected");
+        }
+        Ok(())
+    }
+}
+
+/// Canonicalize and validate a configured rescue root.
+pub(crate) fn canonical_root(root: &Path) -> Result<PathBuf> {
+    let metadata = fs::symlink_metadata(root)
+        .with_context(|| format!("inspect rescue root {}", root.display()))?;
+    validate_directory_metadata(&metadata, "rescue root")?;
+    let canonical = fs::canonicalize(root)
+        .with_context(|| format!("canonicalize rescue root {}", root.display()))?;
+    let canonical_metadata = fs::symlink_metadata(&canonical)
+        .with_context(|| format!("recheck rescue root {}", root.display()))?;
+    validate_directory_metadata(&canonical_metadata, "rescue root")?;
+    Ok(canonical)
+}
+
+/// Return a canonical regular file path after validating every component.
+///
+/// This is useful for preflight and path-only diagnostics.  Callers which
+/// consume bytes should use [`open_regular`] instead so the acquired handle
+/// and the path are checked together.
+pub(crate) fn canonical_regular_path(
+    root: &Path,
+    path: &Path,
+    label: &str,
+) -> Result<PathBuf> {
+    let root = canonical_root(root)?;
+    let candidate = candidate_under_root(&root, path, label)?;
+    walk_without_links(&root, &candidate, label)?;
+    let canonical = fs::canonicalize(&candidate)
+        .with_context(|| format!("canonicalize {label}"))?;
+    if !canonical.starts_with(&root) {
+        bail!("{label} is outside the configured rescue root");
+    }
+    let metadata = fs::symlink_metadata(&canonical)
+        .with_context(|| format!("inspect {label}"))?;
+    validate_regular_metadata(&metadata, label)?;
+    Ok(canonical)
+}
+
+/// Open a regular file read-only after root-bound and no-follow checks.
+pub(crate) fn open_regular(root: &Path, path: &Path, label: &str) -> Result<VerifiedFile> {
+    let root = canonical_root(root)?;
+    let candidate = candidate_under_root(&root, path, label)?;
+    walk_without_links(&root, &candidate, label)?;
+
+    let canonical_before = fs::canonicalize(&candidate)
+        .with_context(|| format!("canonicalize {label}"))?;
+    if !canonical_before.starts_with(&root) {
+        bail!("{label} is outside the configured rescue root");
+    }
+    let path_metadata = fs::symlink_metadata(&candidate)
+        .with_context(|| format!("inspect {label}"))?;
+    validate_regular_metadata(&path_metadata, label)?;
+    let expected_identity = identity(&path_metadata, label)?;
+    let expected_length = path_metadata.len();
+
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    #[cfg(windows)]
+    {
+        // FILE_FLAG_OPEN_REPARSE_POINT makes the final component observable
+        // as a reparse point instead of silently following it.  Parent
+        // components are independently checked by walk_without_links.
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    let probe = options
+        .open(&candidate)
+        .with_context(|| format!("open {label}"))?;
+    let opened_metadata = probe
+        .metadata()
+        .with_context(|| format!("stat {label} handle"))?;
+    validate_regular_metadata(&opened_metadata, label)?;
+    let opened_identity = identity(&opened_metadata, label)?;
+    if opened_identity != expected_identity || opened_metadata.len() != expected_length {
+        bail!("{label} changed while being opened");
+    }
+
+    // A canonical-path recheck catches parent-directory replacement on all
+    // platforms.  It cannot make a race atomic with stable std APIs; if the
+    // replacement is observed, the operation fails closed.
+    let canonical_after = fs::canonicalize(&candidate)
+        .with_context(|| format!("recheck {label}"))?;
+    if canonical_after != canonical_before || !canonical_after.starts_with(&root) {
+        bail!("{label} changed while being opened");
+    }
+
+    Ok(VerifiedFile {
+        file: probe,
+        canonical_path: canonical_before,
+        identity: opened_identity,
+        length: opened_metadata.len(),
+    })
+}
+
+/// Read a bounded snapshot while keeping the validated handle open.
+pub(crate) fn read_bounded(
+    root: &Path,
+    path: &Path,
+    limit: u64,
+    label: &str,
+) -> Result<Vec<u8>> {
+    let mut verified = open_regular(root, path, label)?;
+    read_bounded_from_opened(&mut verified, limit, label)
+}
+
+/// Read a bounded snapshot from a path which was already root-validated by a
+/// caller.  This is used by the Codex adapter's two-pass stability check; the
+/// final component is still opened with the platform-specific no-follow
+/// policy and handle/path identity checks.
+pub(crate) fn read_bounded_existing(
+    path: &Path,
+    limit: u64,
+    label: &str,
+) -> Result<Vec<u8>> {
+    let path_metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect {label}"))?;
+    validate_regular_metadata(&path_metadata, label)?;
+    let expected_identity = identity(&path_metadata, label)?;
+    let expected_length = path_metadata.len();
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    #[cfg(windows)]
+    options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    let file = options
+        .open(path)
+        .with_context(|| format!("open {label}"))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("stat {label} handle"))?;
+    validate_regular_metadata(&metadata, label)?;
+    let opened_identity = identity(&metadata, label)?;
+    if opened_identity != expected_identity || metadata.len() != expected_length {
+        bail!("{label} changed while being opened");
+    }
+    let canonical = fs::canonicalize(path).with_context(|| format!("canonicalize {label}"))?;
+    let canonical_metadata = fs::symlink_metadata(&canonical)
+        .with_context(|| format!("recheck {label}"))?;
+    validate_regular_metadata(&canonical_metadata, label)?;
+    if identity(&canonical_metadata, label)? != expected_identity
+        || canonical_metadata.len() != expected_length
+    {
+        bail!("{label} changed while being opened");
+    }
+    let mut verified = VerifiedFile {
+        file,
+        canonical_path: canonical,
+        identity: opened_identity,
+        length: metadata.len(),
+    };
+    read_bounded_from_opened(&mut verified, limit, label)
+}
+
+fn read_bounded_from_opened(
+    verified: &mut VerifiedFile,
+    limit: u64,
+    label: &str,
+) -> Result<Vec<u8>> {
+    if verified.len() > limit {
+        bail!("{label} exceeds the inspection budget");
+    }
+    let mut bytes = Vec::new();
+    verified
+        .file_mut()
+        .take(limit.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("read {label}"))?;
+    if bytes.len() as u64 > limit {
+        bail!("{label} exceeds the inspection budget");
+    }
+    verified.ensure_unchanged(label)?;
+    Ok(bytes)
+}
+
+/// Open a SQLite database with `READ_ONLY` and `NO_CREATE` semantics after
+/// the same file/path checks used for JSONL sources.
+pub(crate) fn open_sqlite_read_only(
+    root: &Path,
+    path: &Path,
+    label: &str,
+) -> Result<Connection> {
+    let verified = open_regular(root, path, label)?;
+    let canonical = verified.path().to_path_buf();
+    let connection = Connection::open_with_flags(
+        &canonical,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|_| anyhow::anyhow!("{label} could not be opened read-only"))?;
+    // SQLite's flags prevent creation.  query_only protects against accidental
+    // writes in future diagnostic queries; identity is checked before the
+    // connection is returned so a path swap cannot be silently accepted.
+    connection
+        .execute_batch("PRAGMA query_only=ON; PRAGMA busy_timeout=250;")
+        .map_err(|_| anyhow::anyhow!("{label} could not be configured read-only"))?;
+    verified.ensure_unchanged(label)?;
+    Ok(connection)
+}
+
+fn candidate_under_root(root: &Path, path: &Path, label: &str) -> Result<PathBuf> {
+    if path.as_os_str().is_empty() {
+        bail!("{label} path is empty");
+    }
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    };
+    if candidate
+        .components()
+        .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+    {
+        bail!("{label} contains an unsafe path component");
+    }
+    if !candidate.starts_with(root) {
+        bail!("{label} is outside the configured rescue root");
+    }
+    Ok(candidate)
+}
+
+fn walk_without_links(root: &Path, candidate: &Path, label: &str) -> Result<()> {
+    let relative = candidate
+        .strip_prefix(root)
+        .with_context(|| format!("{label} is outside the configured rescue root"))?;
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            bail!("{label} contains an unsafe path component");
+        };
+        current.push(component);
+        let metadata = fs::symlink_metadata(&current)
+            .with_context(|| format!("inspect {label} path component"))?;
+        validate_not_reparse(&metadata, label)?;
+        if current != candidate && !metadata.is_dir() {
+            bail!("{label} has a non-directory parent");
+        }
+    }
+    Ok(())
+}
+
+fn validate_directory_metadata(metadata: &Metadata, label: &str) -> Result<()> {
+    validate_not_reparse(metadata, label)?;
+    if !metadata.is_dir() {
+        bail!("{label} must be a real directory");
+    }
+    Ok(())
+}
+
+fn validate_regular_metadata(metadata: &Metadata, label: &str) -> Result<()> {
+    validate_not_reparse(metadata, label)?;
+    if !metadata.is_file() {
+        bail!("{label} must be a regular file");
+    }
+    #[cfg(unix)]
+    if metadata.nlink() != 1 {
+        bail!("{label} must not be hardlinked");
+    }
+    Ok(())
+}
+
+fn validate_not_reparse(metadata: &Metadata, label: &str) -> Result<()> {
+    if metadata.file_type().is_symlink() {
+        bail!("{label} must not be a symlink or reparse point");
+    }
+    #[cfg(windows)]
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        bail!("{label} must not be a symlink or reparse point");
+    }
+    Ok(())
+}
+
+fn identity(metadata: &Metadata, label: &str) -> Result<FileIdentity> {
+    #[cfg(unix)]
+    {
+        return Ok(FileIdentity::Unix {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        });
+    }
+    #[cfg(windows)]
+    {
+        // These fields are all stable on the supported Windows toolchains.
+        // The Windows file-index/link-count accessors are nightly-only, so we
+        // intentionally do not claim hard-link identity here.
+        return Ok(FileIdentity::Windows {
+            length: metadata.len(),
+            modified: metadata.last_write_time(),
+            created: metadata.creation_time(),
+            attributes: metadata.file_attributes(),
+        });
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        Ok(FileIdentity::Portable {
+            length: metadata.len(),
+            modified_nanos: metadata
+                .modified()
+                .ok()
+                .and_then(|value| value.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|value| value.as_nanos()),
+        })
+    }
+    #[allow(unreachable_code)]
+    {
+        let _ = label;
+        bail!("file identity is unavailable on this platform");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_TEMP_ROOT: AtomicU64 = AtomicU64::new(0);
+
+    struct TempRoot(PathBuf);
+
+    impl TempRoot {
+        fn new(tag: &str) -> Self {
+            let nonce = NEXT_TEMP_ROOT.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "vetto-safe-fs-{tag}-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("temp root");
+            Self(path)
+        }
+    }
+
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn opens_only_regular_files_under_root_and_preserves_bytes() {
+        let temp = TempRoot::new("regular");
+        let root = &temp.0;
+        let path = root.join("sessions/session.jsonl");
+        fs::create_dir_all(path.parent().expect("parent")).expect("parent");
+        fs::write(&path, b"hello\n").expect("source");
+
+        let bytes = read_bounded(root, &path, 1024, "session").expect("read");
+        assert_eq!(bytes, b"hello\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_final_symlink_and_intermediate_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempRoot::new("symlink");
+        let root = &temp.0;
+        let outside = temp.0.join("outside.jsonl");
+        fs::write(&outside, b"outside\n").expect("outside");
+        let final_link = root.join("final.jsonl");
+        symlink(&outside, &final_link).expect("final symlink");
+        assert!(open_regular(root, &final_link, "final").is_err());
+
+        let outside_dir = temp.0.join("outside-dir");
+        fs::create_dir_all(&outside_dir).expect("outside dir");
+        fs::write(outside_dir.join("nested.jsonl"), b"outside\n").expect("nested");
+        let linked_dir = root.join("linked");
+        symlink(&outside_dir, &linked_dir).expect("directory symlink");
+        let nested = linked_dir.join("nested.jsonl");
+        assert!(open_regular(root, &nested, "nested").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_hardlink_identity_aliases() {
+        let temp = TempRoot::new("hardlink");
+        let root = &temp.0;
+        let source = root.join("source.jsonl");
+        let alias = root.join("alias.jsonl");
+        fs::write(&source, b"source\n").expect("source");
+        fs::hard_link(&source, &alias).expect("hardlink");
+        let error = open_regular(root, &alias, "alias").expect_err("hardlink rejected");
+        assert!(error.to_string().contains("hardlinked"), "{error:#}");
+    }
+
+    #[test]
+    fn rejects_root_escape_and_path_replacement_on_revalidation() {
+        let temp = TempRoot::new("race");
+        let root = &temp.0;
+        let path = root.join("session.jsonl");
+        fs::write(&path, b"before\n").expect("source");
+        let verified = open_regular(root, &path, "session").expect("open");
+        let outside = temp.0.join("outside");
+        fs::write(&outside, b"outside\n").expect("outside");
+        assert!(canonical_regular_path(root, Path::new("../outside"), "escape").is_err());
+
+        fs::remove_file(&path).expect("remove source");
+        fs::write(&path, b"replacement\n").expect("replacement");
+        assert!(verified.ensure_unchanged("session").is_err());
+    }
+
+    #[test]
+    fn bounded_reader_rejects_growth() {
+        let temp = TempRoot::new("limit");
+        let root = &temp.0;
+        let path = root.join("session.jsonl");
+        fs::write(&path, b"12345").expect("source");
+        let error = read_bounded(root, &path, 4, "session").expect_err("limit");
+        assert!(error.to_string().contains("budget"), "{error:#}");
+    }
+
+    #[test]
+    fn verified_file_can_be_consumed_without_mutating_source() {
+        let temp = TempRoot::new("readonly");
+        let root = &temp.0;
+        let path = root.join("session.jsonl");
+        fs::write(&path, b"read-only\n").expect("source");
+        let mut file = open_regular(root, &path, "session").expect("open");
+        file.file_mut()
+            .seek(SeekFrom::Start(0))
+            .expect("seek source");
+        let mut bytes = Vec::new();
+        file.file_mut().read_to_end(&mut bytes).expect("read source");
+        file.ensure_unchanged("session").expect("unchanged");
+        assert_eq!(bytes, b"read-only\n");
+        assert_eq!(fs::read(&path).expect("source bytes"), b"read-only\n");
+    }
+
+    #[test]
+    fn sqlite_open_is_read_only_and_never_creates_a_missing_source() {
+        let temp = TempRoot::new("sqlite");
+        let root = &temp.0;
+        let path = root.join("state.sqlite");
+        let connection = Connection::open(&path).expect("fixture database");
+        connection
+            .execute("CREATE TABLE threads (id TEXT PRIMARY KEY)", [])
+            .expect("fixture schema");
+        drop(connection);
+
+        let connection = open_sqlite_read_only(root, &path, "SQLite database").expect("open");
+        assert!(connection
+            .execute("CREATE TABLE should_not_exist (id TEXT)", [])
+            .is_err());
+
+        let missing = root.join("missing.sqlite");
+        assert!(open_sqlite_read_only(root, &missing, "SQLite database").is_err());
+        assert!(!missing.exists(), "read-only open must not create a file");
+    }
+}

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -34,6 +34,8 @@ use std::io::{Seek, SeekFrom};
 
 #[cfg(windows)]
 const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+#[cfg(windows)]
+const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
 
 /// An identity which is stable for the lifetime of an opened source.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,9 +93,7 @@ impl VerifiedFile {
     }
 
     pub(crate) fn metadata(&self) -> Result<Metadata> {
-        self.file
-            .metadata()
-            .context("stat verified file handle")
+        self.file.metadata().context("stat verified file handle")
     }
 
     pub(crate) fn file_mut(&mut self) -> &mut File {
@@ -147,21 +147,16 @@ pub(crate) fn canonical_root(root: &Path) -> Result<PathBuf> {
 /// This is useful for preflight and path-only diagnostics.  Callers which
 /// consume bytes should use [`open_regular`] instead so the acquired handle
 /// and the path are checked together.
-pub(crate) fn canonical_regular_path(
-    root: &Path,
-    path: &Path,
-    label: &str,
-) -> Result<PathBuf> {
+pub(crate) fn canonical_regular_path(root: &Path, path: &Path, label: &str) -> Result<PathBuf> {
     let root = canonical_root(root)?;
     let candidate = candidate_under_root(&root, path, label)?;
     walk_without_links(&root, &candidate, label)?;
-    let canonical = fs::canonicalize(&candidate)
-        .with_context(|| format!("canonicalize {label}"))?;
+    let canonical =
+        fs::canonicalize(&candidate).with_context(|| format!("canonicalize {label}"))?;
     if !canonical.starts_with(&root) {
         bail!("{label} is outside the configured rescue root");
     }
-    let metadata = fs::symlink_metadata(&canonical)
-        .with_context(|| format!("inspect {label}"))?;
+    let metadata = fs::symlink_metadata(&canonical).with_context(|| format!("inspect {label}"))?;
     validate_regular_metadata(&metadata, label)?;
     Ok(canonical)
 }
@@ -172,13 +167,13 @@ pub(crate) fn open_regular(root: &Path, path: &Path, label: &str) -> Result<Veri
     let candidate = candidate_under_root(&root, path, label)?;
     walk_without_links(&root, &candidate, label)?;
 
-    let canonical_before = fs::canonicalize(&candidate)
-        .with_context(|| format!("canonicalize {label}"))?;
+    let canonical_before =
+        fs::canonicalize(&candidate).with_context(|| format!("canonicalize {label}"))?;
     if !canonical_before.starts_with(&root) {
         bail!("{label} is outside the configured rescue root");
     }
-    let path_metadata = fs::symlink_metadata(&candidate)
-        .with_context(|| format!("inspect {label}"))?;
+    let path_metadata =
+        fs::symlink_metadata(&candidate).with_context(|| format!("inspect {label}"))?;
     validate_regular_metadata(&path_metadata, label)?;
     let expected_identity = identity(&path_metadata, label)?;
     let expected_length = path_metadata.len();
@@ -209,8 +204,8 @@ pub(crate) fn open_regular(root: &Path, path: &Path, label: &str) -> Result<Veri
     // A canonical-path recheck catches parent-directory replacement on all
     // platforms.  It cannot make a race atomic with stable std APIs; if the
     // replacement is observed, the operation fails closed.
-    let canonical_after = fs::canonicalize(&candidate)
-        .with_context(|| format!("recheck {label}"))?;
+    let canonical_after =
+        fs::canonicalize(&candidate).with_context(|| format!("recheck {label}"))?;
     if canonical_after != canonical_before || !canonical_after.starts_with(&root) {
         bail!("{label} changed while being opened");
     }
@@ -224,12 +219,7 @@ pub(crate) fn open_regular(root: &Path, path: &Path, label: &str) -> Result<Veri
 }
 
 /// Read a bounded snapshot while keeping the validated handle open.
-pub(crate) fn read_bounded(
-    root: &Path,
-    path: &Path,
-    limit: u64,
-    label: &str,
-) -> Result<Vec<u8>> {
+pub(crate) fn read_bounded(root: &Path, path: &Path, limit: u64, label: &str) -> Result<Vec<u8>> {
     let mut verified = open_regular(root, path, label)?;
     read_bounded_from_opened(&mut verified, limit, label)
 }
@@ -238,13 +228,8 @@ pub(crate) fn read_bounded(
 /// caller.  This is used by the Codex adapter's two-pass stability check; the
 /// final component is still opened with the platform-specific no-follow
 /// policy and handle/path identity checks.
-pub(crate) fn read_bounded_existing(
-    path: &Path,
-    limit: u64,
-    label: &str,
-) -> Result<Vec<u8>> {
-    let path_metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("inspect {label}"))?;
+pub(crate) fn read_bounded_existing(path: &Path, limit: u64, label: &str) -> Result<Vec<u8>> {
+    let path_metadata = fs::symlink_metadata(path).with_context(|| format!("inspect {label}"))?;
     validate_regular_metadata(&path_metadata, label)?;
     let expected_identity = identity(&path_metadata, label)?;
     let expected_length = path_metadata.len();
@@ -266,8 +251,8 @@ pub(crate) fn read_bounded_existing(
         bail!("{label} changed while being opened");
     }
     let canonical = fs::canonicalize(path).with_context(|| format!("canonicalize {label}"))?;
-    let canonical_metadata = fs::symlink_metadata(&canonical)
-        .with_context(|| format!("recheck {label}"))?;
+    let canonical_metadata =
+        fs::symlink_metadata(&canonical).with_context(|| format!("recheck {label}"))?;
     validate_regular_metadata(&canonical_metadata, label)?;
     if identity(&canonical_metadata, label)? != expected_identity
         || canonical_metadata.len() != expected_length
@@ -306,11 +291,7 @@ fn read_bounded_from_opened(
 
 /// Open a SQLite database with `READ_ONLY` and `NO_CREATE` semantics after
 /// the same file/path checks used for JSONL sources.
-pub(crate) fn open_sqlite_read_only(
-    root: &Path,
-    path: &Path,
-    label: &str,
-) -> Result<Connection> {
+pub(crate) fn open_sqlite_read_only(root: &Path, path: &Path, label: &str) -> Result<Connection> {
     let verified = open_regular(root, path, label)?;
     let canonical = verified.path().to_path_buf();
     let connection = Connection::open_with_flags(
@@ -401,6 +382,7 @@ fn validate_not_reparse(metadata: &Metadata, label: &str) -> Result<()> {
 }
 
 fn identity(metadata: &Metadata, label: &str) -> Result<FileIdentity> {
+    let _ = label;
     #[cfg(unix)]
     {
         return Ok(FileIdentity::Unix {

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -148,12 +148,18 @@ pub(crate) fn canonical_root(root: &Path) -> Result<PathBuf> {
 /// consume bytes should use [`open_regular`] instead so the acquired handle
 /// and the path are checked together.
 pub(crate) fn canonical_regular_path(root: &Path, path: &Path, label: &str) -> Result<PathBuf> {
-    let root = canonical_root(root)?;
-    let candidate = candidate_under_root(&root, path, label)?;
-    walk_without_links(&root, &candidate, label)?;
+    let canonical_root = canonical_root(root)?;
+    let lexical_root = lexical_root(root)?;
+    let boundary_root = path
+        .is_absolute()
+        .then_some(&canonical_root)
+        .filter(|candidate_root| path.starts_with(*candidate_root))
+        .unwrap_or(&lexical_root);
+    let candidate = candidate_under_root(boundary_root, path, label)?;
+    walk_without_links(boundary_root, &candidate, label)?;
     let canonical =
         fs::canonicalize(&candidate).with_context(|| format!("canonicalize {label}"))?;
-    if !canonical.starts_with(&root) {
+    if !canonical.starts_with(&canonical_root) {
         bail!("{label} is outside the configured rescue root");
     }
     let metadata = fs::symlink_metadata(&canonical).with_context(|| format!("inspect {label}"))?;
@@ -163,13 +169,19 @@ pub(crate) fn canonical_regular_path(root: &Path, path: &Path, label: &str) -> R
 
 /// Open a regular file read-only after root-bound and no-follow checks.
 pub(crate) fn open_regular(root: &Path, path: &Path, label: &str) -> Result<VerifiedFile> {
-    let root = canonical_root(root)?;
-    let candidate = candidate_under_root(&root, path, label)?;
-    walk_without_links(&root, &candidate, label)?;
+    let canonical_root = canonical_root(root)?;
+    let lexical_root = lexical_root(root)?;
+    let boundary_root = path
+        .is_absolute()
+        .then_some(&canonical_root)
+        .filter(|candidate_root| path.starts_with(*candidate_root))
+        .unwrap_or(&lexical_root);
+    let candidate = candidate_under_root(boundary_root, path, label)?;
+    walk_without_links(boundary_root, &candidate, label)?;
 
     let canonical_before =
         fs::canonicalize(&candidate).with_context(|| format!("canonicalize {label}"))?;
-    if !canonical_before.starts_with(&root) {
+    if !canonical_before.starts_with(&canonical_root) {
         bail!("{label} is outside the configured rescue root");
     }
     let path_metadata =
@@ -206,7 +218,7 @@ pub(crate) fn open_regular(root: &Path, path: &Path, label: &str) -> Result<Veri
     // replacement is observed, the operation fails closed.
     let canonical_after =
         fs::canonicalize(&candidate).with_context(|| format!("recheck {label}"))?;
-    if canonical_after != canonical_before || !canonical_after.starts_with(&root) {
+    if canonical_after != canonical_before || !canonical_after.starts_with(&canonical_root) {
         bail!("{label} changed while being opened");
     }
 
@@ -228,6 +240,7 @@ pub(crate) fn read_bounded(root: &Path, path: &Path, limit: u64, label: &str) ->
 /// caller.  This is used by the Codex adapter's two-pass stability check; the
 /// final component is still opened with the platform-specific no-follow
 /// policy and handle/path identity checks.
+#[allow(dead_code)]
 pub(crate) fn read_bounded_existing(path: &Path, limit: u64, label: &str) -> Result<Vec<u8>> {
     let path_metadata = fs::symlink_metadata(path).with_context(|| format!("inspect {label}"))?;
     validate_regular_metadata(&path_metadata, label)?;
@@ -328,6 +341,15 @@ fn candidate_under_root(root: &Path, path: &Path, label: &str) -> Result<PathBuf
         bail!("{label} is outside the configured rescue root");
     }
     Ok(candidate)
+}
+
+fn lexical_root(root: &Path) -> Result<PathBuf> {
+    if root.is_absolute() {
+        return Ok(root.to_path_buf());
+    }
+    Ok(std::env::current_dir()
+        .context("resolve rescue root")?
+        .join(root))
 }
 
 fn walk_without_links(root: &Path, candidate: &Path, label: &str) -> Result<()> {

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -531,7 +531,9 @@ mod tests {
             .seek(SeekFrom::Start(0))
             .expect("seek source");
         let mut bytes = Vec::new();
-        file.file_mut().read_to_end(&mut bytes).expect("read source");
+        file.file_mut()
+            .read_to_end(&mut bytes)
+            .expect("read source");
         file.ensure_unchanged("session").expect("unchanged");
         assert_eq!(bytes, b"read-only\n");
         assert_eq!(fs::read(&path).expect("source bytes"), b"read-only\n");


### PR DESCRIPTION
## What changed
- centralize root-bound, no-follow, identity-checked rescue file reads
- apply the helper to Codex sessions, index files, and SQLite inventory
- bound SQLite schema and cell values; fail closed on malformed/oversized metadata
- add symlink, hardlink, replacement, escape, bounded-read, and read-only SQLite tests

## Limitation
- Unix verifies device/inode and uses O_NOFOLLOW.
- Windows rejects observable reparse points and reports identity uncertainty as an error; stable std Rust does not expose file-index/link-count APIs.

No release or npm publication.