### PR TITLE
fix(rescue): harden against panic, allocation abort, silent flag ignore

### DIFF
--- a/src/rescue/codex.rs
+++ b/src/rescue/codex.rs
@@ -455,7 +455,13 @@ impl CodexAdapter {
     /// request fails closed as ambiguous.
     pub(crate) fn resolve_exact(root: &Path, selector: &str) -> Result<SessionRef> {
         let context = RescueContext::new(root.to_path_buf());
+        // Backslash is a path separator only on Windows; on Unix it is a legal
+        // filename byte and must reach the filesystem untouched, or keys from
+        // `scan` collide with genuinely nested rollouts.
+        #[cfg(windows)]
         let selector = selector.replace('\\', "/");
+        #[cfg(not(windows))]
+        let selector = selector.to_string();
         if selector.is_empty() || selector.contains('\0') {
             bail!("session selector must be a non-empty exact Codex key");
         }
@@ -569,7 +575,10 @@ impl CodexAdapter {
         let relative = path
             .strip_prefix(&canonical_root)
             .with_context(|| format!("session {} is outside rescue root", path.display()))?;
-        Ok(relative.to_string_lossy().replace('\\', "/"))
+        #[cfg(windows)]
+        return Ok(relative.to_string_lossy().replace('\\', "/"));
+        #[cfg(not(windows))]
+        return Ok(relative.to_string_lossy().into_owned());
     }
 
     fn sha256(bytes: &[u8]) -> String {

--- a/src/rescue/codex_index.rs
+++ b/src/rescue/codex_index.rs
@@ -57,12 +57,13 @@ struct CandidateAccumulator {
 }
 
 impl CandidateAccumulator {
-    fn new(limit: usize) -> Self {
+    fn new(limit: usize, capacity_hint: usize) -> Self {
         Self {
             limit,
             seen_raw: HashSet::new(),
             seen_paths: HashSet::new(),
-            sessions: Vec::with_capacity(limit),
+            // The CLI --limit is unbounded; never preallocate from it directly.
+            sessions: Vec::with_capacity(capacity_hint),
             indexed_rows_seen: 0,
             candidate_count: 0,
             total_bytes: 0,
@@ -165,7 +166,7 @@ pub fn discover(context: &RescueContext, limit: usize) -> Result<IndexDiscovery>
     // must not preempt coarse index budgets (e.g. SQLite fanout), yet no
     // index row may be accepted without a real root to verify against.
     let roots = session_roots(&root).unwrap_or_default();
-    let mut candidates = CandidateAccumulator::new(limit);
+    let mut candidates = CandidateAccumulator::new(limit, limit.min(context.max_files));
     let mut sources = Vec::new();
 
     if read_session_index(&root, context, max_index_rows, |raw| {

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -286,7 +286,11 @@ fn session_id_from_path(path: &Path) -> Option<String> {
     if stem.len() < 36 {
         return None;
     }
-    let candidate = &stem[stem.len() - 36..];
+    // A multi-byte character may straddle this byte offset in a hostile or
+    // merely unusual filename; slicing would panic the whole tool mid-incident.
+    let Some(candidate) = stem.get(stem.len() - 36..) else {
+        return None;
+    };
     let valid = candidate.bytes().enumerate().all(|(index, byte)| {
         if matches!(index, 8 | 13 | 18 | 23) {
             byte == b'-'
@@ -1392,6 +1396,20 @@ mod tests {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.0);
         }
+    }
+
+    #[test]
+    fn session_id_from_path_survives_multibyte_stem_at_slice_boundary() {
+        // 39 bytes: the four-byte character straddles stem.len() - 36, so a
+        // byte-offset slice would panic on a non-char boundary. The lookup
+        // must return None instead of crashing mid-incident.
+        let mut name = String::from("x");
+        name.push('\u{1F389}');
+        name.push_str(&"b".repeat(34));
+        assert!(name.len() >= 36);
+        assert!(name.get(name.len() - 36..).is_none());
+        let path = PathBuf::from(format!("/state/sessions/{name}.jsonl"));
+        assert_eq!(session_id_from_path(&path), None);
     }
 
     fn rollout(root: &Path, id: &str) -> (PathBuf, Vec<u8>) {

--- a/src/rescue/codex_inventory.rs
+++ b/src/rescue/codex_inventory.rs
@@ -288,9 +288,7 @@ fn session_id_from_path(path: &Path) -> Option<String> {
     }
     // A multi-byte character may straddle this byte offset in a hostile or
     // merely unusual filename; slicing would panic the whole tool mid-incident.
-    let Some(candidate) = stem.get(stem.len() - 36..) else {
-        return None;
-    };
+    let candidate = stem.get(stem.len() - 36..)?;
     let valid = candidate.bytes().enumerate().all(|(index, byte)| {
         if matches!(index, 8 | 13 | 18 | 23) {
             byte == b'-'

--- a/src/rescue/mod.rs
+++ b/src/rescue/mod.rs
@@ -125,11 +125,8 @@ pub fn run_cli(
             if *limit == Some(0) {
                 bail!("rescue scan --limit must be greater than zero");
             }
-            if *all && limit.is_some() {
-                bail!(
-                    "`rescue scan --limit` has no effect together with `--all`; the bounded filesystem walk applies its own aggregate budgets"
-                );
-            }
+            // clap rejects --all combined with --limit at parse time; nothing
+            // else to enforce here for that pair.
             if limit.is_some() && adapter_id != "codex" {
                 bail!("`rescue scan --limit` is supported only by the Codex index-first adapter");
             }

--- a/src/rescue/mod.rs
+++ b/src/rescue/mod.rs
@@ -125,6 +125,11 @@ pub fn run_cli(
             if *limit == Some(0) {
                 bail!("rescue scan --limit must be greater than zero");
             }
+            if *all && limit.is_some() {
+                bail!(
+                    "`rescue scan --limit` has no effect together with `--all`; the bounded filesystem walk applies its own aggregate budgets"
+                );
+            }
             if limit.is_some() && adapter_id != "codex" {
                 bail!("`rescue scan --limit` is supported only by the Codex index-first adapter");
             }

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -703,7 +703,10 @@ mod tests {
         let candidate =
             candidate_under_root(root, Path::new("sessions/2026/rollout.jsonl"), "session")
                 .expect("relative path under a dotted operator root");
-        assert_eq!(candidate, Path::new("./rel-root/sessions/2026/rollout.jsonl"));
+        assert_eq!(
+            candidate,
+            Path::new("./rel-root/sessions/2026/rollout.jsonl")
+        );
     }
 
     #[test]

--- a/src/rescue/safe_fs.rs
+++ b/src/rescue/safe_fs.rs
@@ -569,17 +569,20 @@ fn candidate_under_root(root: &Path, path: &Path, label: &str) -> Result<PathBuf
     if path.as_os_str().is_empty() {
         bail!("{label} path is empty");
     }
-    let candidate = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        root.join(path)
-    };
-    if candidate
+    // Scope the component check to the derived part of the path. The operator
+    // chooses the rescue root (`CODEX_HOME=./codex-home` is legitimate); the
+    // threat model targets non-canonical provider-derived paths, not the root.
+    if path
         .components()
         .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
     {
         bail!("{label} contains an unsafe path component");
     }
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    };
     if !candidate.starts_with(root) {
         bail!("{label} is outside the configured rescue root");
     }
@@ -691,6 +694,28 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static NEXT_TEMP_ROOT: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn candidate_under_root_accepts_operator_root_with_dot_component() {
+        // CODEX_HOME=./codex-home is a legitimate operator choice; only
+        // provider-derived path parts are hostile.
+        let root = Path::new("./rel-root");
+        let candidate =
+            candidate_under_root(root, Path::new("sessions/2026/rollout.jsonl"), "session")
+                .expect("relative path under a dotted operator root");
+        assert_eq!(candidate, Path::new("./rel-root/sessions/2026/rollout.jsonl"));
+    }
+
+    #[test]
+    fn candidate_under_root_still_rejects_parent_dir_in_derived_paths() {
+        let error = candidate_under_root(
+            Path::new("/state"),
+            Path::new("sessions/../../etc/passwd"),
+            "session",
+        )
+        .expect_err("derived parent-dir escape must fail closed");
+        assert!(error.to_string().contains("unsafe path component"));
+    }
 
     struct TempRoot(PathBuf);
 

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -84,7 +84,7 @@ fn codex_scan_rejects_limit_together_with_all_instead_of_ignoring_it() {
         "--limit together with --all must fail closed instead of being ignored"
     );
     assert!(
-        stderr(&output).contains("cannot be used with '--limit'"),
+        stderr(&output).contains("cannot be used with '--limit"),
         "stderr: {}",
         stderr(&output)
     );

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -84,7 +84,7 @@ fn codex_scan_rejects_limit_together_with_all_instead_of_ignoring_it() {
         "--limit together with --all must fail closed instead of being ignored"
     );
     assert!(
-        stderr(&output).contains("--limit` has no effect together with `--all"),
+        stderr(&output).contains("cannot be used with '--limit'"),
         "stderr: {}",
         stderr(&output)
     );

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -71,6 +71,26 @@ fn unknown_adapter_is_explicitly_unsupported() {
 }
 
 #[test]
+fn codex_scan_rejects_limit_together_with_all_instead_of_ignoring_it() {
+    let project = TempProject::new("rescue-all-limit-conflict");
+    let root = project.path().join("codex-state");
+    write_file(
+        &root.join("sessions/2026/08/23/rollout-1.jsonl"),
+        "{\"type\":\"session_meta\",\"payload\":{\"id\":\"one\"}}\n",
+    );
+    let output = run_rescue(&root, &["scan", "--all", "--limit", "2"]);
+    assert!(
+        !output.status.success(),
+        "--limit together with --all must fail closed instead of being ignored"
+    );
+    assert!(
+        stderr(&output).contains("--limit` has no effect together with `--all"),
+        "stderr: {}",
+        stderr(&output)
+    );
+}
+
+#[test]
 fn claude_adapter_requires_explicit_root_and_keeps_schema_opaque() {
     let project = TempProject::new("rescue-claude");
     let root = project.path().join("claude-state");
@@ -356,6 +376,22 @@ fn codex_short_basename_is_rejected_when_sessions_are_ambiguous() {
     assert!(
         stderr(&output).contains("ambiguous"),
         "ambiguity error: {}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn codex_index_scan_tolerates_an_unbounded_cli_limit_without_aborting() {
+    let project = TempProject::new("rescue-index-unbounded-limit");
+    let root = project.path().join("codex-home");
+    let path = root.join("sessions/2026/08/rollout-00.jsonl");
+    write_file(&path, "{\"type\":\"turn\"}\n");
+    create_codex_sqlite_index(&root, &[path.as_path()]);
+
+    let output = run_rescue(&root, &["scan", "--limit", "1000000000000000"]);
+    assert!(
+        output.status.success(),
+        "an unbounded --limit must not abort on allocation; stderr: {}",
         stderr(&output)
     );
 }


### PR DESCRIPTION
Fixes bughunt findings D1/D2/D5/D7 plus a scan flag conflict. Tests for each. D3/D4/D6 follow as issues.