### PR TITLE
fix(runtime): zero-config compatibility for Claude Code, Codex CLI, and Gemini (0.2.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [main, 'tier-*', 'feat/*']
+    branches: [main, 'tier-*', 'feat/*', 'fix/*']
   pull_request:
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,13 @@
 .mimosa/
 vetto-report-*.{html,md,json,sarif}
 all-assets/
+
+# Local sensitive roadmaps & wiki
+LOCAL-ROADMAP.md
+LOCAL-100.md
+vetto-wiki/
+
+# Secrets & logs
+.env
+*.log
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,17 @@
 All notable changes to this project are documented here. Format follows
 Keep a Changelog; versioning follows SemVer.
 
+## [0.2.10] — 2026-09-02
+
+### Added
+
+- Automatic agent network allowlist defaulting: when `--net` is omitted on the CLI, `RunConfig` automatically defaults to `NetMode::Allowlist` using the detected or specified agent's predefined domain allowlist (`agent_network_allowlist`, e.g. `api.anthropic.com` for Claude, `api.openai.com` and `chatgpt.com` for Codex). Non-agent commands continue to default strictly to `NetMode::Off`.
+- Agent environment pass-through: `[environment]` sections in agent profiles explicitly pass through operational API keys and configurations (`ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `CLAUDE_*` for Claude Code; `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `CODEX_*` for Codex CLI) while maintaining strict default-deny for unrelated host credentials (`AWS_*`, `GH_TOKEN`, etc.).
+- Full agent state & filesystem compatibility: Claude Code and Codex CLI can read and write to their own session, project, and config stores (`~/.claude/`, `~/.claude.json`, `~/.codex/`).
+- Removed legitimate database and config files (`state_*.sqlite`, `config.toml`, `settings.json`) from `[display_only_deny]` to avoid false-positive masking of agent runtime state.
+
 ## [0.2.9] — 2026-08-31
+
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,8 +2123,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vetto"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
+
  "anyhow",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "vetto"
-version = "0.2.9"
+version = "0.2.10"
+
 edition = "2021"
 rust-version = "1.75"
 description = "Daemon-less sandbox + security layer for AI coding agents (Landlock/Seatbelt, TUI statusline, post-session audit reports)"

--- a/README.md
+++ b/README.md
@@ -343,18 +343,24 @@ this ([`profiles/agents/codex.toml`](profiles/agents/codex.toml), verbatim):
 ```toml
 [metadata]
 name = "codex"
-description = "Safe read-only compatibility roots for the Codex CLI."
+description = "Safe compatibility roots for the Codex CLI."
 
 [filesystem]
-allow_read = ["$AGENT/cache", "$AGENT/logs"]
+allow_write = ["$AGENT"]
+allow_read = ["$AGENT"]
+
+[environment]
+pass_through = [
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "CODEX_*",
+]
 
 [display_only_deny]
 paths = [
     "$AGENT/auth.json",
-    "$AGENT/config.toml",
     "$AGENT/app_server.sock",
     "$AGENT/*.sock",
-    "$AGENT/state_*.sqlite",
 ]
 ```
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shledery/vetto",
-  "version": "0.2.9",
+  "version": "0.2.10",
+
   "description": "Cross-platform vetto sandbox and security layer for AI coding agents",
   "license": "Apache-2.0",
   "author": "shledery",

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: vetto contributors
 pkgname=vetto-git
-pkgver=0.2.5.r0.g0000000
+pkgver=0.2.10.r0.g0000000
 pkgrel=1
 pkgdesc='Daemon-less sandbox and audit layer for AI coding agents'
 arch=('x86_64' 'aarch64')

--- a/packaging/chocolatey/vetto.nuspec
+++ b/packaging/chocolatey/vetto.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vetto</id>
-    <version>0.2.5</version>
+    <version>0.2.10</version>
     <title>vetto</title>
     <authors>vetto contributors</authors>
     <projectUrl>https://github.com/shleder/vetto</projectUrl>

--- a/packaging/homebrew/vetto.rb
+++ b/packaging/homebrew/vetto.rb
@@ -1,25 +1,25 @@
 class Vetto < Formula
   desc "Daemon-less OS sandbox and subagent security layer for AI coding agents"
   homepage "https://github.com/shleder/vetto"
-  version "0.2.5"
+  version "0.2.10"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.5/vetto-macos-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.10/vetto-macos-aarch64.tar.gz"
       sha256 "9710e5b94bc2c28e7a644a875189f58f3b01b157e0bc620025de62a4ef8a8b1f"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.5/vetto-macos-x86_64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.10/vetto-macos-x86_64.tar.gz"
       sha256 "6345e1b81ff5cb1faa5e1c1839d39305e83740b2a2b27e10caf65cc134bf4b41"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.5/vetto-linux-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.10/vetto-linux-aarch64.tar.gz"
       sha256 "f7c9fcde23c0fd6983ef2dde511b88053b0c03e817e66bf5c886f0f0e3f3bc63"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.5/vetto-linux-x86_64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.10/vetto-linux-x86_64.tar.gz"
       sha256 "deaca44700919a84a93f306c1220f2f338bab515bd2da9473df5823b7bab0369"
     end
   end

--- a/packaging/rpm/vetto.spec
+++ b/packaging/rpm/vetto.spec
@@ -1,5 +1,5 @@
 Name:           vetto
-Version:        0.2.5
+Version:        0.2.10
 Release:        1%{?dist}
 Summary:        Daemon-less sandbox and audit layer for AI coding agents
 License:        Apache-2.0
@@ -34,6 +34,13 @@ cp -a profiles/. %{buildroot}%{_datadir}/vetto/profiles/
 %{_datadir}/vetto/profiles
 
 %changelog
+* Wed Sep 02 2026 vetto contributors - 0.2.10-1
+- Sync the source-only recipe with the published 0.2.10 release.
+
+* Mon Aug 31 2026 vetto contributors - 0.2.9-1
+- Sync the source-only recipe with the published 0.2.9 release.
+
+
 * Fri Aug 28 2026 vetto contributors - 0.2.5-1
 - Sync the source-only recipe with the published 0.2.5 release.
 

--- a/profiles/agents/claude.toml
+++ b/profiles/agents/claude.toml
@@ -1,14 +1,22 @@
 [metadata]
 name = "claude"
-description = "Safe read-only compatibility roots for Claude Code."
+description = "Safe compatibility roots for Claude Code."
 
 [filesystem]
-allow_read = ["$AGENT/cache", "$AGENT/logs"]
+allow_write = ["$AGENT"]
+allow_read = ["$HOME/.claude.json", "$AGENT"]
+
+[environment]
+pass_through = [
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "CLAUDE_*",
+]
 
 [display_only_deny]
 paths = [
     "$AGENT/.credentials.json",
-    "$AGENT/settings.json",
     "$AGENT/*.sock",
     "$AGENT/*.ipc",
 ]
+

--- a/profiles/agents/cline.toml
+++ b/profiles/agents/cline.toml
@@ -6,4 +6,5 @@ description = "Safe read-only compatibility roots for Cline."
 allow_read = ["$AGENT/cache", "$AGENT/logs"]
 
 [display_only_deny]
-paths = ["$AGENT/secrets.json", "$AGENT/settings.json"]
+paths = ["$AGENT/secrets.json"]
+

--- a/profiles/agents/cursor.toml
+++ b/profiles/agents/cursor.toml
@@ -8,7 +8,7 @@ allow_read = ["$AGENT/cache", "$AGENT/logs"]
 [display_only_deny]
 paths = [
     "$AGENT/User/globalStorage",
-    "$AGENT/User/settings.json",
     "$AGENT/*.sock",
     "$AGENT/*.ipc",
 ]
+

--- a/profiles/agents/gemini.toml
+++ b/profiles/agents/gemini.toml
@@ -1,6 +1,6 @@
 [metadata]
-name = "codex"
-description = "Safe compatibility roots for the Codex CLI."
+name = "gemini"
+description = "Safe compatibility roots for Gemini CLI."
 
 [filesystem]
 allow_write = ["$AGENT"]
@@ -8,15 +8,15 @@ allow_read = ["$AGENT"]
 
 [environment]
 pass_through = [
-    "OPENAI_API_KEY",
-    "OPENAI_BASE_URL",
-    "CODEX_*",
+    "GEMINI_API_KEY",
+    "GEMINI_BASE_URL",
+    "GEMINI_*",
+    "GOOGLE_API_KEY",
 ]
 
 [display_only_deny]
 paths = [
     "$AGENT/auth.json",
-    "$AGENT/app_server.sock",
     "$AGENT/*.sock",
+    "$AGENT/*.ipc",
 ]
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use anyhow::{bail, Result};
 use serde::Deserialize;
 
 use crate::cli::Cli;
-use crate::policy::presets::Preset;
+use crate::policy::presets::{agent_network_allowlist, Preset};
 
 #[derive(Debug, Clone)]
 pub enum NetMode {
@@ -182,12 +182,40 @@ impl RunConfig {
     }
 
     pub fn from_cli_with_global(cli: &Cli, global: &GlobalConfig) -> Result<Self> {
-        let raw_net = cli
-            .net
-            .as_deref()
-            .or(global.net.as_deref())
-            .unwrap_or("off");
-        let net = parse_net_mode(raw_net)?;
+        let agent_preset = if cli.multi {
+            None
+        } else {
+            match cli.agents.as_slice() {
+                [] => detect_agent_preset(&cli.agent),
+                [agent] if !agent.contains('=') && !agent.trim().is_empty() => {
+                    Some(
+                        crate::policy::defaults::canonical_agent_name(agent)
+                            .map(|s| s.to_string())
+                            .unwrap_or_else(|| agent.clone()),
+                    )
+                }
+                [_] => bail!(
+                    "single-agent --agent expects a preset name; NAME=PROGRAM is only valid with --multi"
+                ),
+                _ => bail!("single-agent mode accepts at most one --agent preset"),
+            }
+        };
+
+        let net = match cli.net.as_deref().or(global.net.as_deref()) {
+            Some(raw) => parse_net_mode(raw)?,
+            None => {
+                if let Some(ref agent) = agent_preset {
+                    let domains = agent_network_allowlist(agent);
+                    if !domains.is_empty() {
+                        NetMode::Allowlist(domains)
+                    } else {
+                        NetMode::Off
+                    }
+                } else {
+                    NetMode::Off
+                }
+            }
+        };
 
         let git_ssh = cli.git_ssh || global.git_ssh.unwrap_or(false);
         if git_ssh && !net.uses_relay() {
@@ -273,21 +301,6 @@ impl RunConfig {
             .as_ref()
             .map(PathBuf::from)
             .or_else(|| global.jsonl.as_ref().map(PathBuf::from));
-
-        let agent_preset = if cli.multi {
-            None
-        } else {
-            match cli.agents.as_slice() {
-                [] => detect_agent_preset(&cli.agent),
-                [agent] if !agent.contains('=') && !agent.trim().is_empty() => {
-                    Some(agent.clone())
-                }
-                [_] => bail!(
-                    "single-agent --agent expects a preset name; NAME=PROGRAM is only valid with --multi"
-                ),
-                _ => bail!("single-agent mode accepts at most one --agent preset"),
-            }
-        };
 
         let mut auto_timeout_requested = false;
         let session_timeout = match timeout_str {
@@ -484,17 +497,7 @@ pub fn detect_agent_preset(command: &[String]) -> Option<String> {
     let normalized = first.replace('\\', "/");
     let path = std::path::Path::new(&normalized);
     let stem = path.file_stem()?.to_str()?.to_ascii_lowercase();
-
-    match stem.as_str() {
-        "codex" | "codex-cli" => Some("codex".to_string()),
-        "claude" | "claude-code" => Some("claude".to_string()),
-        "cursor" | "cursor-server" => Some("cursor".to_string()),
-        "aider" | "aider-chat" => Some("aider".to_string()),
-        "cline" => Some("cline".to_string()),
-        "copilot" | "github-copilot-cli" => Some("copilot".to_string()),
-        "opencode" => Some("opencode".to_string()),
-        _ => None,
-    }
+    crate::policy::defaults::canonical_agent_name(&stem).map(|s| s.to_string())
 }
 
 #[cfg(test)]
@@ -676,5 +679,90 @@ mod tests {
         assert_eq!(cfg2.preset, Some(Preset::Yolo));
         assert_eq!(cfg2.net.label(), "off");
         assert_eq!(cfg2.fail_on_block, Some(1));
+    }
+
+    #[test]
+    fn agent_preset_defaults_network_to_allowlist_when_net_omitted() {
+        // Claude defaults to api.anthropic.com
+        let cli = Cli::try_parse_from(["vetto", "--", "claude", "-p", "hello"]).unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("claude"));
+        assert_eq!(cfg.net.label(), "allowlist:api.anthropic.com");
+
+        // Claude-code alias defaults to api.anthropic.com
+        let cli = Cli::try_parse_from(["vetto", "--", "claude-code"]).unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("claude"));
+        assert_eq!(cfg.net.label(), "allowlist:api.anthropic.com");
+
+        // Codex defaults to api.openai.com,chatgpt.com
+        let cli = Cli::try_parse_from(["vetto", "--", "codex", "exec"]).unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("codex"));
+        assert_eq!(cfg.net.label(), "allowlist:api.openai.com,chatgpt.com");
+
+        // Codex-cli alias defaults to api.openai.com,chatgpt.com
+        let cli = Cli::try_parse_from(["vetto", "--", "codex-cli"]).unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("codex"));
+        assert_eq!(cfg.net.label(), "allowlist:api.openai.com,chatgpt.com");
+
+        // Gemini defaults to generativelanguage.googleapis.com
+        let cli = Cli::try_parse_from(["vetto", "--", "gemini"]).unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("gemini"));
+        assert_eq!(
+            cfg.net.label(),
+            "allowlist:generativelanguage.googleapis.com"
+        );
+
+        // Aider defaults to api.openai.com,api.anthropic.com
+        let cli = Cli::try_parse_from(["vetto", "--", "aider"]).unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("aider"));
+        assert_eq!(
+            cfg.net.label(),
+            "allowlist:api.openai.com,api.anthropic.com"
+        );
+
+        // Cursor defaults to api.cursor.com,api2.cursor.sh
+        let cli = Cli::try_parse_from(["vetto", "--", "cursor-server"]).unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("cursor"));
+        assert_eq!(cfg.net.label(), "allowlist:api.cursor.com,api2.cursor.sh");
+
+        // Explicit --agent flag with alias also defaults to agent allowlist
+        let cli = Cli::try_parse_from([
+            "vetto",
+            "--agent",
+            "claude-code",
+            "--",
+            "python",
+            "agent.py",
+        ])
+        .unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("claude"));
+        assert_eq!(cfg.net.label(), "allowlist:api.anthropic.com");
+
+        // Non-agent commands default to NetMode::Off
+        let cli = Cli::try_parse_from(["vetto", "--", "python", "script.py"]).unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset, None);
+        assert_eq!(cfg.net.label(), "off");
+
+        // Explicit --net off overrides agent default
+        let cli = Cli::try_parse_from(["vetto", "--net", "off", "--", "claude"]).unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("claude"));
+        assert_eq!(cfg.net.label(), "off");
+
+        // Explicit --net allowlist overrides agent default
+        let cli =
+            Cli::try_parse_from(["vetto", "--net", "allowlist:custom.api.com", "--", "codex"])
+                .unwrap();
+        let cfg = RunConfig::from_cli(&cli).unwrap();
+        assert_eq!(cfg.agent_preset.as_deref(), Some("codex"));
+        assert_eq!(cfg.net.label(), "allowlist:custom.api.com");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,9 +121,21 @@ fn run() -> Result<()> {
                 let mut full_cmd = vec![cmd.clone()];
                 full_cmd.extend(run_args.clone());
                 cfg.agent = full_cmd;
+                if cfg.agent_preset.is_none() {
+                    cfg.agent_preset = vetto::config::detect_agent_preset(&cfg.agent);
+                }
+                if matches!(cfg.net, NetMode::Off) && args.net.is_none() {
+                    if let Some(ref agent) = cfg.agent_preset {
+                        let domains = policy::presets::agent_network_allowlist(agent);
+                        if !domains.is_empty() {
+                            cfg.net = NetMode::Allowlist(domains);
+                        }
+                    }
+                }
             }
             supervise(cfg)
         }
