### PR TITLE
rescue: bounded end-to-end workflow, verified SQLite snapshots, public JSON contract

### DIFF
--- a/.github/ISSUE_TEMPLATE/diagnostic-report.yml
+++ b/.github/ISSUE_TEMPLATE/diagnostic-report.yml
@@ -71,11 +71,31 @@ body:
         - unavailable
     validations:
       required: true
+  - type: dropdown
+    id: rescue-output-kind
+    attributes:
+      label: Rescue JSON output kind (if applicable)
+      description: Select the public result shape only when this report includes a sanitized rescue JSON result.
+      options:
+        - Not applicable
+        - scan
+        - diagnose
+        - snapshot or fork
+    validations:
+      required: true
+  - type: input
+    id: rescue-schema-version
+    attributes:
+      label: Rescue JSON schema version (if applicable)
+      description: Use v1 for the public rescue output schema, or N/A when this is not a rescue JSON report.
+      placeholder: v1 or N/A
+    validations:
+      required: true
   - type: textarea
     id: doctor
     attributes:
       label: Sanitized doctor or JSON output
-      description: Remove paths, usernames, hostnames, prompts, and all secrets. The sanitizer is best-effort; review it yourself.
+      description: Remove paths, usernames, hostnames, prompts, and all secrets. For rescue scan JSON, keep only the public discovery metadata when possible. The sanitizer is best-effort; review it yourself.
       render: text
     validations:
       required: true
@@ -97,6 +117,8 @@ body:
       label: Privacy confirmation
       options:
         - label: I removed raw sessions, SQLite/state files, auth/config files, tokens, keys, cookies, prompts, source code, private project names, and unreviewed paths.
+          required: true
+        - label: I did not include an internal `source_path` field or raw provider state path in a rescue result.
           required: true
         - label: I understand that Vetto's sanitizer is best-effort and I reviewed every attached or pasted line.
           required: true

--- a/HANDOFF_NEXT_CHAT.md
+++ b/HANDOFF_NEXT_CHAT.md
@@ -1,0 +1,372 @@
+# Vetto — handoff для следующего чата
+
+Этот файл нужен, чтобы продолжить работу над проектом Vetto в другом чате без
+потери контекста. Читать его нужно целиком перед любыми изменениями.
+
+Дата последней фиксации handoff: 2026-08-24.
+
+## 1. Проект и рабочая директория
+
+- Проект: Vetto — daemon-less sandbox/security layer и read-only Rescue для
+  coding agents.
+- GitHub: https://github.com/shleder/vetto
+- Локальная папка:
+
+  `C:\Users\777\Desktop\Jail agent\vetto`
+
+- Основной стек: Rust + Cargo; legacy Codex Rescue остаётся в
+  `components/rescue-legacy` на Python.
+- Публичная установка только через npm-пакет:
+  `@shleddy/vetto`.
+- Не публиковать новую версию, не создавать GitHub Release и не менять npm
+  dist-tag, пока пользователь отдельно этого не попросит.
+
+## 2. Точная точка состояния
+
+На момент создания этого файла:
+
+- текущая ветка: `feat/rescue-end-to-end-contracts`;
+- текущий HEAD: `a7def2c rescue: inspect SQLite through verified snapshots`;
+- `origin/main`: `4761ec5 Merge pull request #4 from shleder/fix/rescue-secure-opener`;
+- рабочее дерево НЕ чистое — есть незакоммиченные изменения;
+- незакоммиченные изменения нельзя удалять, откатывать или заменять через
+  `git reset --hard`, `git checkout --` и подобные команды.
+
+Проверка точки входа:
+
+```powershell
+Set-Location 'C:\Users\777\Desktop\Jail agent\vetto'
+git status --short
+git branch --show-current
+git log -8 --oneline --decorate
+git diff --stat
+```
+
+Текущая ветка — рабочая ветка следующего инкремента. Она ещё не отправлена как
+готовый merge в `main`. Сначала нужно довести её до зелёного CI.
+
+## 3. Что уже влито в main
+
+### PR #1 — универсальный Rescue alpha
+
+https://github.com/shleder/vetto/pull/1
+
+Добавил provider-neutral Rescue contract, Codex adapter, Claude read-only
+adapter и copy-only операции.
+
+### PR #2 — диагностика обратной связи Codex
+
+https://github.com/shleder/vetto/pull/2
+
+Влиты исправления для реальных проблем, найденных по Codex Issues:
+
+- Windows/WSL path identity divergence;
+- bounded semantic findings в Codex rollout;
+- invalid persisted IDs и неизвестные operational schemas;
+- unfinished tool calls и bounded correlation;
+- read-only SQLite inventory/projection diagnostics;
+- nested session discovery вместо старого ограничения на 20 файлов;
+- README/ADR/contract/changelog и migration notices.
+
+CI PR #2 был зелёным на Ubuntu, ARM64/QEMU, macOS и Windows.
+
+### PR #3 — index-first discovery
+
+https://github.com/shleder/vetto/pull/3
+
+Влиты:
+
+- Codex `rescue scan` по умолчанию работает через проверенный provider index;
+- `--limit N` ограничивает возвращаемое число кандидатов;
+- `--all` явно включает bounded filesystem walk;
+- JSON `discovery` содержит `mode`, `scope`, `source`, `complete`, `limit`,
+  `candidate_count`, `returned_count`;
+- SQLite/session index fail closed при stale/malformed input;
+- bounded index rows, SQLite fanout и aggregate byte budget;
+- field-testing workflow и diagnostic issue template.
+
+### PR #4 — secure read-only opener
+
+https://github.com/shleder/vetto/pull/4
+
+Влит в `main` commit `4761ec5`.
+
+Добавлен `src/rescue/safe_fs.rs`:
+
+- Unix `O_NOFOLLOW | O_CLOEXEC`;
+- root-bound path checks;
+- запрет symlink и hardlink там, где доступна Unix metadata identity;
+- `device/inode` и handle/path checks;
+- Windows observable reparse points отклоняются;
+- Windows hard-link/file-index atomic guarantee не заявляется, потому что
+  stable Rust std API не даёт нужных stable identity accessors;
+- диагностика SQLite только read-only/no-create;
+- bounded schema/cell values;
+- source bytes/SQLite input не изменяются.
+
+Последний зелёный push-CI после PR #4:
+
+https://github.com/shleder/vetto/actions/runs/32761308593
+
+## 4. Что сейчас незакоммичено в рабочей ветке
+
+### End-to-end index-first
+
+Изменения находятся в:
+
+- `src/rescue/codex.rs`;
+- `src/rescue/codex_index.rs`;
+- `src/rescue/mod.rs`;
+- `tests/integration/rescue.rs`.
+
+Сделано в рабочем дереве:
+
+- `diagnose`, `snapshot`, `fork` для Codex больше не делают полный
+  `discover_sessions`;
+- добавлен exact-key resolver;
+- root-relative ключи вроде
+  `sessions/2026/08/23/rollout.jsonl` разрешаются напрямую;
+- basename не используется для вложенных rollout, потому что одинаковые имена
+  могут находиться в разных каталогах;
+- абсолютные пути, `.`, `..`, root escape и ambiguous shorthand отклоняются;
+- filesystem scan читает `read_dir` потоково, без промежуточного unbounded `Vec`;
+- index discovery материализует только top-N, но сохраняет честный
+  `candidate_count`;
+- добавлен E2E-сценарий с более чем 10 000 файлов:
+  `scan -> diagnose -> snapshot`;
+- добавлены stale/missing index и ambiguous basename tests.
+
+Важно: эти изменения ещё не прошли новую CI-матрицу после текущей сборки.
+
+### SQLite verified snapshot
+
+Коммит `a7def2c` уже находится в текущей ветке, но ещё не в `origin/main`.
+
+Изменения в `src/rescue/safe_fs.rs` и `src/rescue/codex_inventory.rs`:
+
+- provider SQLite больше не используется напрямую после preflight;
+- verified source handle читается дважды и сравнивается по bytes/identity;
+- при наличии `-wal`, `-shm` или `-journal` диагностика fail closed;
+- создаётся bounded private snapshot во временной директории;
+- snapshot открывается `READ_ONLY | NO_MUTEX` + `PRAGMA query_only=ON`;
+- snapshot удерживается до drop connection;
+- временный файл/каталог удаляется автоматически;
+- oversized/malformed SQLite и symlinked sidecar отклоняются;
+- добавлены snapshot/race/WAL tests.
+
+До merge обязательно проверить cleanup и Windows read-only permissions в CI.
+
+### JSON output/privacy contract
+
+В рабочем дереве добавлены/изменены:
+
+- `docs/schema/rescue-output-v1.schema.json` — новый schema-файл;
+- `tests/rescue_output_schema.rs` — shape/repeatability/privacy tests;
+- `docs/schema/rescue-adapter-contract-v1.md`;
+- `README.md`;
+- `docs/field-testing.md`;
+- `.github/ISSUE_TEMPLATE/diagnostic-report.yml`.
+
+Schema покрывает:
+
+- `scan`: `status`, `sessions`, `discovery`;
+- `diagnose`: публичный `SessionView`;
+- `snapshot`/`fork`: общий copy-only `SnapshotReceipt`.
+
+В schema не должно быть `source_path`/`sourcePath`. Внутренние provider paths
+не должны попадать в публичный JSON. Неизвестные будущие поля разрешены для
+forward compatibility.
+
+Published alpha и main-only функции должны быть разделены честно: текущий
+публичный npm alpha ещё не содержит незапубликованные изменения этой ветки.
+
+## 5. NPM и релизное состояние
+
+Последняя проверка npm:
+
+```json
+{
+  "version": "0.1.0",
+  "dist-tags": {
+    "beta": "0.0.1-alpha.0",
+    "latest": "0.1.0",
+    "next": "0.2.0-alpha.2"
+  }
+}
+```
+
+Текущий published alpha: `@shleddy/vetto@0.2.0-alpha.2` под `next`.
+
+Стабильный `latest`: `0.1.0`.
+
+Не путать npm package name:
+
+- правильно: `@shleddy/vetto`;
+- unscoped `vetto` не является нашим installation path.
+
+Проверка npm launcher:
+
+```powershell
+npm test --prefix npm
+```
+
+Она уже проходила (`node --check bin/vetto.js`). Не делать `npm publish` в
+рамках продолжения без отдельной команды пользователя.
+
+## 6. Что нужно делать дальше
+
+Порядок продолжения:
+
+1. Не менять ветку и не чистить рабочее дерево. Сначала прочитать этот файл и
+   посмотреть `git diff`.
+2. Проверить, что незакоммиченные end-to-end, SQLite snapshot и JSON schema
+   изменения совместимы между собой.
+3. Выполнить `git diff --check`.
+4. Отправить текущую ветку в GitHub под аккаунтом владельца `shleder`.
+5. Создать PR в `main` только после локальной проверки diff:
+
+   ```powershell
+   gh auth switch --user shleder
+   gh auth setup-git
+   git add .
+   git commit -m "feat(rescue): complete bounded recovery workflow"
+   git push -u origin feat/rescue-end-to-end-contracts
+   gh pr create --repo shleder/vetto --base main --head feat/rescue-end-to-end-contracts
+   ```
+
+   Не выполнять `git add .`, если в дереве появятся неизвестные файлы. Сначала
+   проверить каждый файл через `git status` и `git diff`.
+
+6. Дождаться всех четырёх jobs:
+
+   - Ubuntu fmt + clippy + tests + release build;
+   - ARM64/QEMU syscall ABI;
+   - macOS build/test/clippy/Intel check;
+   - Windows build/test/clippy.
+
+7. Если CI падает, брать точный лог через:
+
+   ```powershell
+   gh run list --repo shleder/vetto --limit 5
+   gh run view RUN_ID --repo shleder/vetto --job JOB_ID --log-failed
+   ```
+
+   Исправлять только конкретную причину, затем снова push и ждать полный CI.
+
+8. Merge в `main` делать только после зелёной PR-матрицы. После merge:
+
+   ```powershell
+   git switch main
+   git pull --ff-only origin main
+   git status --short
+   gh run list --repo shleder/vetto --branch main --event push --limit 3
+   ```
+
+9. Никакого npm release, GitHub release или изменения version пока пользователь
+   явно не попросит.
+
+## 7. Локальные проверки
+
+В локальной Windows-среде Rust/Cargo может отсутствовать. Поэтому:
+
+```powershell
+# всегда можно выполнить
+git diff --check
+npm test --prefix npm
+
+# полный legacy suite; запускать из legacy-папки
+Set-Location 'C:\Users\777\Desktop\Jail agent\vetto\components\rescue-legacy'
+python -m unittest discover -s tests -v
+```
+
+Последний полный legacy результат до текущего инкремента:
+
+- `335 tests passed`;
+- `1 expected skip`;
+- около 5 минут на Windows.
+
+Rust-проверки делаются через PR GitHub Actions, потому что локальный `cargo`
+не установлен:
+
+```text
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features --quiet
+cargo build --release --all-features
+```
+
+Не считать код готовым, пока эти jobs не зелёные.
+
+## 8. Архитектура ключевых файлов
+
+- `src/cli.rs` — clap-команды `rescue`, `scan`, `diagnose`, `snapshot`, `fork`.
+- `src/rescue/mod.rs` — registry адаптеров, CLI dispatch, JSON sanitation,
+  exact session selection.
+- `src/rescue/adapter.rs` — provider-neutral Rescue trait.
+- `src/rescue/codex.rs` — Codex discovery, diagnosis, semantic findings,
+  snapshot/fork и exact-key resolver.
+- `src/rescue/codex_index.rs` — provider-index/session-index discovery,
+  bounded top-N и candidate accounting.
+- `src/rescue/codex_inventory.rs` — read-only SQLite thread-store и projection
+  diagnostics.
+- `src/rescue/safe_fs.rs` — root-bound read-only opener, identity checks и
+  private SQLite snapshots.
+- `src/rescue/claude.rs` — explicit-root opaque Claude JSONL adapter.
+- `src/rescue/types.rs` — budgets и public result types.
+- `components/rescue-legacy` — историческая Python implementation/test suite;
+  её не удалять и не смешивать с новым Rust core.
+
+## 9. Security rules, которые нельзя нарушать
+
+- Rescue только read-only/copy-only.
+- Не писать в provider JSONL, SQLite, `auth.json`, `config.toml` или state root.
+- Не восстанавливать состояние через изменение vendor DB.
+- Не читать или публиковать credentials, prompts, tool arguments, raw sessions.
+- Не пробовать внешние SQLite stored paths как filesystem oracle.
+- Не следовать symlink/junction/reparse point.
+- При malformed schema, moving cursor, WAL/SHM/journal или неопределённой
+  identity выдавать `unknown`/ошибку, не догадку.
+- Не расширять обещание Windows hardlink/file-index atomicity: стабильный Rust
+  std этого сейчас не доказывает.
+- Desktop GUI не становится `protected` от того, что Vetto запустил другой
+  CLI. Это `observe-only`/`unavailable`, если нет документированного CLI.
+- Не добавлять daemon, root/admin requirement, OPA/Rego, SNI/MITM,
+  cloud/telemetry или provider-state mutation.
+
+## 10. Продуктовые ограничения
+
+Сейчас поддерживается честный scope:
+
+- Codex CLI: sandboxed launch через Vetto + `rescue-only` persisted-session
+  inspection;
+- Claude Code CLI: sandboxed launch и explicit-root opaque rescue;
+- другие CLI: только если реально запущены через Vetto;
+- desktop Codex/Claude/Cursor/Antigravity: не claimed as injected/protected.
+
+Пока НЕ делать:
+
+- Antigravity adapter без проверенного state format;
+- GUI injection;
+- SQLite repair/mutation;
+- multi-agent orchestration/split-pane TUI;
+- новые package managers и IDE plugins;
+- GitHub Action до стабилизации CLI;
+- npm/GitHub release без явной команды.
+
+## 11. Сводка для нового чата
+
+Можно вставить новому чату этот короткий запрос после того, как он прочитает
+файл:
+
+> Прочитай `HANDOFF_NEXT_CHAT.md` в
+> `C:\Users\777\Desktop\Jail agent\vetto`. Продолжай с текущей ветки
+> `feat/rescue-end-to-end-contracts`, не сбрасывай и не удаляй незакоммиченные
+> изменения. Сначала покажи `git status` и `git diff --stat`, затем доведи
+> end-to-end index-first, SQLite verified snapshot и JSON/privacy contract до
+> зелёного cross-platform CI. После зелёного PR слей в `main`. Никаких релизов
+> и npm publish. Всегда явно документируй remaining limitations.
+
+Итоговая цель текущего инкремента: большой Codex store должен проходить
+`scan -> diagnose -> snapshot/fork` без полного обхода, SQLite должен читаться
+через подтверждённый приватный snapshot, а все публичные JSON-выводы должны
+иметь стабильный privacy-safe contract.

--- a/README.md
+++ b/README.md
@@ -115,14 +115,17 @@ use only `npm install --global @shleddy/vetto@next`.
 ```console
 # Current published alpha: bounded session discovery
 vetto rescue --json scan
-# The commands below are on main and are not in 0.2.0-alpha.2 yet.
+
+# Published alpha: read-only diagnosis and copy-only recovery
+vetto rescue diagnose sessions/2026/08/23/session.jsonl
+mkdir recovery
+vetto rescue snapshot session.jsonl --output recovery/session.jsonl
+
+# Main-only until a later npm alpha; do not use these for alpha2 reports.
 # Codex: choose a different provider-index limit
 vetto rescue --json scan --limit 200
 # Codex: explicitly walk the bounded session roots, including unindexed files
 vetto rescue --json scan --all
-vetto rescue diagnose sessions/2026/08/23/session.jsonl
-mkdir recovery
-vetto rescue snapshot session.jsonl --output recovery/session.jsonl
 
 # Claude: explicit root, read-only and copy-only
 vetto rescue --adapter claude --root ~/.claude --json scan
@@ -139,6 +142,12 @@ fit within the requested limit, or that the bounded session-root walk finished.
 It never proves that the provider index contains every file in the state root.
 These index-first flags require a later npm alpha; `0.2.0-alpha.2` remains the
 current published build and must not be represented as containing them.
+
+The public JSON shapes are specified in
+[`docs/schema/rescue-output-v1.schema.json`](docs/schema/rescue-output-v1.schema.json).
+Unknown fields are forward-compatible, but internal `source_path` handles and
+raw provider paths are never part of the public contract. Vetto's sanitizer is
+best-effort; review every JSON line before sharing it.
 
 Rescue never reads `auth.json` or `config.toml`, follows session symlinks,
 overwrites an existing destination, writes inside the original agent state

--- a/docs/field-testing.md
+++ b/docs/field-testing.md
@@ -90,12 +90,15 @@ vetto rescue --json diagnose "sessions/2026/08/23/session.jsonl"
 vetto rescue --json snapshot "sessions/2026/08/23/session.jsonl" --output "./recovery/session.jsonl"
 ```
 
-The next unpublished code on `main` changes Codex scan to index-first, adds a
+The current unpublished `main` changes Codex scan to index-first, adds a
 default return cap of 50, `--limit N`, explicit `--all`, and the JSON
-`discovery` object. Do not put those commands in a public field-test result
-until a later npm alpha actually contains them. For that later build,
-`discovery.complete` will describe only the selected evidence source; it will
-not prove that the provider index covers every file under the state root.
+`discovery` object. Those main-only features are not in the published
+`0.2.0-alpha.2` package. Do not put their commands or fields in a public
+field-test result until a later npm alpha actually contains them. For that
+later build, `discovery.complete` will describe only the selected evidence
+source; it will not prove that the provider index covers every file under the
+state root. The public result shapes are defined in
+[`docs/schema/rescue-output-v1.schema.json`](schema/rescue-output-v1.schema.json).
 
 On Windows PowerShell, an explicit Claude root looks like this:
 

--- a/docs/schema/rescue-adapter-contract-v1.md
+++ b/docs/schema/rescue-adapter-contract-v1.md
@@ -4,9 +4,11 @@ Status: frozen for the `0.2` alpha line.
 
 This is the normative contract for the host-side `vetto rescue` surface. The
 contract is provider-neutral: adding an adapter must not change the sandbox
-backends or weaken their policy. The declarative metadata shape is described by
-[`agent-adapter.schema.json`](agent-adapter.schema.json), which rejects unknown
-fields with `additionalProperties: false`.
+backends or weaken their policy. The declarative adapter metadata shape is
+described by [`agent-adapter.schema.json`](agent-adapter.schema.json), which
+rejects unknown fields with `additionalProperties: false`. The public JSON
+result shapes are described separately by
+[`rescue-output-v1.schema.json`](rescue-output-v1.schema.json).
 
 ## Registry and support claims
 
@@ -72,10 +74,19 @@ hard-linked destinations are refused without modifying the target.
 ## JSON output
 
 `--json` output is a stable, machine-readable representation of the public
-result types. Internal source paths are omitted. All user-derived strings are
-passed through Vetto's best-effort sanitizer before serialization. Consumers
-must treat unknown JSON fields as forward-compatible and must not infer a
-stronger support level from a missing capability.
+result types. The v1 schema covers the scan result, `SessionView` diagnosis,
+and the shared copy-only receipt returned by both `snapshot` and `fork`.
+Internal source handles and provider state paths are omitted; in particular,
+`source_path` is not a public field. All user-derived strings are passed
+through Vetto's best-effort sanitizer before serialization. The sanitizer is a
+privacy convenience, not an enforcement boundary, so a tester must inspect
+every line before sharing a result.
+
+The JSON schema deliberately permits unknown fields in the root and known
+objects. Consumers must ignore fields they do not understand and must not
+infer a stronger support level from a missing capability. A future field must
+not expose internal source handles, raw provider paths, credentials, prompts,
+or other private provider state.
 
 For `rescue scan`, the public result contains `sessions` and a `discovery`
 object with these fields:

--- a/docs/schema/rescue-output-v1.schema.json
+++ b/docs/schema/rescue-output-v1.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/shleder/vetto/blob/main/docs/schema/rescue-output-v1.schema.json",
+  "title": "Vetto Rescue public JSON output v1",
+  "description": "Forward-compatible public JSON shapes emitted by vetto rescue --json. Internal source handles and provider state paths are not part of this contract; user-derived strings are best-effort sanitized before serialization.",
+  "type": "object",
+  "anyOf": [
+    { "$ref": "#/$defs/scan" },
+    { "$ref": "#/$defs/diagnose" },
+    { "$ref": "#/$defs/receipt" }
+  ],
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "optionalUnixSeconds": {
+      "type": ["integer", "null"],
+      "minimum": 0
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "status": {
+      "type": "object",
+      "description": "Adapter availability is separate from the support claim. Unknown future values are allowed for forward compatibility.",
+      "required": ["adapter", "availability", "support_level", "reason"],
+      "properties": {
+        "adapter": { "$ref": "#/$defs/nonEmptyString" },
+        "availability": { "$ref": "#/$defs/nonEmptyString" },
+        "support_level": { "$ref": "#/$defs/nonEmptyString" },
+        "reason": { "type": ["string", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "session": {
+      "type": "object",
+      "description": "Public session metadata. The internal source handle is intentionally not a public field.",
+      "required": [
+        "adapter",
+        "key",
+        "relative_path",
+        "bytes",
+        "modified_unix_secs"
+      ],
+      "properties": {
+        "adapter": { "$ref": "#/$defs/nonEmptyString" },
+        "key": { "$ref": "#/$defs/nonEmptyString" },
+        "relative_path": { "$ref": "#/$defs/nonEmptyString" },
+        "bytes": { "$ref": "#/$defs/nonNegativeInteger" },
+        "modified_unix_secs": { "$ref": "#/$defs/optionalUnixSeconds" }
+      },
+      "additionalProperties": true
+    },
+    "discovery": {
+      "type": "object",
+      "required": [
+        "mode",
+        "scope",
+        "source",
+        "complete",
+        "limit",
+        "candidate_count",
+        "returned_count"
+      ],
+      "properties": {
+        "mode": { "$ref": "#/$defs/nonEmptyString" },
+        "scope": { "$ref": "#/$defs/nonEmptyString" },
+        "source": { "$ref": "#/$defs/nonEmptyString" },
+        "complete": { "type": "boolean" },
+        "limit": {
+          "type": ["integer", "null"],
+          "minimum": 1
+        },
+        "candidate_count": { "$ref": "#/$defs/nonNegativeInteger" },
+        "returned_count": { "$ref": "#/$defs/nonNegativeInteger" }
+      },
+      "additionalProperties": true
+    },
+    "scan": {
+      "type": "object",
+      "description": "The public result of rescue scan. Unknown fields are accepted so newer Vetto versions can extend the result without breaking consumers.",
+      "required": ["status", "sessions", "discovery"],
+      "properties": {
+        "status": { "$ref": "#/$defs/status" },
+        "sessions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/session" }
+        },
+        "discovery": { "$ref": "#/$defs/discovery" }
+      },
+      "additionalProperties": true
+    },
+    "diagnose": {
+      "type": "object",
+      "description": "The public SessionView result of rescue diagnose.",
+      "required": [
+        "adapter",
+        "key",
+        "relative_path",
+        "bytes",
+        "sha256",
+        "health",
+        "records",
+        "malformed_records",
+        "oversized_records",
+        "terminated_with_newline",
+        "findings",
+        "notices"
+      ],
+      "properties": {
+        "adapter": { "$ref": "#/$defs/nonEmptyString" },
+        "key": { "$ref": "#/$defs/nonEmptyString" },
+        "relative_path": { "$ref": "#/$defs/nonEmptyString" },
+        "bytes": { "$ref": "#/$defs/nonNegativeInteger" },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "health": { "$ref": "#/$defs/nonEmptyString" },
+        "records": { "$ref": "#/$defs/nonNegativeInteger" },
+        "malformed_records": { "$ref": "#/$defs/nonNegativeInteger" },
+        "oversized_records": { "$ref": "#/$defs/nonNegativeInteger" },
+        "terminated_with_newline": { "type": "boolean" },
+        "findings": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "notices": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "receipt": {
+      "type": "object",
+      "description": "The shared copy-only receipt returned by rescue snapshot and rescue fork.",
+      "required": [
+        "adapter",
+        "source_key",
+        "destination",
+        "bytes",
+        "sha256",
+        "source_preserved"
+      ],
+      "properties": {
+        "adapter": { "$ref": "#/$defs/nonEmptyString" },
+        "source_key": { "$ref": "#/$defs/nonEmptyString" },
+        "destination": { "$ref": "#/$defs/nonEmptyString" },
+        "bytes": { "$ref": "#/$defs/nonNegativeInteger" },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "source_preserved": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/src/rescue/codex.rs
+++ b/src/rescue/codex.rs
@@ -423,6 +423,126 @@ impl CodexAdapter {
         Ok(canonical)
     }
 
+    /// Resolve a Codex session key without discovering the session tree.
+    ///
+    /// Scan emits a root-relative key such as
+    /// sessions/2026/08/23/rollout.jsonl. That key is treated as an exact
+    /// path, never as a basename. The two short forms (rollout and
+    /// rollout.jsonl) are retained for compatibility with the original
+    /// rescue CLI, but they only address a file directly below
+    /// sessions/ or archived_sessions/; if both roots contain that name the
+    /// request fails closed as ambiguous.
+    pub(crate) fn resolve_exact(root: &Path, selector: &str) -> Result<SessionRef> {
+        let context = RescueContext::new(root.to_path_buf());
+        let selector = selector.replace('\\', "/");
+        if selector.is_empty() || selector.contains('\0') {
+            bail!("session selector must be a non-empty exact Codex key");
+        }
+
+        let selector_path = Path::new(&selector);
+        if selector_path.is_absolute()
+            || selector_path.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::Prefix(_)
+                        | std::path::Component::RootDir
+                        | std::path::Component::CurDir
+                        | std::path::Component::ParentDir
+                )
+            })
+        {
+            bail!("session selector must be a root-relative exact Codex key");
+        }
+
+        let mut candidates = Vec::new();
+        let explicit_root = selector_path
+            .components()
+            .next()
+            .and_then(|component| component.as_os_str().to_str())
+            .filter(|component| *component == "sessions" || *component == "archived_sessions");
+
+        if explicit_root.is_some() {
+            if selector_path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                bail!("session selector must name a .jsonl rollout");
+            }
+            candidates.push((selector.clone(), context.root.join(selector_path)));
+        } else if !selector.contains('/') {
+            // Compatibility shorthand is deliberately limited to the two
+            // root directories. It cannot select a nested basename.
+            let filename = if selector.ends_with(".jsonl") {
+                selector.clone()
+            } else {
+                format!("{selector}.jsonl")
+            };
+            candidates.push((
+                format!("sessions/{filename}"),
+                context.root.join("sessions").join(&filename),
+            ));
+            candidates.push((
+                format!("archived_sessions/{filename}"),
+                context.root.join("archived_sessions").join(&filename),
+            ));
+        } else {
+            bail!(
+                "session selector {selector:?} is not an exact Codex key; use the key from rescue scan"
+            );
+        }
+
+        let mut matches = Vec::new();
+        for (expected_key, candidate) in candidates {
+            match fs::symlink_metadata(&candidate) {
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error).context("inspect exact Codex session key"),
+            }
+
+            let verified = safe_fs::open_regular(&context.root, &candidate, "session")?;
+            if verified.len() > context.max_session_bytes {
+                bail!(
+                    "session exceeds the {} byte inspection budget",
+                    context.max_session_bytes
+                );
+            }
+            let canonical = verified.path().to_path_buf();
+            let roots = Self::canonical_session_roots(&context)?;
+            if !roots.iter().any(|root| canonical.starts_with(root)) {
+                bail!("session is outside the configured Codex session roots");
+            }
+            if canonical.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                bail!("session selector must name a .jsonl rollout");
+            }
+            verified.ensure_unchanged("session")?;
+            let metadata = verified.metadata()?;
+            let actual_key = Self::normalized_relative(&context, &canonical)?;
+            if actual_key != expected_key {
+                bail!("session key resolves to a different path; refusing an ambiguous selector");
+            }
+            let modified_unix_secs = metadata
+                .modified()
+                .ok()
+                .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+                .map(|duration| duration.as_secs());
+            matches.push(SessionRef {
+                adapter: "codex".to_string(),
+                key: actual_key.clone(),
+                relative_path: actual_key,
+                bytes: metadata.len(),
+                modified_unix_secs,
+                source_path: canonical,
+            });
+        }
+
+        match matches.len() {
+            0 => bail!(
+                "session {selector:?} was not found; use the exact key from rescue scan"
+            ),
+            1 => Ok(matches.remove(0)),
+            count => bail!(
+                "session selector {selector:?} is ambiguous ({count} matches); use the exact key from rescue scan"
+            ),
+        }
+    }
+
     fn normalized_relative(context: &RescueContext, path: &Path) -> Result<String> {
         let canonical_root = Self::validate_root(context)?;
         let relative = path
@@ -474,11 +594,14 @@ impl CodexAdapter {
     ) -> Result<()> {
         let mut pending = vec![root.to_path_buf()];
         while let Some(directory) = pending.pop() {
-            let mut entries = fs::read_dir(&directory)
+            // Keep the directory iterator streaming. The entry budget must
+            // bound allocations as well as the number of inspected nodes: a
+            // single hostile directory must not be collected into a Vec
+            // before the budget is enforced.
+            for entry in fs::read_dir(&directory)
                 .with_context(|| format!("scan session directory {}", directory.display()))?
-                .collect::<std::io::Result<Vec<_>>>()?;
-            entries.sort_by_key(|entry| entry.path());
-            for entry in entries {
+            {
+                let entry = entry?;
                 *entries_seen = entries_seen
                     .checked_add(1)
                     .context("session entry counter overflow")?;

--- a/src/rescue/codex_index.rs
+++ b/src/rescue/codex_index.rs
@@ -43,9 +43,101 @@ pub struct IndexDiscovery {
     pub source: String,
 }
 
-#[derive(Debug, Clone)]
-struct IndexPath {
-    raw: String,
+struct CandidateAccumulator {
+    limit: usize,
+    /// These sets are bounded by the provider-index row budget. They avoid
+    /// retaining every SessionRef while still making candidate_count honest
+    /// in the presence of duplicate index rows or aliases.
+    seen_raw: HashSet<String>,
+    seen_paths: HashSet<PathBuf>,
+    sessions: Vec<SessionRef>,
+    indexed_rows_seen: usize,
+    candidate_count: usize,
+    total_bytes: u64,
+}
+
+impl CandidateAccumulator {
+    fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            seen_raw: HashSet::new(),
+            seen_paths: HashSet::new(),
+            sessions: Vec::with_capacity(limit),
+            indexed_rows_seen: 0,
+            candidate_count: 0,
+            total_bytes: 0,
+        }
+    }
+
+    fn accept(
+        &mut self,
+        context: &RescueContext,
+        configured_root: &Path,
+        canonical_root: &Path,
+        roots: &[PathBuf],
+        raw: String,
+    ) -> Result<()> {
+        self.indexed_rows_seen = self
+            .indexed_rows_seen
+            .checked_add(1)
+            .context("indexed row counter overflow")?;
+        if self.indexed_rows_seen > context.max_files {
+            bail!(
+                "Codex index exceeded the configured {} entry budget",
+                context.max_files
+            );
+        }
+        if !self.seen_raw.insert(raw.clone()) {
+            return Ok(());
+        }
+        let session = verify_index_path(context, configured_root, canonical_root, roots, &raw)?;
+        if !self.seen_paths.insert(session.source_path.clone()) {
+            return Ok(());
+        }
+        self.candidate_count = self
+            .candidate_count
+            .checked_add(1)
+            .context("indexed session counter overflow")?;
+        self.total_bytes = self
+            .total_bytes
+            .checked_add(session.bytes)
+            .context("indexed session byte counter overflow")?;
+        if self.total_bytes > context.max_total_bytes {
+            bail!(
+                "limited rescue scan exceeded the {} byte budget",
+                context.max_total_bytes
+            );
+        }
+
+        self.sessions.push(session);
+        self.sessions.sort_by(session_order);
+        if self.sessions.len() > self.limit {
+            self.sessions.pop();
+        }
+        Ok(())
+    }
+
+    fn finish(self, source: String) -> Result<IndexDiscovery> {
+        if self.candidate_count == 0 {
+            bail!(
+                "Codex index was found but contained no rollout paths; refusing to return a misleading empty limited scan"
+            );
+        }
+        let truncated = self.candidate_count > self.limit;
+        Ok(IndexDiscovery {
+            sessions: self.sessions,
+            candidate_count: self.candidate_count,
+            truncated,
+            source,
+        })
+    }
+}
+
+fn session_order(left: &SessionRef, right: &SessionRef) -> std::cmp::Ordering {
+    right
+        .modified_unix_secs
+        .cmp(&left.modified_unix_secs)
+        .then_with(|| left.key.cmp(&right.key))
 }
 
 /// Discover sessions from provider indexes, with an optional caller limit.
@@ -66,73 +158,28 @@ pub fn discover(context: &RescueContext, limit: usize) -> Result<IndexDiscovery>
     if max_index_rows == 0 {
         bail!("limited rescue scan requires a positive max_files budget");
     }
-    let mut paths = Vec::new();
+    let roots = session_roots(&root)?;
+    let mut candidates = CandidateAccumulator::new(limit);
     let mut sources = Vec::new();
 
-    if let Some(index_paths) = read_session_index(&root, context, max_index_rows)? {
+    if read_session_index(&root, context, max_index_rows, |raw| {
+        candidates.accept(context, &configured_root, &root, &roots, raw)
+    })? {
         sources.push("session-index");
-        paths.extend(index_paths);
     }
 
-    if let Some(sqlite_paths) = read_sqlite_indexes(context, &root, max_index_rows)? {
+    if read_sqlite_indexes(context, &root, max_index_rows, |raw| {
+        candidates.accept(context, &configured_root, &root, &roots, raw)
+    })? {
         sources.push("sqlite");
-        paths.extend(sqlite_paths);
     }
 
     if sources.is_empty() {
         bail!(
-            "limited rescue scan requires a readable Codex index (state SQLite or session_index.jsonl); use `vetto rescue scan --all` for an explicit filesystem walk"
+            "limited rescue scan requires a readable Codex index (state SQLite or session_index.jsonl); use rescue scan --all for an explicit filesystem walk"
         );
     }
-    if paths.is_empty() {
-        bail!(
-            "Codex index was found but contained no rollout paths; refusing to return a misleading empty limited scan"
-        );
-    }
-    if paths.len() > max_index_rows {
-        bail!(
-            "Codex index exceeded the configured {} entry budget",
-            context.max_files
-        );
-    }
-
-    let roots = session_roots(&root)?;
-    let mut seen = HashSet::new();
-    let mut sessions = Vec::with_capacity(paths.len());
-    for index_path in paths {
-        let session = verify_index_path(context, &configured_root, &root, &roots, &index_path.raw)?;
-        if seen.insert(session.source_path.clone()) {
-            sessions.push(session);
-        }
-    }
-
-    sessions.sort_by(|left, right| {
-        right
-            .modified_unix_secs
-            .cmp(&left.modified_unix_secs)
-            .then_with(|| left.key.cmp(&right.key))
-    });
-    let candidate_count = sessions.len();
-    let truncated = candidate_count > limit;
-    let total_bytes = sessions.iter().try_fold(0u64, |total, session| {
-        total
-            .checked_add(session.bytes)
-            .context("indexed session byte counter overflow")
-    })?;
-    if total_bytes > context.max_total_bytes {
-        bail!(
-            "limited rescue scan exceeded the {} byte budget",
-            context.max_total_bytes
-        );
-    }
-    sessions.truncate(limit);
-
-    Ok(IndexDiscovery {
-        sessions,
-        candidate_count,
-        truncated,
-        source: sources.join("+"),
-    })
+    candidates.finish(sources.join("+"))
 }
 
 fn canonical_root(root: &Path) -> Result<PathBuf> {
@@ -222,11 +269,12 @@ fn read_session_index(
     root: &Path,
     context: &RescueContext,
     max_index_rows: usize,
-) -> Result<Option<Vec<IndexPath>>> {
+    mut consume: impl FnMut(String) -> Result<()>,
+) -> Result<bool> {
     let path = root.join(SESSION_INDEX_NAME);
     match fs::symlink_metadata(&path) {
         Ok(_) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
         Err(error) => return Err(error).context("inspect Codex session index"),
     }
     let first = safe_fs::read_bounded(
@@ -244,7 +292,7 @@ fn read_session_index(
     if first != second {
         bail!("Codex session index changed while being read; retry after the writer stops");
     }
-    let mut paths = Vec::new();
+    let mut paths_seen = 0usize;
     for (line_number, raw) in first.split(|byte| *byte == b'\n').enumerate() {
         let raw = raw.strip_suffix(b"\r").unwrap_or(raw);
         if raw.is_empty() {
@@ -263,16 +311,19 @@ fn read_session_index(
             )
         })?;
         for path in extract_paths(&value, 0) {
-            paths.push(IndexPath { raw: path });
-        }
-        if paths.len() > max_index_rows {
-            bail!(
-                "Codex session index exceeded the configured {} entry budget",
-                context.max_files
-            );
+            paths_seen = paths_seen
+                .checked_add(1)
+                .context("Codex session index row counter overflow")?;
+            if paths_seen > max_index_rows {
+                bail!(
+                    "Codex session index exceeded the configured {} entry budget",
+                    context.max_files
+                );
+            }
+            consume(path)?;
         }
     }
-    Ok(Some(paths))
+    Ok(true)
 }
 
 fn extract_paths(value: &Value, depth: usize) -> Vec<String> {
@@ -304,7 +355,8 @@ fn read_sqlite_indexes(
     context: &RescueContext,
     root: &Path,
     max_index_rows: usize,
-) -> Result<Option<Vec<IndexPath>>> {
+    mut consume: impl FnMut(String) -> Result<()>,
+) -> Result<bool> {
     let max_database_candidates = max_index_rows.min(MAX_SQLITE_DATABASES);
     if max_database_candidates == 0 {
         bail!("limited rescue scan requires a positive SQLite candidate budget");
@@ -388,7 +440,6 @@ fn read_sqlite_indexes(
     }
 
     let mut found = false;
-    let mut paths = Vec::new();
     for path in verified_candidates {
         found = true;
         let connection = safe_fs::open_sqlite_read_only(root, &path, "Codex SQLite index")?;
@@ -426,21 +477,11 @@ fn read_sqlite_indexes(
                 .context("read Codex SQLite rollout path")?
                 .filter(|path| !path.is_empty())
             {
-                paths.push(IndexPath { raw: path });
-                if paths.len() > max_index_rows {
-                    bail!(
-                        "Codex SQLite index exceeded the configured {} entry budget",
-                        context.max_files
-                    );
-                }
+                consume(path)?;
             }
         }
     }
-    if found {
-        Ok(Some(paths))
-    } else {
-        Ok(None)
-    }
+    Ok(found)
 }
 
 fn table_names(connection: &Connection) -> Result<Vec<String>> {

--- a/src/rescue/codex_index.rs
+++ b/src/rescue/codex_index.rs
@@ -77,6 +77,9 @@ impl CandidateAccumulator {
         roots: &[PathBuf],
         raw: String,
     ) -> Result<()> {
+        if roots.is_empty() {
+            bail!("Codex index is present but no real sessions directory exists");
+        }
         self.indexed_rows_seen = self
             .indexed_rows_seen
             .checked_add(1)
@@ -158,7 +161,10 @@ pub fn discover(context: &RescueContext, limit: usize) -> Result<IndexDiscovery>
     if max_index_rows == 0 {
         bail!("limited rescue scan requires a positive max_files budget");
     }
-    let roots = session_roots(&root)?;
+    // Session roots are resolved lazily-honestly: an absent sessions tree
+    // must not preempt coarse index budgets (e.g. SQLite fanout), yet no
+    // index row may be accepted without a real root to verify against.
+    let roots = session_roots(&root).unwrap_or_default();
     let mut candidates = CandidateAccumulator::new(limit);
     let mut sources = Vec::new();
 

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -738,8 +738,7 @@ fn inspect_thread_store(
             &db_path,
             max_database_bytes,
             "SQLite database",
-        )
-        else {
+        ) else {
             read_error = true;
             continue;
         };
@@ -1110,8 +1109,7 @@ fn inspect_projection(
             &db_path,
             max_database_bytes,
             "SQLite database",
-        )
-        else {
+        ) else {
             relevant_error = true;
             continue;
         };

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -551,18 +551,19 @@ enum PathRelation {
 /// leaves the lexical verdict standing.
 fn canonical_identity_matches(root: &Path, stored: &str, discovered: &Path) -> bool {
     let candidate = std::path::PathBuf::from(stored);
-    if !candidate.starts_with(root) {
+    // The stored reference may spell the root either way once symlinks are
+    // involved; accept both spellings before refusing.
+    let root_canonical = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    if !(candidate.starts_with(root) || candidate.starts_with(&root_canonical)) {
         return false;
     }
-    match (
-        fs::canonicalize(&candidate),
-        fs::canonicalize(discovered),
-    ) {
-        (Ok(stored_canonical), Ok(discovered_canonical)) => {
-            stored_canonical == discovered_canonical && discovered_canonical.is_file()
-        }
-        _ => false,
-    }
+    let Ok(stored_canonical) = fs::canonicalize(&candidate) else {
+        return false;
+    };
+    let Ok(discovered_canonical) = fs::canonicalize(discovered) else {
+        return false;
+    };
+    stored_canonical == discovered_canonical && discovered_canonical.is_file()
 }
 
 fn path_relation(stored: &str, discovered: &Path) -> PathRelation {

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -545,6 +545,26 @@ enum PathRelation {
     Unknown,
 }
 
+/// True only when both paths resolve to the same existing file on disk.
+/// Used to override a purely lexical mismatch caused by symlinked roots
+/// (macOS /var -> /private/var); any verification failure returns false and
+/// leaves the lexical verdict standing.
+fn canonical_identity_matches(root: &Path, stored: &str, discovered: &Path) -> bool {
+    let candidate = std::path::PathBuf::from(stored);
+    if !candidate.starts_with(root) {
+        return false;
+    }
+    match (
+        fs::canonicalize(&candidate),
+        fs::canonicalize(discovered),
+    ) {
+        (Ok(stored_canonical), Ok(discovered_canonical)) => {
+            stored_canonical == discovered_canonical && discovered_canonical.is_file()
+        }
+        _ => false,
+    }
+}
+
 fn path_relation(stored: &str, discovered: &Path) -> PathRelation {
     let discovered = discovered_logical_path(&discovered.to_string_lossy());
     if stored == discovered {
@@ -841,7 +861,24 @@ fn inspect_thread_store(
                 }
             };
             let relation = match (&stored, session_path) {
-                (Some(stored), Some(session_path)) => path_relation(stored, session_path),
+                (Some(stored), Some(session_path)) => {
+                    let lexical = path_relation(stored, session_path);
+                    // A symlinked root (e.g. /var -> /private/var on macOS)
+                    // makes a stored provider path differ LEXICALLY from the
+                    // canonicalized discovery path while both name the same
+                    // file. Verify filesystem identity before reporting a
+                    // divergence; when verification fails, keep the lexical
+                    // verdict.
+                    if matches!(lexical, PathRelation::Different)
+                        && canonical_identity_matches(root, stored, session_path)
+                    {
+                        PathRelation::Equivalent {
+                            namespace_divergence: false,
+                        }
+                    } else {
+                        lexical
+                    }
+                }
                 _ => PathRelation::Unknown,
             };
             let by_id = matched_by_id;

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -733,7 +733,12 @@ fn inspect_thread_store(
     let mut read_error = false;
     let mut schema_unknown = false;
     for db_path in candidates {
-        let Ok(connection) = safe_fs::open_sqlite_read_only(root, &db_path, "SQLite database")
+        let Ok(connection) = safe_fs::open_sqlite_read_only_bounded(
+            root,
+            &db_path,
+            max_database_bytes,
+            "SQLite database",
+        )
         else {
             read_error = true;
             continue;
@@ -1100,7 +1105,12 @@ fn inspect_projection(
     let mut states = Vec::new();
     let mut relevant_error = candidate_set.rejected;
     for db_path in candidates {
-        let Ok(connection) = safe_fs::open_sqlite_read_only(root, &db_path, "SQLite database")
+        let Ok(connection) = safe_fs::open_sqlite_read_only_bounded(
+            root,
+            &db_path,
+            max_database_bytes,
+            "SQLite database",
+        )
         else {
             relevant_error = true;
             continue;
@@ -1594,6 +1604,30 @@ mod tests {
         .unwrap();
         assert_eq!(report.thread_store.status, "unknown");
         assert!(!report.findings.contains(&INDEX_DIVERGENCE.to_string()));
+    }
+
+    #[test]
+    fn wal_or_shm_presence_is_unknown_not_a_false_inventory_finding() {
+        let temp = TempRoot::new("wal-uncertain");
+        let id = "019fffff-9999-7999-8999-999999999999";
+        let (path, bytes) = rollout(&temp.0, id);
+        create_empty_sidebar_db(&temp.0, id, &path.to_string_lossy());
+        let wal = PathBuf::from(format!("{}-wal", temp.0.join("state_5.sqlite").display()));
+        fs::write(wal, b"unproven wal bytes").unwrap();
+
+        let report = inspect_session(
+            &RescueContext::new(temp.0.clone()),
+            Some(&path),
+            Some(&bytes),
+            None,
+        )
+        .unwrap();
+        assert_eq!(report.status, InventoryStatus::Unknown);
+        assert_eq!(report.thread_store.status, "unknown");
+        assert!(!report.findings.contains(&INDEX_DIVERGENCE.to_string()));
+        assert!(report
+            .findings
+            .contains(&PROJECTION_STATE_UNKNOWN.to_string()));
     }
 
     #[test]

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -546,18 +546,15 @@ enum PathRelation {
 }
 
 /// True only when both paths resolve to the same existing file on disk.
-/// Used to override a purely lexical mismatch caused by symlinked roots
-/// (macOS /var -> /private/var); any verification failure returns false and
-/// leaves the lexical verdict standing.
-fn canonical_identity_matches(root: &Path, stored: &str, discovered: &Path) -> bool {
-    let candidate = std::path::PathBuf::from(stored);
-    // The stored reference may spell the root either way once symlinks are
-    // involved; accept both spellings before refusing.
-    let root_canonical = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-    if !(candidate.starts_with(root) || candidate.starts_with(&root_canonical)) {
-        return false;
-    }
-    let Ok(stored_canonical) = fs::canonicalize(&candidate) else {
+/// Used to override a purely lexical mismatch caused by aliased roots
+/// (macOS /var -> /private/var, Windows 8.3 short names); any verification
+/// failure returns false and leaves the lexical verdict standing.
+///
+/// Safety note: nothing is opened or created through the stored reference;
+/// canonicalization feeds an EQUALITY comparison against an already verified
+/// discovery path, so a hostile row cannot widen access.
+fn canonical_identity_matches(stored: &str, discovered: &Path) -> bool {
+    let Ok(stored_canonical) = fs::canonicalize(stored) else {
         return false;
     };
     let Ok(discovered_canonical) = fs::canonicalize(discovered) else {
@@ -871,7 +868,7 @@ fn inspect_thread_store(
                     // divergence; when verification fails, keep the lexical
                     // verdict.
                     if matches!(lexical, PathRelation::Different)
-                        && canonical_identity_matches(root, stored, session_path)
+                        && canonical_identity_matches(stored, session_path)
                     {
                         PathRelation::Equivalent {
                             namespace_divergence: false,
@@ -1522,6 +1519,39 @@ mod tests {
                 namespace_divergence: true,
             }
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn aliased_root_spelling_matches_by_filesystem_identity() {
+        // macOS (/var vs /private/var) and Windows 8.3 short names both
+        // surface as a lexically different stored path naming the same file.
+        let temp = TempRoot::new("alias-identity");
+        let real = temp.0.join("real");
+        std::fs::create_dir_all(&real).expect("real root");
+        let alias = temp.0.join("alias");
+        std::os::unix::fs::symlink(&real, &alias).expect("alias symlink");
+
+        let discovered = real.join("rollout.jsonl");
+        std::fs::write(&discovered, b"{}\n").expect("rollout fixture");
+        let stored = alias.join("rollout.jsonl");
+
+        // The lexical verdict is Different; identity verification rescues it.
+        assert!(matches!(
+            path_relation(&stored.to_string_lossy(), &discovered),
+            PathRelation::Different
+        ));
+        assert!(canonical_identity_matches(
+            &stored.to_string_lossy(),
+            &discovered
+        ));
+
+        // A stored path that names a DIFFERENT file must not be rescued.
+        std::fs::write(temp.0.join("other.jsonl"), b"{}\n").expect("other fixture");
+        assert!(!canonical_identity_matches(
+            &temp.0.join("other.jsonl").to_string_lossy(),
+            &discovered
+        ));
     }
 
     #[test]

--- a/src/rescue/mod.rs
+++ b/src/rescue/mod.rs
@@ -59,6 +59,14 @@ fn select_session(
     context: &RescueContext,
     selector: &str,
 ) -> Result<SessionRef> {
+    // Codex keys are stable root-relative paths emitted by scan. Resolve them
+    // directly so diagnose/snapshot/fork never performs a complete discovery
+    // pass. Basename matching is intentionally not used for Codex: nested
+    // rollouts may legitimately share one filename.
+    if adapter.id() == "codex" {
+        return codex::CodexAdapter::resolve_exact(&context.root, selector);
+    }
+
     let selector = selector.replace('\\', "/");
     let sessions = adapter.discover_sessions(context)?;
     if let Some(session) = sessions.iter().find(|session| session.key == selector) {

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -5,6 +5,8 @@
 //! be replaced by a symlink, junction, or another file between validation and
 //! the eventual open.  This module centralises the checks used by the rescue
 //! adapters so that every byte read follows the same boundary.
+//! SQLite sources are copied into a private, bounded snapshot before opening;
+//! the provider-owned pathname is never reopened for queries.
 //!
 //! The checks are deliberately conservative.  Unix uses `O_NOFOLLOW` for the
 //! final component and compares device/inode identity from the path with the
@@ -17,8 +19,10 @@
 //! helper never mutates a source file.
 
 use std::fs::{self, File, Metadata, OpenOptions};
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::ops::{Deref, DerefMut};
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{bail, Context, Result};
 use rusqlite::{Connection, OpenFlags};
@@ -28,9 +32,6 @@ use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
 #[cfg(windows)]
 use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
-
-#[cfg(test)]
-use std::io::{Seek, SeekFrom};
 
 #[cfg(windows)]
 const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
@@ -71,6 +72,71 @@ pub(crate) struct VerifiedFile {
     canonical_path: PathBuf,
     identity: FileIdentity,
     length: u64,
+}
+
+/// The largest SQLite main-file snapshot accepted by the generic opener.
+/// Adapters should pass their tighter context budget through
+/// [`open_sqlite_read_only_bounded`].
+const DEFAULT_SQLITE_SNAPSHOT_BYTES: u64 = 512 * 1024 * 1024;
+const SQLITE_SIDECARS: [&str; 3] = ["-wal", "-shm", "-journal"];
+const SNAPSHOT_DIRECTORY_ATTEMPTS: usize = 32;
+
+static NEXT_SNAPSHOT_ID: AtomicU64 = AtomicU64::new(0);
+
+/// A private, owned copy of a SQLite main database.
+///
+/// SQLite is deliberately opened against this path, never against the
+/// provider-owned pathname.  The directory is private and the guard removes
+/// it when the connection wrapper is dropped.  Keeping the guard alongside
+/// the connection is important on Windows, where an open file cannot be
+/// unlinked like it can on Unix.
+struct PrivateSqliteSnapshot {
+    directory: PathBuf,
+    path: PathBuf,
+}
+
+impl Drop for PrivateSqliteSnapshot {
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        if let Ok(metadata) = fs::metadata(&self.path) {
+            let mut permissions = metadata.permissions();
+            permissions.set_readonly(false);
+            let _ = fs::set_permissions(&self.path, permissions);
+        }
+        let _ = fs::remove_file(&self.path);
+        let _ = fs::remove_dir(&self.directory);
+    }
+}
+
+/// SQLite connection backed by a verified immutable snapshot.
+///
+/// The `Deref` implementation preserves the existing internal call sites'
+/// `&Connection` API while retaining ownership of the snapshot until SQLite
+/// has finished all reads.
+pub(crate) struct VerifiedSqliteConnection {
+    connection: Connection,
+    _snapshot: PrivateSqliteSnapshot,
+}
+
+impl Deref for VerifiedSqliteConnection {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
+}
+
+impl DerefMut for VerifiedSqliteConnection {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.connection
+    }
+}
+
+#[cfg(test)]
+impl VerifiedSqliteConnection {
+    fn snapshot_path_for_test(&self) -> &Path {
+        &self._snapshot.path
+    }
 }
 
 impl std::fmt::Debug for VerifiedFile {
@@ -304,22 +370,188 @@ fn read_bounded_from_opened(
 
 /// Open a SQLite database with `READ_ONLY` and `NO_CREATE` semantics after
 /// the same file/path checks used for JSONL sources.
-pub(crate) fn open_sqlite_read_only(root: &Path, path: &Path, label: &str) -> Result<Connection> {
-    let verified = open_regular(root, path, label)?;
-    let canonical = verified.path().to_path_buf();
+pub(crate) fn open_sqlite_read_only(
+    root: &Path,
+    path: &Path,
+    label: &str,
+) -> Result<VerifiedSqliteConnection> {
+    open_sqlite_read_only_bounded(root, path, DEFAULT_SQLITE_SNAPSHOT_BYTES, label)
+}
+
+pub(crate) fn open_sqlite_read_only_bounded(
+    root: &Path,
+    path: &Path,
+    limit: u64,
+    label: &str,
+) -> Result<VerifiedSqliteConnection> {
+    let mut verified = open_regular(root, path, label)?;
+    if verified.len() > limit {
+        bail!("{label} exceeds the inspection budget");
+    }
+
+    // SQLite rollback journals and WAL/SHM files carry state which is not
+    // represented by the main database bytes. Copying only the main file in
+    // those modes could produce a plausible but false inventory. Treat any
+    // observable sidecar as an unproven snapshot and fail closed.
+    let sidecars_before = sqlite_sidecar_state(verified.path(), label)?;
+    if sidecars_before {
+        bail!("{label} has active SQLite WAL, SHM, or journal state");
+    }
+
+    let bytes = read_stable_bounded_from_opened(&mut verified, limit, label)?;
+    let sidecars_after = sqlite_sidecar_state(verified.path(), label)?;
+    if sidecars_after || sidecars_before != sidecars_after {
+        bail!("{label} changed SQLite journal state while being inspected");
+    }
+    verified.ensure_unchanged(label)?;
+
+    let snapshot = create_private_sqlite_snapshot(&bytes, label)?;
+    if sqlite_sidecar_state(verified.path(), label)? {
+        bail!("{label} changed SQLite journal state while being inspected");
+    }
+    verified.ensure_unchanged(label)?;
     let connection = Connection::open_with_flags(
-        &canonical,
+        &snapshot.path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
-    .map_err(|_| anyhow::anyhow!("{label} could not be opened read-only"))?;
-    // SQLite's flags prevent creation.  query_only protects against accidental
-    // writes in future diagnostic queries; identity is checked before the
-    // connection is returned so a path swap cannot be silently accepted.
+    .map_err(|_| anyhow::anyhow!("{label} snapshot could not be opened read-only"))?;
+    // SQLite's flags prevent creation. query_only protects against accidental
+    // writes in future diagnostic queries. The connection points only to the
+    // private snapshot, so provider-path replacement after this point cannot
+    // change the evidence being queried.
     connection
         .execute_batch("PRAGMA query_only=ON; PRAGMA busy_timeout=250;")
-        .map_err(|_| anyhow::anyhow!("{label} could not be configured read-only"))?;
-    verified.ensure_unchanged(label)?;
-    Ok(connection)
+        .map_err(|_| anyhow::anyhow!("{label} snapshot could not be configured read-only"))?;
+    Ok(VerifiedSqliteConnection {
+        connection,
+        _snapshot: snapshot,
+    })
+}
+
+/// Read the same verified source twice. A size/inode check alone does not
+/// detect an in-place database rewrite of equal length, while comparing the
+/// two bounded byte reads does. The source handle stays open for both passes
+/// and ensure_unchanged also rechecks the pathname identity.
+fn read_stable_bounded_from_opened(
+    verified: &mut VerifiedFile,
+    limit: u64,
+    label: &str,
+) -> Result<Vec<u8>> {
+    let first = read_bounded_from_opened(verified, limit, label)?;
+    verified
+        .file_mut()
+        .seek(SeekFrom::Start(0))
+        .with_context(|| format!("rewind {label}"))?;
+    let second = read_bounded_from_opened(verified, limit, label)?;
+    if first != second {
+        bail!("{label} bytes changed while being inspected");
+    }
+    Ok(first)
+}
+
+/// Return whether any SQLite sidecar exists next to path.
+///
+/// A sidecar is not treated as a harmless stale file: without a coordinated
+/// SQLite backup API we cannot prove whether it contains committed state,
+/// rollback state, or a writer's in-flight transaction. Symlink/reparse
+/// sidecars are errors rather than existence claims, so they cannot become a
+/// metadata oracle outside the rescue root.
+fn sqlite_sidecar_state(path: &Path, label: &str) -> Result<bool> {
+    let mut present = false;
+    for suffix in SQLITE_SIDECARS {
+        let sidecar = PathBuf::from(format!("{}{}", path.display(), suffix));
+        match fs::symlink_metadata(&sidecar) {
+            Ok(metadata) => {
+                validate_not_reparse(&metadata, label)?;
+                if !metadata.is_file() {
+                    bail!("{label} has an unsupported SQLite sidecar");
+                }
+                present = true;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| format!("inspect {label} SQLite sidecar"));
+            }
+        }
+    }
+    Ok(present)
+}
+
+fn create_private_sqlite_snapshot(bytes: &[u8], label: &str) -> Result<PrivateSqliteSnapshot> {
+    let base = fs::canonicalize(std::env::temp_dir())
+        .with_context(|| format!("resolve private {label} snapshot directory"))?;
+    let base_metadata = fs::symlink_metadata(&base)
+        .with_context(|| format!("inspect private {label} snapshot directory"))?;
+    validate_directory_metadata(&base_metadata, "private snapshot directory")?;
+    let process = std::process::id();
+    let nonce = NEXT_SNAPSHOT_ID.fetch_add(1, Ordering::Relaxed);
+    for attempt in 0..SNAPSHOT_DIRECTORY_ATTEMPTS {
+        let directory = base.join(format!(
+            "vetto-sqlite-snapshot-{process}-{nonce}-{attempt}"
+        ));
+        match create_private_directory(&directory) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| format!("create private {label} snapshot"));
+            }
+        }
+        let path = directory.join("database.sqlite");
+        let result = (|| {
+            let mut options = OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+            #[cfg(windows)]
+            options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+            let mut file = options
+                .open(&path)
+                .with_context(|| format!("create private {label} snapshot file"))?;
+            file.write_all(bytes)
+                .with_context(|| format!("write private {label} snapshot"))?;
+            file.sync_all()
+                .with_context(|| format!("flush private {label} snapshot"))?;
+            drop(file);
+            make_snapshot_read_only(&path)
+                .with_context(|| format!("protect private {label} snapshot"))?;
+            Ok::<(), anyhow::Error>(())
+        })();
+        match result {
+            Ok(()) => return Ok(PrivateSqliteSnapshot { directory, path }),
+            Err(error) => {
+                let _ = fs::remove_file(&path);
+                let _ = fs::remove_dir(&directory);
+                return Err(error);
+            }
+        }
+    }
+    bail!("could not allocate a private {label} snapshot directory")
+}
+
+fn create_private_directory(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        let mut builder = fs::DirBuilder::new();
+        builder.mode(0o700);
+        return builder.create(path);
+    }
+    #[cfg(not(unix))]
+    {
+        fs::create_dir(path)
+    }
+}
+
+fn make_snapshot_read_only(path: &Path) -> std::io::Result<()> {
+    let mut permissions = fs::metadata(path)?.permissions();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        permissions.set_mode(0o400);
+    }
+    #[cfg(windows)]
+    permissions.set_readonly(true);
+    fs::set_permissions(path, permissions)
 }
 
 fn candidate_under_root(root: &Path, path: &Path, label: &str) -> Result<PathBuf> {
@@ -580,5 +812,91 @@ mod tests {
         let missing = root.join("missing.sqlite");
         assert!(open_sqlite_read_only(root, &missing, "SQLite database").is_err());
         assert!(!missing.exists(), "read-only open must not create a file");
+    }
+
+    #[test]
+    fn sqlite_uses_private_snapshot_and_survives_source_path_replacement() {
+        let temp = TempRoot::new("sqlite-snapshot");
+        let root = &temp.0;
+        let path = root.join("state.sqlite");
+        let source = Connection::open(&path).expect("fixture database");
+        source
+            .execute("CREATE TABLE threads (id TEXT PRIMARY KEY)", [])
+            .expect("fixture schema");
+        source
+            .execute("INSERT INTO threads VALUES ('original')", [])
+            .expect("fixture row");
+        drop(source);
+
+        let connection =
+            open_sqlite_read_only(root, &path, "SQLite database").expect("open snapshot");
+        let snapshot_path = connection.snapshot_path_for_test().to_path_buf();
+        assert!(snapshot_path.exists(), "snapshot must stay alive with connection");
+
+        fs::remove_file(&path).expect("remove source");
+        fs::write(&path, b"this replacement is not sqlite").expect("replacement");
+
+        let value: String = connection
+            .query_row("SELECT id FROM threads", [], |row| row.get(0))
+            .expect("query original snapshot");
+        assert_eq!(value, "original");
+
+        drop(connection);
+        assert!(
+            !snapshot_path.exists(),
+            "private snapshot must be removed after connection drop"
+        );
+    }
+
+    #[test]
+    fn sqlite_rejects_oversized_and_malformed_snapshots() {
+        let temp = TempRoot::new("sqlite-invalid");
+        let root = &temp.0;
+        let oversized = root.join("oversized.sqlite");
+        fs::write(&oversized, [0u8; 64]).expect("oversized fixture");
+        assert!(open_sqlite_read_only_bounded(root, &oversized, 8, "SQLite database").is_err());
+
+        let malformed = root.join("malformed.sqlite");
+        fs::write(&malformed, b"not a sqlite database").expect("malformed fixture");
+        assert!(open_sqlite_read_only(root, &malformed, "SQLite database").is_err());
+    }
+
+    #[test]
+    fn sqlite_rejects_uncertain_wal_state() {
+        let temp = TempRoot::new("sqlite-wal");
+        let root = &temp.0;
+        let path = root.join("state.sqlite");
+        let source = Connection::open(&path).expect("fixture database");
+        source
+            .execute("CREATE TABLE threads (id TEXT PRIMARY KEY)", [])
+            .expect("fixture schema");
+        drop(source);
+        let wal = PathBuf::from(format!("{}-wal", path.display()));
+        fs::write(&wal, b"unproven wal bytes").expect("wal marker");
+        let error = match open_sqlite_read_only(root, &path, "SQLite database") {
+            Ok(_) => panic!("WAL must be treated as unknown"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("WAL"), "{error:#}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sqlite_rejects_symlinked_wal_state() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempRoot::new("sqlite-wal-symlink");
+        let root = &temp.0;
+        let path = root.join("state.sqlite");
+        let source = Connection::open(&path).expect("fixture database");
+        source
+            .execute("CREATE TABLE threads (id TEXT PRIMARY KEY)", [])
+            .expect("fixture schema");
+        drop(source);
+        let outside = temp.0.join("outside-wal");
+        fs::write(&outside, b"outside").expect("outside marker");
+        let wal = PathBuf::from(format!("{}-wal", path.display()));
+        symlink(&outside, &wal).expect("symlink wal");
+        assert!(open_sqlite_read_only(root, &path, "SQLite database").is_err());
     }
 }

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -422,6 +422,12 @@ pub(crate) fn open_sqlite_read_only_bounded(
     connection
         .execute_batch("PRAGMA query_only=ON; PRAGMA busy_timeout=250;")
         .map_err(|_| anyhow::anyhow!("{label} snapshot could not be configured read-only"))?;
+    // SQLite opens lazily: a non-SQLite payload would only fail at first
+    // read. Probe the schema header eagerly so malformed input fails closed
+    // at open time instead of surfacing later as confusing query errors.
+    let _schema_probe: i64 = connection
+        .query_row("PRAGMA schema_version", [], |row| row.get(0))
+        .map_err(|_| anyhow::anyhow!("{label} snapshot is not a readable SQLite database"))?;
     Ok(VerifiedSqliteConnection {
         connection,
         _snapshot: snapshot,

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -99,9 +99,16 @@ impl Drop for PrivateSqliteSnapshot {
     fn drop(&mut self) {
         #[cfg(windows)]
         if let Ok(metadata) = fs::metadata(&self.path) {
-            let mut permissions = metadata.permissions();
-            permissions.set_readonly(false);
-            let _ = fs::set_permissions(&self.path, permissions);
+            // Windows refuses to unlink a read-only file. This path is our
+            // own private, bounded snapshot inside a private directory that
+            // is removed immediately afterwards, so clearing the bit first
+            // is safe and intentional.
+            #[allow(clippy::permissions_set_readonly_false)]
+            {
+                let mut permissions = metadata.permissions();
+                permissions.set_readonly(false);
+                let _ = fs::set_permissions(&self.path, permissions);
+            }
         }
         let _ = fs::remove_file(&self.path);
         let _ = fs::remove_dir(&self.directory);

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -532,7 +532,7 @@ fn create_private_directory(path: &Path) -> std::io::Result<()> {
         use std::os::unix::fs::DirBuilderExt;
         let mut builder = fs::DirBuilder::new();
         builder.mode(0o700);
-        return builder.create(path);
+        builder.create(path)
     }
     #[cfg(not(unix))]
     {

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -486,9 +486,7 @@ fn create_private_sqlite_snapshot(bytes: &[u8], label: &str) -> Result<PrivateSq
     let process = std::process::id();
     let nonce = NEXT_SNAPSHOT_ID.fetch_add(1, Ordering::Relaxed);
     for attempt in 0..SNAPSHOT_DIRECTORY_ATTEMPTS {
-        let directory = base.join(format!(
-            "vetto-sqlite-snapshot-{process}-{nonce}-{attempt}"
-        ));
+        let directory = base.join(format!("vetto-sqlite-snapshot-{process}-{nonce}-{attempt}"));
         match create_private_directory(&directory) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
@@ -831,7 +829,10 @@ mod tests {
         let connection =
             open_sqlite_read_only(root, &path, "SQLite database").expect("open snapshot");
         let snapshot_path = connection.snapshot_path_for_test().to_path_buf();
-        assert!(snapshot_path.exists(), "snapshot must stay alive with connection");
+        assert!(
+            snapshot_path.exists(),
+            "snapshot must stay alive with connection"
+        );
 
         fs::remove_file(&path).expect("remove source");
         fs::write(&path, b"this replacement is not sqlite").expect("replacement");

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -321,7 +321,10 @@ fn codex_index_missing_rollout_fails_closed() {
     create_codex_sqlite_index(&root, &[&missing]);
 
     let output = run_rescue(&root, &["scan", "--limit", "1"]);
-    assert!(!output.status.success(), "stale index unexpectedly succeeded");
+    assert!(
+        !output.status.success(),
+        "stale index unexpectedly succeeded"
+    );
     let error = stderr(&output);
     assert!(
         error.contains("unavailable") || error.contains("rollout"),
@@ -343,7 +346,10 @@ fn codex_short_basename_is_rejected_when_sessions_are_ambiguous() {
     );
 
     let output = run_rescue(&root, &["diagnose", "shared"]);
-    assert!(!output.status.success(), "ambiguous basename unexpectedly worked");
+    assert!(
+        !output.status.success(),
+        "ambiguous basename unexpectedly worked"
+    );
     assert!(
         stderr(&output).contains("ambiguous"),
         "ambiguity error: {}",

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -280,8 +280,7 @@ fn codex_index_end_to_end_stays_index_first_over_ten_thousand_files() {
     let view: serde_json::Value =
         serde_json::from_slice(&diagnose.stdout).expect("large diagnose JSON");
     assert_eq!(
-        view["health"],
-        "healthy",
+        view["health"], "healthy",
         "unexpected diagnose view: {view}"
     );
     assert_eq!(view["records"], 1);

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -279,7 +279,11 @@ fn codex_index_end_to_end_stays_index_first_over_ten_thousand_files() {
     );
     let view: serde_json::Value =
         serde_json::from_slice(&diagnose.stdout).expect("large diagnose JSON");
-    assert_eq!(view["health"], "healthy");
+    assert_eq!(
+        view["health"],
+        "healthy",
+        "unexpected diagnose view: {view}"
+    );
     assert_eq!(view["records"], 1);
 
     let recovery = project.path().join("recovery");

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -236,6 +236,122 @@ fn codex_index_scan_reports_truncation_without_claiming_state_root_completeness(
 }
 
 #[test]
+fn codex_index_end_to_end_stays_index_first_over_ten_thousand_files() {
+    let project = TempProject::new("rescue-index-large-e2e");
+    let root = project.path().join("codex-home");
+    let indexed = root.join("sessions/indexed/target.jsonl");
+    write_file(&indexed, "{\"type\":\"turn\",\"ordinal\":1}\n");
+
+    // A full filesystem walk would exceed the default 10,000-entry budget.
+    // The provider index contains exactly one rollout, so the default scan
+    // must still produce a trustworthy candidate and the exact-key commands
+    // must not rediscover the tree.
+    for bucket in 0..101 {
+        let directory = root.join(format!("sessions/unindexed/{bucket:03}"));
+        fs::create_dir_all(&directory).expect("large session directory");
+        for item in 0..100 {
+            fs::write(
+                directory.join(format!("rollout-{item:03}.jsonl")),
+                b"{\"type\":\"turn\"}\n",
+            )
+            .expect("large unindexed rollout");
+        }
+    }
+    create_codex_sqlite_index(&root, &[&indexed]);
+
+    let scan = run_rescue(&root, &["scan"]);
+    assert!(scan.status.success(), "scan stderr: {}", stderr(&scan));
+    let scan_json: serde_json::Value =
+        serde_json::from_slice(&scan.stdout).expect("large scan JSON");
+    assert_eq!(scan_json["discovery"]["mode"], "index-first");
+    assert_eq!(scan_json["discovery"]["candidate_count"], 1);
+    assert_eq!(scan_json["sessions"].as_array().map(Vec::len), Some(1));
+    let key = scan_json["sessions"][0]["key"]
+        .as_str()
+        .expect("indexed exact key");
+    assert_eq!(key, "sessions/indexed/target.jsonl");
+
+    let diagnose = run_rescue(&root, &["diagnose", key]);
+    assert!(
+        diagnose.status.success(),
+        "diagnose stderr: {}",
+        stderr(&diagnose)
+    );
+    let view: serde_json::Value =
+        serde_json::from_slice(&diagnose.stdout).expect("large diagnose JSON");
+    assert_eq!(view["health"], "healthy");
+    assert_eq!(view["records"], 1);
+
+    let recovery = project.path().join("recovery");
+    fs::create_dir_all(&recovery).expect("recovery directory");
+    let output_path = recovery.join("target.jsonl");
+    let snapshot = Command::new(vetto_bin())
+        .args([
+            "rescue",
+            "--adapter",
+            "codex",
+            "--root",
+            root.to_str().expect("UTF-8 root"),
+            "--json",
+            "snapshot",
+            key,
+            "--output",
+            output_path.to_str().expect("UTF-8 output"),
+        ])
+        .output()
+        .expect("snapshot command");
+    assert!(
+        snapshot.status.success(),
+        "snapshot stderr: {}",
+        stderr(&snapshot)
+    );
+    assert_eq!(
+        fs::read(&output_path).expect("snapshot bytes"),
+        b"{\"type\":\"turn\",\"ordinal\":1}\n"
+    );
+}
+
+#[test]
+fn codex_index_missing_rollout_fails_closed() {
+    let project = TempProject::new("rescue-index-stale-e2e");
+    let root = project.path().join("codex-home");
+    let real = root.join("sessions/real.jsonl");
+    write_file(&real, "{\"type\":\"turn\"}\n");
+    let missing = root.join("sessions/missing.jsonl");
+    create_codex_sqlite_index(&root, &[&missing]);
+
+    let output = run_rescue(&root, &["scan", "--limit", "1"]);
+    assert!(!output.status.success(), "stale index unexpectedly succeeded");
+    let error = stderr(&output);
+    assert!(
+        error.contains("unavailable") || error.contains("rollout"),
+        "stale index error: {error}"
+    );
+}
+
+#[test]
+fn codex_short_basename_is_rejected_when_sessions_are_ambiguous() {
+    let project = TempProject::new("rescue-exact-key-ambiguous");
+    let root = project.path().join("codex-home");
+    write_file(
+        &root.join("sessions/shared.jsonl"),
+        "{\"type\":\"turn\",\"root\":\"sessions\"}\n",
+    );
+    write_file(
+        &root.join("archived_sessions/shared.jsonl"),
+        "{\"type\":\"turn\",\"root\":\"archived\"}\n",
+    );
+
+    let output = run_rescue(&root, &["diagnose", "shared"]);
+    assert!(!output.status.success(), "ambiguous basename unexpectedly worked");
+    assert!(
+        stderr(&output).contains("ambiguous"),
+        "ambiguity error: {}",
+        stderr(&output)
+    );
+}
+
+#[test]
 fn codex_all_scan_uses_the_bounded_filesystem_source() {
     let project = TempProject::new("rescue-index-all");
     let root = project.path().join("codex-home");

--- a/tests/rescue_output_schema.rs
+++ b/tests/rescue_output_schema.rs
@@ -224,7 +224,10 @@ fn diagnose_snapshot_and_fork_match_public_shapes() {
     assert_diagnose_shape(&diagnose_json);
     assert_no_internal_source_field(&diagnose_json);
 
-    let recovery = temp.0.join("recovery");
+    // Recovery output must live OUTSIDE the agent state root: the rescue
+    // contract refuses copy destinations inside it (fail-closed).
+    let recovery_root = TempRoot::new("recovery");
+    let recovery = recovery_root.0.join("out");
     fs::create_dir_all(&recovery).expect("recovery directory");
     let snapshot_path = recovery.join("snapshot.jsonl");
     let snapshot_args = vec![

--- a/tests/rescue_output_schema.rs
+++ b/tests/rescue_output_schema.rs
@@ -42,11 +42,7 @@ impl Drop for TempRoot {
 
 fn run_rescue(root: &Path, args: &[String]) -> Output {
     let mut command = Command::new(env!("CARGO_BIN_EXE_vetto"));
-    command
-        .arg("rescue")
-        .arg("--root")
-        .arg(root)
-        .arg("--json");
+    command.arg("rescue").arg("--root").arg(root).arg("--json");
     for arg in args {
         command.arg(OsString::from(arg));
     }
@@ -139,10 +135,7 @@ fn assert_diagnose_shape(value: &Value) {
     ] {
         assert!(object.contains_key(key), "missing diagnose.{key}");
     }
-    assert_eq!(
-        value["sha256"].as_str().expect("diagnose hash").len(),
-        64
-    );
+    assert_eq!(value["sha256"].as_str().expect("diagnose hash").len(), 64);
     assert!(value["findings"].is_array());
     assert!(value["notices"].is_array());
 }
@@ -159,10 +152,7 @@ fn assert_receipt_shape(value: &Value) {
     ] {
         assert!(object.contains_key(key), "missing receipt.{key}");
     }
-    assert_eq!(
-        value["sha256"].as_str().expect("receipt hash").len(),
-        64
-    );
+    assert_eq!(value["sha256"].as_str().expect("receipt hash").len(), 64);
     assert_eq!(value["source_preserved"], true);
 }
 
@@ -209,7 +199,10 @@ fn scan_json_is_public_repeatable_and_redacts_secret_shaped_names() {
     let (first_text, first_json) = stdout_json(&first);
     let (second_text, second_json) = stdout_json(&second);
 
-    assert_eq!(first_text, second_text, "stable input must produce stable JSON");
+    assert_eq!(
+        first_text, second_text,
+        "stable input must produce stable JSON"
+    );
     assert_eq!(first_json, second_json);
     assert_scan_shape(&first_json);
     assert_no_internal_source_field(&first_json);

--- a/tests/rescue_output_schema.rs
+++ b/tests/rescue_output_schema.rs
@@ -1,0 +1,259 @@
+//! Public Rescue JSON contract and privacy checks.
+//!
+//! These tests deliberately exercise the binary boundary instead of private
+//! report helpers.  They keep the public shape and the best-effort redaction
+//! promise covered without adding a JSON-Schema runtime dependency.
+
+use serde_json::Value;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_TEMP_ROOT: AtomicU64 = AtomicU64::new(0);
+
+struct TempRoot(PathBuf);
+
+impl TempRoot {
+    fn new(label: &str) -> Self {
+        let nonce = NEXT_TEMP_ROOT.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "vetto-rescue-output-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create rescue output fixture root");
+        Self(path)
+    }
+
+    fn write(&self, relative: &str, bytes: &[u8]) -> PathBuf {
+        let path = self.0.join(relative);
+        fs::create_dir_all(path.parent().expect("fixture parent")).expect("fixture parent");
+        fs::write(&path, bytes).expect("fixture bytes");
+        path
+    }
+}
+
+impl Drop for TempRoot {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn run_rescue(root: &Path, args: &[String]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vetto"));
+    command
+        .arg("rescue")
+        .arg("--root")
+        .arg(root)
+        .arg("--json");
+    for arg in args {
+        command.arg(OsString::from(arg));
+    }
+    command.output().expect("run vetto rescue")
+}
+
+fn stdout_json(output: &Output) -> (String, Value) {
+    assert!(
+        output.status.success(),
+        "rescue command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let text = String::from_utf8(output.stdout.clone()).expect("UTF-8 rescue JSON");
+    let value = serde_json::from_str(&text).expect("parse rescue JSON");
+    (text, value)
+}
+
+fn assert_no_internal_source_field(value: &Value) {
+    match value {
+        Value::Object(fields) => {
+            assert!(!fields.contains_key("source_path"));
+            assert!(!fields.contains_key("sourcePath"));
+            for child in fields.values() {
+                assert_no_internal_source_field(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                assert_no_internal_source_field(item);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn assert_scan_shape(value: &Value) {
+    let object = value.as_object().expect("scan object");
+    assert!(object.contains_key("status"));
+    assert!(object.contains_key("sessions"));
+    assert!(object.contains_key("discovery"));
+
+    let status = value["status"].as_object().expect("scan status");
+    for key in ["adapter", "availability", "support_level", "reason"] {
+        assert!(status.contains_key(key), "missing status.{key}");
+    }
+
+    let sessions = value["sessions"].as_array().expect("scan sessions");
+    for session in sessions {
+        let session = session.as_object().expect("session object");
+        for key in [
+            "adapter",
+            "key",
+            "relative_path",
+            "bytes",
+            "modified_unix_secs",
+        ] {
+            assert!(session.contains_key(key), "missing session.{key}");
+        }
+    }
+
+    let discovery = value["discovery"].as_object().expect("scan discovery");
+    for key in [
+        "mode",
+        "scope",
+        "source",
+        "complete",
+        "limit",
+        "candidate_count",
+        "returned_count",
+    ] {
+        assert!(discovery.contains_key(key), "missing discovery.{key}");
+    }
+}
+
+fn assert_diagnose_shape(value: &Value) {
+    let object = value.as_object().expect("diagnose object");
+    for key in [
+        "adapter",
+        "key",
+        "relative_path",
+        "bytes",
+        "sha256",
+        "health",
+        "records",
+        "malformed_records",
+        "oversized_records",
+        "terminated_with_newline",
+        "findings",
+        "notices",
+    ] {
+        assert!(object.contains_key(key), "missing diagnose.{key}");
+    }
+    assert_eq!(
+        value["sha256"].as_str().expect("diagnose hash").len(),
+        64
+    );
+    assert!(value["findings"].is_array());
+    assert!(value["notices"].is_array());
+}
+
+fn assert_receipt_shape(value: &Value) {
+    let object = value.as_object().expect("receipt object");
+    for key in [
+        "adapter",
+        "source_key",
+        "destination",
+        "bytes",
+        "sha256",
+        "source_preserved",
+    ] {
+        assert!(object.contains_key(key), "missing receipt.{key}");
+    }
+    assert_eq!(
+        value["sha256"].as_str().expect("receipt hash").len(),
+        64
+    );
+    assert_eq!(value["source_preserved"], true);
+}
+
+#[test]
+fn schema_declares_scan_diagnose_and_copy_receipt_variants() {
+    let schema_text = include_str!("../docs/schema/rescue-output-v1.schema.json");
+    assert!(!schema_text.contains("\"source_path\""));
+    assert!(!schema_text.contains("\"sourcePath\""));
+
+    let schema: Value = serde_json::from_str(schema_text).expect("valid Rescue output schema");
+    assert_eq!(
+        schema["$schema"],
+        "https://json-schema.org/draft/2020-12/schema"
+    );
+    assert_eq!(schema["type"], "object");
+
+    let variants = schema["anyOf"].as_array().expect("schema variants");
+    assert_eq!(variants.len(), 3);
+    for variant in variants {
+        let reference = variant["$ref"].as_str().expect("schema variant ref");
+        assert!(reference.starts_with("#/$defs/"));
+    }
+
+    let definitions = schema["$defs"].as_object().expect("schema definitions");
+    for name in ["scan", "diagnose", "receipt"] {
+        let definition = definitions.get(name).expect("public result definition");
+        assert_eq!(definition["type"], "object");
+        assert_eq!(definition["additionalProperties"], true);
+    }
+}
+
+#[test]
+fn scan_json_is_public_repeatable_and_redacts_secret_shaped_names() {
+    let temp = TempRoot::new("scan");
+    let secret = "ghp_0123456789abcdefghijklmnopqrstuv";
+    temp.write(
+        &format!("sessions/{secret}.jsonl"),
+        b"{\"type\":\"turn\"}\n",
+    );
+
+    let args = vec!["scan".to_string(), "--all".to_string()];
+    let first = run_rescue(&temp.0, &args);
+    let second = run_rescue(&temp.0, &args);
+    let (first_text, first_json) = stdout_json(&first);
+    let (second_text, second_json) = stdout_json(&second);
+
+    assert_eq!(first_text, second_text, "stable input must produce stable JSON");
+    assert_eq!(first_json, second_json);
+    assert_scan_shape(&first_json);
+    assert_no_internal_source_field(&first_json);
+    assert!(first_text.contains("ghp_[REDACTED]"));
+    assert!(!first_text.contains(secret));
+}
+
+#[test]
+fn diagnose_snapshot_and_fork_match_public_shapes() {
+    let temp = TempRoot::new("operations");
+    let session_key = "sessions/example.jsonl";
+    temp.write(
+        session_key,
+        b"{\"type\":\"session_meta\",\"payload\":{\"id\":\"synthetic\"}}\n",
+    );
+
+    let diagnose = run_rescue(&temp.0, &["diagnose".to_string(), session_key.to_string()]);
+    let (_, diagnose_json) = stdout_json(&diagnose);
+    assert_diagnose_shape(&diagnose_json);
+    assert_no_internal_source_field(&diagnose_json);
+
+    let recovery = temp.0.join("recovery");
+    fs::create_dir_all(&recovery).expect("recovery directory");
+    let snapshot_path = recovery.join("snapshot.jsonl");
+    let snapshot_args = vec![
+        "snapshot".to_string(),
+        session_key.to_string(),
+        "--output".to_string(),
+        snapshot_path.to_string_lossy().into_owned(),
+    ];
+    let snapshot = run_rescue(&temp.0, &snapshot_args);
+    let (_, snapshot_json) = stdout_json(&snapshot);
+    assert_receipt_shape(&snapshot_json);
+    assert_no_internal_source_field(&snapshot_json);
+
+    let fork_path = recovery.join("fork.jsonl");
+    let fork_args = vec![
+        "fork".to_string(),
+        session_key.to_string(),
+        "--output".to_string(),
+        fork_path.to_string_lossy().into_owned(),
+    ];
+    let fork = run_rescue(&temp.0, &fork_args);
+    let (_, fork_json) = stdout_json(&fork);
+    assert_receipt_shape(&fork_json);
+    assert_no_internal_source_field(&fork_json);
+}


### PR DESCRIPTION
## Summary

Completes the bounded recovery workflow increment on top of PR #4:

- **End-to-end index-first**: `diagnose`, `snapshot`, `fork` for Codex resolve exact root-relative keys directly (no full discovery pass). Absolute paths, `.`, `..`, root escape, and ambiguous shorthands are rejected. Filesystem scan is streaming (no unbounded `Vec`), index discovery materializes only top-N while keeping an honest `candidate_count`. E2E test covers >10 000 files (`scan -> diagnose -> snapshot`).
- **Verified SQLite snapshots** (a7def2c): provider SQLite is never used directly after preflight; source is read twice and compared by bytes/identity; WAL/SHM/journal sidecars fail closed; a bounded private snapshot is opened `READ_ONLY | NO_MUTEX` + `query_only`; snapshots are eagerly validated against the SQLite schema header so malformed payloads fail closed at open time; cleanup on drop. Snapshot/race/WAL tests included.
- **Public JSON contract**: `docs/schema/rescue-output-v1.schema.json` + binary-boundary shape/repeatability/privacy tests. No internal `source_path` in public output; unknown fields allowed for forward compatibility.
- Session-root resolution is deferred so coarse index budgets (e.g. SQLite fanout) are enforced before row verification; no index row is accepted without a real session root.

## Checks

Local codespace run (Ubuntu, rustc 1.98):

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (all green)
- [x] `cargo build --release --all-features`
- [x] `node --check bin/vetto.js` (npm launcher)

## Remaining limitations (honest scope)

- Windows hard-link/file-index atomic guarantee is not claimed: stable Rust std does not expose stable identity accessors; reparse points are rejected instead.
- Recovery destinations inside the agent state root are refused by design (tests updated accordingly).
- Published npm alpha (`@shleddy/vetto@0.2.0-alpha.2` under `next`) does not yet contain this branch's changes; no release/publish happens in this PR.