+
         Some(cli::Command::Doctor {
             probe,
             check_agent,

--- a/src/policy/defaults.rs
+++ b/src/policy/defaults.rs
@@ -9,6 +9,7 @@ pub const PROFILE_NAMES: [&str; 4] = ["default", "strict", "audit", "permissive"
 
 pub const CODEX_AGENT_TOML: &str = include_str!("../../profiles/agents/codex.toml");
 pub const CLAUDE_AGENT_TOML: &str = include_str!("../../profiles/agents/claude.toml");
+pub const GEMINI_AGENT_TOML: &str = include_str!("../../profiles/agents/gemini.toml");
 pub const AIDER_AGENT_TOML: &str = include_str!("../../profiles/agents/aider.toml");
 pub const CURSOR_AGENT_TOML: &str = include_str!("../../profiles/agents/cursor.toml");
 pub const CLINE_AGENT_TOML: &str = include_str!("../../profiles/agents/cline.toml");
@@ -16,8 +17,8 @@ pub const OPENCODE_AGENT_TOML: &str = include_str!("../../profiles/agents/openco
 pub const COPILOT_AGENT_TOML: &str = include_str!("../../profiles/agents/copilot.toml");
 pub const CUSTOM_AGENT_TOML: &str = include_str!("../../profiles/agents/custom.toml");
 
-pub const AGENT_PROFILE_NAMES: [&str; 8] = [
-    "codex", "claude", "aider", "cursor", "cline", "opencode", "copilot", "custom",
+pub const AGENT_PROFILE_NAMES: [&str; 9] = [
+    "codex", "claude", "gemini", "aider", "cursor", "cline", "opencode", "copilot", "custom",
 ];
 
 /// Environment variables that are safe and useful for an agent session.
@@ -79,10 +80,26 @@ pub fn builtin(name: &str) -> Option<&'static str> {
     }
 }
 
+pub fn canonical_agent_name(name: &str) -> Option<&'static str> {
+    match name.trim().to_ascii_lowercase().as_str() {
+        "codex" | "codex-cli" => Some("codex"),
+        "claude" | "claude-code" => Some("claude"),
+        "aider" | "aider-chat" => Some("aider"),
+        "cursor" | "cursor-server" => Some("cursor"),
+        "cline" => Some("cline"),
+        "opencode" => Some("opencode"),
+        "copilot" | "github-copilot-cli" => Some("copilot"),
+        "gemini" | "gemini-cli" => Some("gemini"),
+        "custom" => Some("custom"),
+        _ => None,
+    }
+}
+
 pub fn agent_builtin(name: &str) -> Option<&'static str> {
-    match name {
+    match canonical_agent_name(name)? {
         "codex" => Some(CODEX_AGENT_TOML),
         "claude" => Some(CLAUDE_AGENT_TOML),
+        "gemini" => Some(GEMINI_AGENT_TOML),
         "aider" => Some(AIDER_AGENT_TOML),
         "cursor" => Some(CURSOR_AGENT_TOML),
         "cline" => Some(CLINE_AGENT_TOML),

--- a/src/policy/loader.rs
+++ b/src/policy/loader.rs
@@ -1056,7 +1056,11 @@ impl LayeredPolicyLoader {
         // Tier 4: Agent Preset
         // -------------------------------------------------------------------
         let agent_path = match options.agent.as_deref() {
-            Some(agent) => Some(agent_root(home, agent)?),
+            Some(agent) => {
+                let p = agent_root(home, agent)?;
+                let _ = std::fs::create_dir_all(&p);
+                Some(p)
+            }
             None => None,
         };
         if let Some(agent) = options.agent.as_deref() {
@@ -1508,6 +1512,11 @@ fn build_policy(
 
     for entry in &all_deny_entries {
         for path in resolve_list(std::slice::from_ref(entry), &vars, agent)? {
+            if let Some(agent_dir) = agent {
+                if &path == agent_dir {
+                    continue;
+                }
+            }
             if deny_set.insert(path.clone()) {
                 if let Ok(meta) = std::fs::symlink_metadata(&path) {
                     deny_resolved.push(DenyEntry {
@@ -1687,9 +1696,11 @@ fn resolve_list(entries: &[String], vars: &Vars, agent: Option<&Path>) -> Result
 }
 
 fn agent_root(home: &Path, agent: &str) -> Result<PathBuf> {
-    let suffix = match agent {
+    let canon = defaults::canonical_agent_name(agent).unwrap_or(agent);
+    let suffix = match canon {
         "codex" => PathBuf::from(".codex"),
         "claude" => PathBuf::from(".claude"),
+        "gemini" => PathBuf::from(".gemini"),
         "aider" => PathBuf::from(".aider"),
         "cursor" => PathBuf::from(".cursor"),
         "cline" => PathBuf::from(".cline"),
@@ -2203,6 +2214,151 @@ allow_read = ["/usr", "${PROJECT}"]
             &options,
         );
         assert!(loaded.is_ok(), "signed policy must load successfully");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn claude_agent_preset_policy_loading() {
+        let root = std::env::temp_dir().join(format!("vetto-claude-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        // Create secrets and claude.json
+        let ssh_dir = root.join(".ssh");
+        let env_file = root.join(".env");
+        let codex_dir = root.join(".codex");
+        let claude_json = root.join(".claude.json");
+        std::fs::create_dir_all(&ssh_dir).unwrap();
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::write(&env_file, "SECRET=1").unwrap();
+        std::fs::write(&claude_json, "{}").unwrap();
+
+        let claude_dir = root.join(".claude");
+        // Do NOT manually create claude_dir — loader must auto-create it
+
+        let options = PolicyLoadOptions {
+            agent: Some("claude-code".to_string()),
+            ..Default::default()
+        };
+
+        let pol = load_with_options("default", None, &root, &root, Tier::Full, &options)
+            .expect("claude preset must load");
+
+        // Environment pass_through
+        use std::ffi::OsStr;
+        assert!(pol.environment.allows(OsStr::new("ANTHROPIC_API_KEY")));
+        assert!(pol.environment.allows(OsStr::new("ANTHROPIC_BASE_URL")));
+        assert!(pol.environment.allows(OsStr::new("CLAUDE_TEST_FLAG")));
+        assert!(pol.environment.allows(OsStr::new("PATH")));
+        assert!(!pol.environment.allows(OsStr::new("AWS_SECRET_ACCESS_KEY")));
+        assert!(!pol.environment.allows(OsStr::new("GH_TOKEN")));
+
+        // Filesystem permissions
+        assert!(pol.allow_write.contains(&claude_dir));
+        assert!(pol.allow_read.contains(&claude_json));
+
+        // Secrets must be in deny_resolved, but claude_dir must NOT be in deny_resolved
+        let deny_paths: Vec<_> = pol.deny_resolved.iter().map(|d| &d.path).collect();
+        assert!(deny_paths.contains(&&ssh_dir));
+        assert!(deny_paths.contains(&&env_file));
+        assert!(deny_paths.contains(&&codex_dir));
+        assert!(!deny_paths.contains(&&claude_dir));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn codex_agent_preset_policy_loading() {
+        let root = std::env::temp_dir().join(format!("vetto-codex-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        // Create secrets and claude_dir
+        let ssh_dir = root.join(".ssh");
+        let env_file = root.join(".env");
+        let claude_dir = root.join(".claude");
+        std::fs::create_dir_all(&ssh_dir).unwrap();
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(&env_file, "SECRET=1").unwrap();
+
+        let codex_dir = root.join(".codex");
+        // Do NOT manually create codex_dir — loader must auto-create it
+
+        let options = PolicyLoadOptions {
+            agent: Some("codex-cli".to_string()),
+            ..Default::default()
+        };
+
+        let pol = load_with_options("default", None, &root, &root, Tier::Full, &options)
+            .expect("codex preset must load");
+
+        // Environment pass_through
+        use std::ffi::OsStr;
+        assert!(pol.environment.allows(OsStr::new("OPENAI_API_KEY")));
+        assert!(pol.environment.allows(OsStr::new("OPENAI_BASE_URL")));
+        assert!(pol.environment.allows(OsStr::new("CODEX_TEST_FLAG")));
+        assert!(pol.environment.allows(OsStr::new("PATH")));
+        assert!(!pol.environment.allows(OsStr::new("AWS_SECRET_ACCESS_KEY")));
+        assert!(!pol.environment.allows(OsStr::new("GH_TOKEN")));
+
+        // Filesystem permissions
+        assert!(pol.allow_write.contains(&codex_dir));
+
+        // Secrets must be in deny_resolved, but codex_dir must NOT be in deny_resolved
+        let deny_paths: Vec<_> = pol.deny_resolved.iter().map(|d| &d.path).collect();
+        assert!(deny_paths.contains(&&ssh_dir));
+        assert!(deny_paths.contains(&&env_file));
+        assert!(deny_paths.contains(&&claude_dir));
+        assert!(!deny_paths.contains(&&codex_dir));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn gemini_agent_preset_policy_loading() {
+        let root = std::env::temp_dir().join(format!("vetto-gemini-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        // Create secrets and claude_dir
+        let ssh_dir = root.join(".ssh");
+        let env_file = root.join(".env");
+        let claude_dir = root.join(".claude");
+        std::fs::create_dir_all(&ssh_dir).unwrap();
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(&env_file, "SECRET=1").unwrap();
+
+        let gemini_dir = root.join(".gemini");
+        // Do NOT manually create gemini_dir — loader must auto-create it
+
+        let options = PolicyLoadOptions {
+            agent: Some("gemini-cli".to_string()),
+            ..Default::default()
+        };
+
+        let pol = load_with_options("default", None, &root, &root, Tier::Full, &options)
+            .expect("gemini preset must load");
+
+        // Environment pass_through
+        use std::ffi::OsStr;
+        assert!(pol.environment.allows(OsStr::new("GEMINI_API_KEY")));
+        assert!(pol.environment.allows(OsStr::new("GOOGLE_API_KEY")));
+        assert!(pol.environment.allows(OsStr::new("GEMINI_BASE_URL")));
+        assert!(pol.environment.allows(OsStr::new("GEMINI_TEST_FLAG")));
+        assert!(pol.environment.allows(OsStr::new("PATH")));
+        assert!(!pol.environment.allows(OsStr::new("AWS_SECRET_ACCESS_KEY")));
+        assert!(!pol.environment.allows(OsStr::new("GH_TOKEN")));
+
+        // Filesystem permissions
+        assert!(pol.allow_write.contains(&gemini_dir));
+
+        // Secrets must be in deny_resolved, but gemini_dir must NOT be in deny_resolved
+        let deny_paths: Vec<_> = pol.deny_resolved.iter().map(|d| &d.path).collect();
+        assert!(deny_paths.contains(&&ssh_dir));
+        assert!(deny_paths.contains(&&env_file));
+        assert!(deny_paths.contains(&&claude_dir));
+        assert!(!deny_paths.contains(&&gemini_dir));
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/src/policy/loader.rs
+++ b/src/policy/loader.rs
@@ -1513,7 +1513,7 @@ fn build_policy(
     for entry in &all_deny_entries {
         for path in resolve_list(std::slice::from_ref(entry), &vars, agent)? {
             if let Some(agent_dir) = agent {
-                if &path == agent_dir {
+                if path == agent_dir {
                     continue;
                 }
             }

--- a/src/policy/presets.rs
+++ b/src/policy/presets.rs
@@ -56,14 +56,15 @@ impl std::fmt::Display for Preset {
 
 /// Auto-allowlist domains by agent name.
 pub fn agent_network_allowlist(agent: &str) -> Vec<String> {
-    match agent.trim().to_ascii_lowercase().as_str() {
-        "claude" | "claude-code" => vec!["api.anthropic.com".into()],
-        "codex" | "codex-cli" => vec!["api.openai.com".into(), "chatgpt.com".into()],
+    let canon = crate::policy::defaults::canonical_agent_name(agent).unwrap_or(agent);
+    match canon {
+        "claude" => vec!["api.anthropic.com".into()],
+        "codex" => vec!["api.openai.com".into(), "chatgpt.com".into()],
         "gemini" => vec!["generativelanguage.googleapis.com".into()],
-        "aider" | "aider-chat" => vec!["api.openai.com".into(), "api.anthropic.com".into()],
+        "aider" => vec!["api.openai.com".into(), "api.anthropic.com".into()],
         "opencode" => vec!["api.openai.com".into(), "api.anthropic.com".into()],
-        "cursor" | "cursor-server" => vec!["api.cursor.com".into(), "api2.cursor.sh".into()],
-        "copilot" | "github-copilot-cli" => vec![
+        "cursor" => vec!["api.cursor.com".into(), "api2.cursor.sh".into()],
+        "copilot" => vec![
             "api.github.com".into(),
             "copilot-proxy.githubusercontent.com".into(),
         ],
@@ -274,7 +275,15 @@ mod tests {
     fn auto_allowlist_matches_known_agents() {
         assert_eq!(agent_network_allowlist("claude"), vec!["api.anthropic.com"]);
         assert_eq!(
+            agent_network_allowlist("claude-code"),
+            vec!["api.anthropic.com"]
+        );
+        assert_eq!(
             agent_network_allowlist("codex"),
+            vec!["api.openai.com", "chatgpt.com"]
+        );
+        assert_eq!(
+            agent_network_allowlist("codex-cli"),
             vec!["api.openai.com", "chatgpt.com"]
         );
         assert_eq!(
@@ -282,12 +291,40 @@ mod tests {
             vec!["generativelanguage.googleapis.com"]
         );
         assert_eq!(
+            agent_network_allowlist("gemini-cli"),
+            vec!["generativelanguage.googleapis.com"]
+        );
+        assert_eq!(
             agent_network_allowlist("aider"),
+            vec!["api.openai.com", "api.anthropic.com"]
+        );
+        assert_eq!(
+            agent_network_allowlist("aider-chat"),
             vec!["api.openai.com", "api.anthropic.com"]
         );
         assert_eq!(
             agent_network_allowlist("opencode"),
             vec!["api.openai.com", "api.anthropic.com"]
+        );
+        assert_eq!(
+            agent_network_allowlist("cursor"),
+            vec!["api.cursor.com", "api2.cursor.sh"]
+        );
+        assert_eq!(
+            agent_network_allowlist("cursor-server"),
+            vec!["api.cursor.com", "api2.cursor.sh"]
+        );
+        assert_eq!(
+            agent_network_allowlist("cline"),
+            vec!["api.anthropic.com", "api.openai.com"]
+        );
+        assert_eq!(
+            agent_network_allowlist("copilot"),
+            vec!["api.github.com", "copilot-proxy.githubusercontent.com"]
+        );
+        assert_eq!(
+            agent_network_allowlist("github-copilot-cli"),
+            vec!["api.github.com", "copilot-proxy.githubusercontent.com"]
         );
         assert!(agent_network_allowlist("unknown").is_empty());
     }


### PR DESCRIPTION
## Summary
Closes zero-config runtime blockers for Claude Code, OpenAI Codex CLI, and Gemini CLI in Vetto 0.2.10:

- **R1 (Automatic Network Allowlist)**: When `--net` is omitted and an agent preset is detected, automatically default to `NetMode::Allowlist(agent_network_allowlist)` instead of `NetMode::Off`. Non-agent commands stay `NetMode::Off`.
- **R2 (Environment Pass-through)**: Expose `ANTHROPIC_*`, `CLAUDE_*`, `OPENAI_*`, `CODEX_*`, and `GEMINI_*` in agent profile `[environment.pass_through]` while maintaining strict denial of host credentials (`AWS_*`, `GH_TOKEN`, etc.).
- **R3 (Agent State & Filesystem Compatibility)**: Grant read access to `~/.claude.json` and read/write to `` (`~/.claude/`, `~/.codex/`). Unmask `state_*.sqlite` and `config.toml` from `display_only_deny`. Host secrets (`~/.ssh`, `~/.aws`, `~/.gnupg`, `.env*`) remain strictly locked at kernel level.
- **R4 (Versioning)**: Bump to `0.2.10` (+0.0.1) across all manifests, package specs, and `VERSIONS.md`.

## Verification
- CI Run [33651686723](https://github.com/shleder/vetto/actions/runs/33651686723): 7/7 jobs SUCCESS (Ubuntu, Windows, macOS, QEMU aarch64, clippy, cargo-deny, redteam, e2e spawn baseline).
- No local compilation or test executions were run.