### PR TITLE
feat(upgrade-audit): automated self-updating and session audit inspector (0.2.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project are documented here. Format follows
 Keep a Changelog; versioning follows SemVer.
 
+## [0.2.11] — 2026-09-02
+
+### Added
+
+- **Automated Self-Update (`vetto upgrade`)**: End-to-end self-updating across all distribution channels with active installation method detection (npm global `@shledery/vetto`, cargo install `vetto`, Homebrew tap `shleder/vetto`, and direct binary via GitHub Releases). Supports `--dry-run`, `--check`, `--channel <stable|alpha>`, clean changelog diff display, and atomic replacement for binary releases.
+- **Update Notification Banner**: Lightweight, non-blocking update check against npm registry / GitHub releases during `vetto doctor` and session initialization, cached for 24 hours in `~/.vetto/cache/update-check.json`. Subtle, non-intrusive banner (`Update available: X.Y.Z -> A.B.C (run 'vetto upgrade')`) with zero startup latency impact on timeout or offline.
+- **Session Audit Inspector (`vetto audit [session_id]`)**: Dedicated security inspector CLI command to inspect recorded session events from `~/.vetto/logs/*.jsonl` or `.vetto/reports/*.json`.
+  - Lists past agent execution sessions with timestamps, commands, agent presets, tiers, exit statuses, and violation counts.
+  - Given a session ID (or `--latest`), displays structured breakdown of all security events: denied filesystem access paths (Landlock), blocked outbound network destinations, and filtered syscalls (seccomp).
+  - Full `--json` output support for automated security pipelines and CI integration.
+
 ## [0.2.10] — 2026-09-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vetto"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
 
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vetto"
-version = "0.2.10"
+version = "0.2.11"
 
 edition = "2021"
 rust-version = "1.75"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shledery/vetto",
-  "version": "0.2.10",
+  "version": "0.2.11",
 
   "description": "Cross-platform vetto sandbox and security layer for AI coding agents",
   "license": "Apache-2.0",

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: vetto contributors
 pkgname=vetto-git
-pkgver=0.2.10.r0.g0000000
+pkgver=0.2.11.r0.g0000000
 pkgrel=1
 pkgdesc='Daemon-less sandbox and audit layer for AI coding agents'
 arch=('x86_64' 'aarch64')

--- a/packaging/chocolatey/vetto.nuspec
+++ b/packaging/chocolatey/vetto.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vetto</id>
-    <version>0.2.10</version>
+    <version>0.2.11</version>
     <title>vetto</title>
     <authors>vetto contributors</authors>
     <projectUrl>https://github.com/shleder/vetto</projectUrl>

--- a/packaging/homebrew/vetto.rb
+++ b/packaging/homebrew/vetto.rb
@@ -1,25 +1,25 @@
 class Vetto < Formula
   desc "Daemon-less OS sandbox and subagent security layer for AI coding agents"
   homepage "https://github.com/shleder/vetto"
-  version "0.2.10"
+  version "0.2.11"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.10/vetto-macos-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.11/vetto-macos-aarch64.tar.gz"
       sha256 "9710e5b94bc2c28e7a644a875189f58f3b01b157e0bc620025de62a4ef8a8b1f"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.10/vetto-macos-x86_64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.11/vetto-macos-x86_64.tar.gz"
       sha256 "6345e1b81ff5cb1faa5e1c1839d39305e83740b2a2b27e10caf65cc134bf4b41"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.10/vetto-linux-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.11/vetto-linux-aarch64.tar.gz"
       sha256 "f7c9fcde23c0fd6983ef2dde511b88053b0c03e817e66bf5c886f0f0e3f3bc63"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.10/vetto-linux-x86_64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.11/vetto-linux-x86_64.tar.gz"
       sha256 "deaca44700919a84a93f306c1220f2f338bab515bd2da9473df5823b7bab0369"
     end
   end

--- a/packaging/rpm/vetto.spec
+++ b/packaging/rpm/vetto.spec
@@ -1,5 +1,5 @@
 Name:           vetto
-Version:        0.2.10
+Version:        0.2.11
 Release:        1%{?dist}
 Summary:        Daemon-less sandbox and audit layer for AI coding agents
 License:        Apache-2.0
@@ -34,6 +34,9 @@ cp -a profiles/. %{buildroot}%{_datadir}/vetto/profiles/
 %{_datadir}/vetto/profiles
 
 %changelog
+* Wed Sep 02 2026 vetto contributors - 0.2.11-1
+- Sync the source-only recipe with the published 0.2.11 release.
+
 * Wed Sep 02 2026 vetto contributors - 0.2.10-1
 - Sync the source-only recipe with the published 0.2.10 release.
 

--- a/src/audit/digest.rs
+++ b/src/audit/digest.rs
@@ -165,6 +165,7 @@ mod tests {
                 ts: Utc::now(),
                 session_id: "s1".into(),
                 agent: "codex".into(),
+                command: Some("codex".into()),
                 profile: "default".into(),
                 policy_path: None,
                 exit_code: 0,
@@ -174,11 +175,13 @@ mod tests {
                 blocked_count: 0,
                 events_total: 20,
                 report_path: None,
+                log_path: None,
             },
             AuditRecord {
                 ts: Utc::now(),
                 session_id: "s2".into(),
                 agent: "codex".into(),
+                command: Some("codex".into()),
                 profile: "strict".into(),
                 policy_path: None,
                 exit_code: 1,
@@ -188,11 +191,13 @@ mod tests {
                 blocked_count: 3,
                 events_total: 15,
                 report_path: None,
+                log_path: None,
             },
             AuditRecord {
                 ts: Utc::now(),
                 session_id: "s3".into(),
                 agent: "claude".into(),
+                command: Some("claude".into()),
                 profile: "default".into(),
                 policy_path: None,
                 exit_code: 0,
@@ -202,6 +207,7 @@ mod tests {
                 blocked_count: 2,
                 events_total: 30,
                 report_path: None,
+                log_path: None,
             },
         ];
 

--- a/src/audit/history.rs
+++ b/src/audit/history.rs
@@ -451,11 +451,25 @@ fn parse_jsonl_log(path: &Path, session_hint: &str) -> Result<SessionAuditDetail
     let file = File::open(path).with_context(|| format!("open log {}", path.display()))?;
     let reader = BufReader::new(file);
 
-    let mut session_id = Path::new(session_hint)
+    let stem = path
         .file_stem()
         .and_then(|s| s.to_str())
-        .unwrap_or(session_hint)
-        .to_string();
+        .unwrap_or(session_hint);
+    let clean = stem
+        .strip_prefix(".vetto-report-")
+        .or_else(|| stem.strip_prefix("vetto-report-"))
+        .unwrap_or(stem);
+    let mut session_id = if clean.starts_with("session-") {
+        clean.to_string()
+    } else if !clean.is_empty() && clean != "latest" {
+        format!("session-{clean}")
+    } else if session_hint.starts_with("session-") {
+        session_hint.to_string()
+    } else if !session_hint.is_empty() && session_hint != "latest" {
+        format!("session-{session_hint}")
+    } else {
+        session_hint.to_string()
+    };
     let mut timestamp = Utc::now();
     let mut command = None;
     let mut agent = "default".to_string();

--- a/src/audit/history.rs
+++ b/src/audit/history.rs
@@ -1,9 +1,9 @@
-//! Audit history log index (~/.vetto/history.jsonl) and `vetto audit` subcommand (Feature 40).
+//! Audit history log index (~/.vetto/history.jsonl) and `vetto audit` session inspector.
 //!
-//! Every completed sandboxed session appends an audit summary line to `~/.vetto/history.jsonl`.
-//! The `vetto audit` subcommand displays this history with filtering and search.
+//! Inspects recorded session events, filesystem denials, blocked egress, and filtered syscalls.
 
-use std::fs::{File, OpenOptions};
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
@@ -16,6 +16,8 @@ pub struct AuditRecord {
     pub ts: DateTime<Utc>,
     pub session_id: String,
     pub agent: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
     pub profile: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_path: Option<String>,
@@ -27,6 +29,64 @@ pub struct AuditRecord {
     pub events_total: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub report_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionAuditDetail {
+    pub session_id: String,
+    pub timestamp: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    pub agent: String,
+    pub profile: String,
+    pub tier: String,
+    pub net_mode: String,
+    pub exit_code: i32,
+    pub duration_secs: u64,
+    pub violations_total: u64,
+    pub events_total: u64,
+    pub filesystem_denials: Vec<FilesystemDenial>,
+    pub blocked_network: Vec<BlockedNetworkDestination>,
+    pub filtered_syscalls: Vec<FilteredSyscall>,
+    pub suspicious_signals: Vec<SuspiciousSignalDetail>,
+    pub recommendations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilesystemDenial {
+    pub path: String,
+    pub process: String,
+    pub source: String,
+    pub count: u64,
+    pub remediation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockedNetworkDestination {
+    pub destination: String,
+    pub host: String,
+    pub port: u16,
+    pub count: u64,
+    pub remediation: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilteredSyscall {
+    pub syscall: String,
+    pub comm: String,
+    pub source: String,
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuspiciousSignalDetail {
+    pub category: String,
+    pub severity: String,
+    pub subject: String,
+    pub reason: String,
+    pub count: u64,
 }
 
 /// Resolves the default global audit history path (~/.vetto/history.jsonl).
@@ -43,7 +103,7 @@ pub fn record_session_history(record: &AuditRecord) -> Result<()> {
         return Ok(());
     };
     if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
+        let _ = fs::create_dir_all(parent);
     }
     append_record_to_file(&path, record)
 }
@@ -63,29 +123,77 @@ pub fn append_record_to_file(path: &Path, record: &AuditRecord) -> Result<()> {
     Ok(())
 }
 
-/// Reads all audit records from a history file.
+/// Reads all audit records from a history file (or auto-discovers from logs if empty).
 pub fn read_history(path: &Path) -> Result<Vec<AuditRecord>> {
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
-    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
-    let reader = BufReader::new(file);
     let mut records = Vec::new();
+    if path.exists() {
+        let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+        let reader = BufReader::new(file);
 
-    for line in reader.lines() {
-        let line = match line {
-            Ok(l) => l,
-            Err(_) => continue,
-        };
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        if let Ok(rec) = serde_json::from_str::<AuditRecord>(trimmed) {
-            records.push(rec);
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            if let Ok(rec) = serde_json::from_str::<AuditRecord>(trimmed) {
+                records.push(rec);
+            }
         }
     }
+
+    if records.is_empty() {
+        let discovered = discover_history_from_logs();
+        if !discovered.is_empty() {
+            return Ok(discovered);
+        }
+    }
+
     Ok(records)
+}
+
+/// Auto-discovers past session records from ~/.vetto/logs/*.jsonl.
+pub fn discover_history_from_logs() -> Vec<AuditRecord> {
+    let mut records = Vec::new();
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from);
+
+    if let Some(h) = home {
+        let logs_dir = h.join(".vetto").join("logs");
+        if logs_dir.exists() {
+            if let Ok(entries) = fs::read_dir(&logs_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                        if let Ok(detail) = parse_jsonl_log(&path, "") {
+                            records.push(AuditRecord {
+                                ts: detail.timestamp,
+                                session_id: detail.session_id,
+                                agent: detail.agent,
+                                command: detail.command,
+                                profile: detail.profile,
+                                policy_path: None,
+                                exit_code: detail.exit_code,
+                                duration_secs: detail.duration_secs,
+                                tier: detail.tier,
+                                net_mode: detail.net_mode,
+                                blocked_count: detail.violations_total,
+                                events_total: detail.events_total,
+                                report_path: None,
+                                log_path: Some(path.display().to_string()),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+    records.sort_by_key(|r| r.ts);
+    records
 }
 
 /// Filter and sort history records.
@@ -124,7 +232,13 @@ pub fn filter_records<'a>(
                 let in_profile = rec.profile.to_ascii_lowercase().contains(q);
                 let in_agent = rec.agent.to_ascii_lowercase().contains(q);
                 let in_session = rec.session_id.to_ascii_lowercase().contains(q);
-                if !in_policy && !in_profile && !in_agent && !in_session {
+                let in_command = rec
+                    .command
+                    .as_deref()
+                    .unwrap_or("")
+                    .to_ascii_lowercase()
+                    .contains(q);
+                if !in_policy && !in_profile && !in_agent && !in_session && !in_command {
                     return false;
                 }
             }
@@ -138,7 +252,6 @@ pub fn parse_since_duration(s: &str) -> Result<DateTime<Utc>> {
     let s = s.trim();
     let now = Utc::now();
 
-    // Check if it is a relative duration like 24h, 7d, 30m, 90s
     if let Some(rest) = s.strip_suffix('h') {
         let hours: i64 = rest.parse().context("invalid hours in --since")?;
         return Ok(now - Duration::hours(hours));
@@ -156,7 +269,6 @@ pub fn parse_since_duration(s: &str) -> Result<DateTime<Utc>> {
         return Ok(now - Duration::seconds(secs));
     }
 
-    // Try parsing date/datetime e.g. "2026-08-30" or ISO
     if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
         return Ok(dt.with_timezone(&Utc));
     }
@@ -169,7 +281,846 @@ pub fn parse_since_duration(s: &str) -> Result<DateTime<Utc>> {
     anyhow::bail!("invalid --since value '{s}'; expected e.g. 24h, 7d, 30m, or YYYY-MM-DD")
 }
 
-/// Execute the `vetto audit` CLI subcommand.
+/// Inspects a session by session ID, report path, or log path.
+pub fn inspect_session(target: &str) -> Result<SessionAuditDetail> {
+    if target == "latest" || target.trim().is_empty() {
+        return inspect_latest_session();
+    }
+
+    let target_path = Path::new(target);
+    if target_path.exists() && target_path.is_file() {
+        let ext = target_path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+        if ext == "jsonl" {
+            return parse_jsonl_log(target_path, target);
+        } else if ext == "json" {
+            return parse_json_report(target_path, target);
+        }
+    }
+
+    // Try finding matching log or report in known directories
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from);
+
+    let stripped = target.strip_prefix("session-").unwrap_or(target);
+
+    // 1. Check ~/.vetto/logs/<target>.jsonl
+    if let Some(ref h) = home {
+        let log_file = h
+            .join(".vetto")
+            .join("logs")
+            .join(format!("{target}.jsonl"));
+        if log_file.exists() {
+            return parse_jsonl_log(&log_file, target);
+        }
+        let log_file_raw = h.join(".vetto").join("logs").join(target);
+        if log_file_raw.exists() {
+            return parse_jsonl_log(&log_file_raw, target);
+        }
+    }
+
+    // 2. Search logs in ~/.vetto/logs/ for matching filename
+    if let Some(ref h) = home {
+        let logs_dir = h.join(".vetto").join("logs");
+        if logs_dir.exists() {
+            if let Ok(entries) = fs::read_dir(&logs_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    if (name.contains(target) || name.contains(stripped))
+                        && name.ends_with(".jsonl")
+                    {
+                        return parse_jsonl_log(&path, target);
+                    }
+                }
+            }
+        }
+    }
+
+    // 3. Check reports in current directory, .vetto/reports/, or ~/.vetto/reports/
+    let report_candidates = vec![
+        PathBuf::from("."),
+        PathBuf::from(".vetto/reports"),
+        PathBuf::from(".vetto-reports"),
+        home.as_ref()
+            .map(|h| h.join(".vetto").join("reports"))
+            .unwrap_or_default(),
+    ];
+
+    for rep_dir in report_candidates {
+        if rep_dir.exists() {
+            if let Ok(entries) = fs::read_dir(&rep_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    if (name.contains(target)
+                        || name.contains(stripped)
+                        || (target == "latest"
+                            && (name.starts_with(".vetto-report-")
+                                || name.starts_with("vetto-report-"))))
+                        && (name.ends_with(".json") || name.ends_with(".jsonl"))
+                    {
+                        if name.ends_with(".jsonl") {
+                            return parse_jsonl_log(&path, target);
+                        } else {
+                            return parse_json_report(&path, target);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // 4. Check ~/.vetto/history.jsonl for matching session
+    if let Some(history_file) = default_history_path() {
+        let records = read_history(&history_file)?;
+        let matched = records.iter().find(|r| {
+            r.session_id == target
+                || r.session_id.contains(target)
+                || r.session_id.strip_prefix("session-") == Some(target)
+        });
+
+        if let Some(rec) = matched {
+            if let Some(ref lp) = rec.log_path {
+                let p = Path::new(lp);
+                if p.exists() {
+                    return parse_jsonl_log(p, &rec.session_id);
+                }
+            }
+            if let Some(ref rp) = rec.report_path {
+                let p = Path::new(rp);
+                if p.exists() {
+                    return parse_json_report(p, &rec.session_id);
+                }
+            }
+            return Ok(build_detail_from_history_record(rec));
+        }
+    }
+
+    anyhow::bail!(
+        "session '{target}' not found in logs (~/.vetto/logs/*.jsonl), reports, or history. Run 'vetto audit' to view available sessions."
+    )
+}
+
+/// Inspects the most recent recorded session.
+pub fn inspect_latest_session() -> Result<SessionAuditDetail> {
+    if let Some(history_file) = default_history_path() {
+        let records = read_history(&history_file)?;
+        if let Some(latest) = records.last() {
+            return inspect_session(&latest.session_id);
+        }
+    }
+
+    // Fallback: check latest file in ~/.vetto/logs/
+    if let Some(home) = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+    {
+        let logs_dir = home.join(".vetto").join("logs");
+        if logs_dir.exists() {
+            let mut log_files = Vec::new();
+            if let Ok(entries) = fs::read_dir(&logs_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                        if let Ok(meta) = path.metadata() {
+                            let mtime = meta.modified().unwrap_or(std::time::UNIX_EPOCH);
+                            log_files.push((path, mtime));
+                        }
+                    }
+                }
+            }
+            log_files.sort_by_key(|(_, mtime)| std::cmp::Reverse(*mtime));
+            if let Some((path, _)) = log_files.first() {
+                let stem = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("latest");
+                return parse_jsonl_log(path, stem);
+            }
+        }
+    }
+
+    anyhow::bail!("no past session logs or history found. Run a sandboxed session first with 'vetto -- <command>'.")
+}
+
+fn parse_jsonl_log(path: &Path, session_hint: &str) -> Result<SessionAuditDetail> {
+    let file = File::open(path).with_context(|| format!("open log {}", path.display()))?;
+    let reader = BufReader::new(file);
+
+    let mut session_id = Path::new(session_hint)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(session_hint)
+        .to_string();
+    let mut timestamp = Utc::now();
+    let mut command = None;
+    let mut agent = "default".to_string();
+    let mut profile = "default".to_string();
+    let mut tier = "unknown".to_string();
+    let mut net_mode = "unknown".to_string();
+    let mut exit_code = 0;
+    let mut duration_secs = 0;
+    let mut events_total = 0u64;
+
+    let mut denials_map: BTreeMap<(String, String, String), u64> = BTreeMap::new();
+    let mut network_map: BTreeMap<(String, u16), u64> = BTreeMap::new();
+    let mut syscalls_map: BTreeMap<(String, String, String), u64> = BTreeMap::new();
+    let mut suspicious_map: BTreeMap<(String, String, String, String), u64> = BTreeMap::new();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let ev_res = serde_json::from_str::<crate::events::Event>(trimmed);
+        if let Ok(ev) = ev_res {
+            events_total += 1;
+
+            if let Some(signal) = crate::classifier::classify_event(&ev) {
+                let key = (
+                    signal.category.to_string(),
+                    signal.severity.label().to_string(),
+                    signal.subject,
+                    signal.reason.to_string(),
+                );
+                *suspicious_map.entry(key).or_insert(0) += 1;
+            }
+
+            match ev {
+                crate::events::Event::SessionStarted {
+                    ts,
+                    pid,
+                    tier: t,
+                    net_mode: nm,
+                    profile: p,
+                } => {
+                    timestamp = ts;
+                    if session_id.is_empty()
+                        || session_id == "latest"
+                        || session_id.contains('/')
+                        || session_id.contains('\\')
+                    {
+                        session_id = format!("session-{pid}");
+                    }
+                    tier = t;
+                    net_mode = nm;
+                    profile = p;
+                }
+                crate::events::Event::ExecObserved { argv, .. } => {
+                    if command.is_none() && !argv.is_empty() {
+                        command = Some(argv.join(" "));
+                        if let Some(first) = argv.first() {
+                            agent = Path::new(first)
+                                .file_name()
+                                .and_then(|n| n.to_str())
+                                .unwrap_or(first)
+                                .to_string();
+                        }
+                    }
+                }
+                crate::events::Event::BlockedAttempt {
+                    comm, path, source, ..
+                } => {
+                    let is_syscall = source.contains("seccomp")
+                        || path.starts_with("syscall:")
+                        || source == "syscall";
+                    if is_syscall {
+                        let sys_name = path.strip_prefix("syscall:").unwrap_or(&path).to_string();
+                        *syscalls_map.entry((sys_name, comm, source)).or_insert(0) += 1;
+                    } else {
+                        *denials_map.entry((path, comm, source)).or_insert(0) += 1;
+                    }
+                }
+                crate::events::Event::NetRequest {
+                    host,
+                    port,
+                    allowed,
+                    ..
+                } => {
+                    if !allowed {
+                        *network_map.entry((host, port)).or_insert(0) += 1;
+                    }
+                }
+                crate::events::Event::NetQuotaExceeded { host, .. } => {
+                    *network_map.entry((host, 0)).or_insert(0) += 1;
+                }
+                crate::events::Event::SessionEnded {
+                    exit_code: code,
+                    duration_secs: dur,
+                    ..
+                } => {
+                    exit_code = code;
+                    duration_secs = dur;
+                }
+                _ => {}
+            }
+        } else if let Ok(val) = serde_json::from_str::<serde_json::Value>(trimmed) {
+            let event_type = val
+                .get("event")
+                .or_else(|| val.get("type"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if !event_type.is_empty() {
+                events_total += 1;
+                match event_type {
+                    "session_started" => {
+                        if let Some(ts_str) = val.get("ts").and_then(|v| v.as_str()) {
+                            if let Ok(dt) = DateTime::parse_from_rfc3339(ts_str) {
+                                timestamp = dt.with_timezone(&Utc);
+                            }
+                        }
+                        if let Some(pid) = val.get("pid").and_then(|v| v.as_u64()) {
+                            if session_id.is_empty()
+                                || session_id == "latest"
+                                || session_id.contains('/')
+                                || session_id.contains('\\')
+                            {
+                                session_id = format!("session-{pid}");
+                            }
+                        }
+                        if let Some(t) = val.get("tier").and_then(|v| v.as_str()) {
+                            tier = t.to_string();
+                        }
+                        if let Some(nm) = val.get("net_mode").and_then(|v| v.as_str()) {
+                            net_mode = nm.to_string();
+                        }
+                        if let Some(p) = val.get("profile").and_then(|v| v.as_str()) {
+                            profile = p.to_string();
+                        }
+                    }
+                    "exec_observed" => {
+                        if let Some(arr) = val.get("argv").and_then(|v| v.as_array()) {
+                            let argv: Vec<String> = arr
+                                .iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect();
+                            if command.is_none() && !argv.is_empty() {
+                                command = Some(argv.join(" "));
+                                if let Some(first) = argv.first() {
+                                    agent = Path::new(first)
+                                        .file_name()
+                                        .and_then(|n| n.to_str())
+                                        .unwrap_or(first)
+                                        .to_string();
+                                }
+                            }
+                        }
+                    }
+                    "blocked_attempt" => {
+                        let path = val
+                            .get("path")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let comm = val
+                            .get("comm")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("agent")
+                            .to_string();
+                        let source = val
+                            .get("source")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("landlock")
+                            .to_string();
+                        let is_syscall = source.contains("seccomp")
+                            || path.starts_with("syscall:")
+                            || source == "syscall";
+                        if is_syscall {
+                            let sys_name =
+                                path.strip_prefix("syscall:").unwrap_or(&path).to_string();
+                            *syscalls_map.entry((sys_name, comm, source)).or_insert(0) += 1;
+                        } else {
+                            *denials_map.entry((path, comm, source)).or_insert(0) += 1;
+                        }
+                    }
+                    "net_request" => {
+                        let host = val
+                            .get("host")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let port = val.get("port").and_then(|v| v.as_u64()).unwrap_or(0) as u16;
+                        let allowed = val.get("allowed").and_then(|v| v.as_bool()).unwrap_or(true);
+                        if !allowed {
+                            *network_map.entry((host, port)).or_insert(0) += 1;
+                        }
+                    }
+                    "session_ended" => {
+                        if let Some(code) = val.get("exit_code").and_then(|v| v.as_i64()) {
+                            exit_code = code as i32;
+                        }
+                        if let Some(dur) = val.get("duration_secs").and_then(|v| v.as_u64()) {
+                            duration_secs = dur;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let filesystem_denials = denials_map
+        .into_iter()
+        .map(|((p, comm, src), count)| FilesystemDenial {
+            path: p.clone(),
+            process: comm,
+            source: src,
+            count,
+            remediation: format!("vetto allow {p}"),
+        })
+        .collect::<Vec<_>>();
+
+    let blocked_network = network_map
+        .into_iter()
+        .map(|((h, port), count)| BlockedNetworkDestination {
+            destination: if port > 0 {
+                format!("{h}:{port}")
+            } else {
+                h.clone()
+            },
+            host: h.clone(),
+            port,
+            count,
+            remediation: format!("vetto allow --net {h}"),
+        })
+        .collect::<Vec<_>>();
+
+    let filtered_syscalls = syscalls_map
+        .into_iter()
+        .map(|((sys, comm, src), count)| FilteredSyscall {
+            syscall: sys,
+            comm,
+            source: src,
+            count,
+        })
+        .collect::<Vec<_>>();
+
+    let suspicious_signals = suspicious_map
+        .into_iter()
+        .map(|((cat, sev, subj, reason), count)| SuspiciousSignalDetail {
+            category: cat,
+            severity: sev,
+            subject: subj,
+            reason,
+            count,
+        })
+        .collect::<Vec<_>>();
+
+    let violations_total = (filesystem_denials.iter().map(|d| d.count).sum::<u64>())
+        + (blocked_network.iter().map(|n| n.count).sum::<u64>())
+        + (filtered_syscalls.iter().map(|s| s.count).sum::<u64>());
+
+    let mut recommendations = Vec::new();
+    for d in &filesystem_denials {
+        recommendations.push(format!("Grant filesystem access: {}", d.remediation));
+    }
+    for n in &blocked_network {
+        recommendations.push(format!("Grant network domain: {}", n.remediation));
+    }
+    if exit_code == 124 {
+        recommendations.push("Session timed out: consider extending --timeout".to_string());
+    }
+
+    if session_id.is_empty() || session_id == "latest" {
+        session_id = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+    }
+
+    Ok(SessionAuditDetail {
+        session_id,
+        timestamp,
+        command,
+        agent,
+        profile,
+        tier,
+        net_mode,
+        exit_code,
+        duration_secs,
+        violations_total,
+        events_total,
+        filesystem_denials,
+        blocked_network,
+        filtered_syscalls,
+        suspicious_signals,
+        recommendations,
+    })
+}
+
+fn parse_json_report(path: &Path, session_hint: &str) -> Result<SessionAuditDetail> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("read report {}", path.display()))?;
+    let val: serde_json::Value =
+        serde_json::from_str(&content).with_context(|| "parse report JSON")?;
+
+    let session_id = val
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| {
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or(session_hint);
+            let clean = stem
+                .strip_prefix('.')
+                .unwrap_or(stem)
+                .strip_prefix("vetto-report-")
+                .unwrap_or(stem);
+            if clean.is_empty() || clean == "latest" {
+                session_hint.to_string()
+            } else if clean.starts_with("session-") {
+                clean.to_string()
+            } else {
+                format!("session-{clean}")
+            }
+        });
+
+    let timestamp = val
+        .get("started_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(Utc::now);
+
+    let profile = val
+        .get("profile")
+        .and_then(|v| v.as_str())
+        .unwrap_or("default")
+        .to_string();
+    let tier = val
+        .get("tier")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let net_mode = val
+        .get("net_mode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let exit_code = val.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    let duration_secs = val
+        .get("duration_secs")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let events_total = val
+        .get("events_total")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    let mut filesystem_denials = Vec::new();
+    let mut filtered_syscalls = Vec::new();
+
+    if let Some(blocks) = val.get("blocked_attempts").and_then(|v| v.as_array()) {
+        for b in blocks {
+            let path_str = b.get("path").and_then(|v| v.as_str()).unwrap_or("");
+            let comm = b
+                .get("comm")
+                .and_then(|v| v.as_str())
+                .unwrap_or("agent")
+                .to_string();
+            let source = b
+                .get("source")
+                .and_then(|v| v.as_str())
+                .unwrap_or("landlock")
+                .to_string();
+            let count = b.get("count").and_then(|v| v.as_u64()).unwrap_or(1);
+
+            if source.contains("seccomp") || path_str.starts_with("syscall:") {
+                filtered_syscalls.push(FilteredSyscall {
+                    syscall: path_str
+                        .strip_prefix("syscall:")
+                        .unwrap_or(path_str)
+                        .to_string(),
+                    comm,
+                    source,
+                    count,
+                });
+            } else {
+                filesystem_denials.push(FilesystemDenial {
+                    path: path_str.to_string(),
+                    process: comm,
+                    source,
+                    count,
+                    remediation: format!("vetto allow {path_str}"),
+                });
+            }
+        }
+    }
+
+    let mut net_map: BTreeMap<(String, u16), u64> = BTreeMap::new();
+    if let Some(nets) = val.get("net_requests").and_then(|v| v.as_array()) {
+        for n in nets {
+            let allowed = n.get("allowed").and_then(|v| v.as_bool()).unwrap_or(true);
+            if !allowed {
+                let host = n.get("host").and_then(|v| v.as_str()).unwrap_or("");
+                let port = n.get("port").and_then(|v| v.as_u64()).unwrap_or(443) as u16;
+                *net_map.entry((host.to_string(), port)).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let blocked_network = net_map
+        .into_iter()
+        .map(|((host, port), count)| BlockedNetworkDestination {
+            destination: if port > 0 {
+                format!("{host}:{port}")
+            } else {
+                host.clone()
+            },
+            host: host.clone(),
+            port,
+            count,
+            remediation: format!("vetto allow --net {host}"),
+        })
+        .collect::<Vec<_>>();
+
+    let mut suspicious_signals = Vec::new();
+    if let Some(sigs) = val.get("suspicious_signals").and_then(|v| v.as_array()) {
+        for s in sigs {
+            let category = s.get("category").and_then(|v| v.as_str()).unwrap_or("");
+            let severity = s.get("severity").and_then(|v| v.as_str()).unwrap_or("low");
+            let subject = s.get("subject").and_then(|v| v.as_str()).unwrap_or("");
+            let reason = s.get("reason").and_then(|v| v.as_str()).unwrap_or("");
+            let count = s.get("count").and_then(|v| v.as_u64()).unwrap_or(1);
+
+            suspicious_signals.push(SuspiciousSignalDetail {
+                category: category.to_string(),
+                severity: severity.to_string(),
+                subject: subject.to_string(),
+                reason: reason.to_string(),
+                count,
+            });
+        }
+    }
+
+    let violations_total = (filesystem_denials.iter().map(|d| d.count).sum::<u64>())
+        + (blocked_network.iter().map(|n| n.count).sum::<u64>())
+        + (filtered_syscalls.iter().map(|s| s.count).sum::<u64>());
+
+    let mut recommendations = Vec::new();
+    for d in &filesystem_denials {
+        recommendations.push(format!("Grant filesystem access: {}", d.remediation));
+    }
+    for n in &blocked_network {
+        recommendations.push(format!("Grant network domain: {}", n.remediation));
+    }
+
+    let command = val
+        .get("command")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let agent = val
+        .get("agent")
+        .or_else(|| val.get("agent_preset"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("default")
+        .to_string();
+
+    Ok(SessionAuditDetail {
+        session_id,
+        timestamp,
+        command,
+        agent,
+        profile,
+        tier,
+        net_mode,
+        exit_code,
+        duration_secs,
+        violations_total,
+        events_total,
+        filesystem_denials,
+        blocked_network,
+        filtered_syscalls,
+        suspicious_signals,
+        recommendations,
+    })
+}
+
+fn build_detail_from_history_record(rec: &AuditRecord) -> SessionAuditDetail {
+    let mut recommendations = Vec::new();
+    if rec.blocked_count > 0 {
+        recommendations.push(format!(
+            "Session encountered {} intercepted violations. Check session log for full stream.",
+            rec.blocked_count
+        ));
+    }
+    if rec.exit_code == 124 {
+        recommendations.push("Session timed out: consider extending --timeout".to_string());
+    }
+
+    SessionAuditDetail {
+        session_id: rec.session_id.clone(),
+        timestamp: rec.ts,
+        command: rec.command.clone(),
+        agent: rec.agent.clone(),
+        profile: rec.profile.clone(),
+        tier: rec.tier.clone(),
+        net_mode: rec.net_mode.clone(),
+        exit_code: rec.exit_code,
+        duration_secs: rec.duration_secs,
+        violations_total: rec.blocked_count,
+        events_total: rec.events_total,
+        filesystem_denials: Vec::new(),
+        blocked_network: Vec::new(),
+        filtered_syscalls: Vec::new(),
+        suspicious_signals: Vec::new(),
+        recommendations,
+    }
+}
+
+/// Dispatches the `vetto audit` CLI subcommand with session inspection or listing.
+pub fn run_audit_command(
+    session_id: Option<&str>,
+    latest: bool,
+    since: Option<&str>,
+    agent: Option<&str>,
+    limit: Option<usize>,
+    query: Option<&str>,
+    json_output: bool,
+) -> Result<()> {
+    if latest || session_id.is_some() {
+        let detail = if latest {
+            inspect_latest_session()?
+        } else {
+            let id = session_id.unwrap();
+            match inspect_session(id) {
+                Ok(d) => d,
+                Err(e) => {
+                    // If target wasn't found as a direct session, attempt query listing
+                    if since.is_none() && agent.is_none() && query.is_none() {
+                        if let Ok(()) = run_audit(None, None, limit, Some(id), json_output) {
+                            return Ok(());
+                        }
+                    }
+                    return Err(e);
+                }
+            }
+        };
+
+        if json_output {
+            println!("{}", serde_json::to_string_pretty(&detail)?);
+        } else {
+            render_session_audit(&detail);
+        }
+        return Ok(());
+    }
+
+    run_audit(since, agent, limit, query, json_output)
+}
+
+/// Formats and renders a detailed session audit to stdout.
+pub fn render_session_audit(detail: &SessionAuditDetail) {
+    let status_str = if detail.exit_code == 0 {
+        "0 (Success)".to_string()
+    } else if detail.exit_code == 124 {
+        "124 (Timeout)".to_string()
+    } else {
+        format!("{} (Failed)", detail.exit_code)
+    };
+
+    println!("=== Vetto Session Audit: {} ===", detail.session_id);
+    println!(
+        "Timestamp:    {}",
+        detail.timestamp.format("%Y-%m-%d %H:%M:%S UTC")
+    );
+    if let Some(ref cmd) = detail.command {
+        println!("Command:      {cmd} (preset: {})", detail.agent);
+    } else {
+        println!("Agent Preset: {}", detail.agent);
+    }
+    println!(
+        "Sandbox Tier: {} (Profile: {})",
+        detail.tier, detail.profile
+    );
+    println!("Network Mode: {}", detail.net_mode);
+    println!("Exit Status:  {status_str}");
+    println!("Duration:     {}s", detail.duration_secs);
+    println!(
+        "Violations:   {} intercepted security event(s) (out of {} total events)",
+        detail.violations_total, detail.events_total
+    );
+    println!();
+
+    // 1. Filesystem Denials
+    println!("[1] Denied Filesystem Access (Landlock / Sandbox Boundary):");
+    if detail.filesystem_denials.is_empty() {
+        println!("  • None observed");
+    } else {
+        for d in &detail.filesystem_denials {
+            println!(
+                "  • {} ({} attempt(s) by '{}', source: {})",
+                d.path, d.count, d.process, d.source
+            );
+            println!("    └─ Remediation: {}", d.remediation);
+        }
+    }
+    println!();
+
+    // 2. Blocked Network
+    println!("[2] Blocked Outbound Network Destinations:");
+    if detail.blocked_network.is_empty() {
+        println!("  • None observed");
+    } else {
+        for n in &detail.blocked_network {
+            println!("  • {} ({} denied connection(s))", n.destination, n.count);
+            println!("    └─ Remediation: {}", n.remediation);
+        }
+    }
+    println!();
+
+    // 3. Filtered Syscalls
+    println!("[3] Filtered Syscalls & Kernel Violations (Seccomp / Audit):");
+    if detail.filtered_syscalls.is_empty() {
+        println!("  • None observed");
+    } else {
+        for s in &detail.filtered_syscalls {
+            println!(
+                "  • Syscall: {} (comm: '{}', source: {}, {} occurrence(s))",
+                s.syscall, s.comm, s.source, s.count
+            );
+        }
+    }
+    println!();
+
+    // 4. Suspicious Signals
+    if !detail.suspicious_signals.is_empty() {
+        println!("[4] Suspicious Signals Intercepted:");
+        for sig in &detail.suspicious_signals {
+            println!(
+                "  • [{}] {} on '{}': {} ({} count)",
+                sig.severity.to_ascii_uppercase(),
+                sig.category,
+                sig.subject,
+                sig.reason,
+                sig.count
+            );
+        }
+        println!();
+    }
+
+    // 5. Policy Recommendations
+    if !detail.recommendations.is_empty() {
+        println!("[*] Policy Recommendations:");
+        for rec in &detail.recommendations {
+            println!("  • {rec}");
+        }
+        println!();
+    }
+}
+
+/// Execute the `vetto audit` session listing CLI subcommand.
 pub fn run_audit(
     since: Option<&str>,
     agent: Option<&str>,
@@ -187,7 +1138,6 @@ pub fn run_audit(
     };
 
     let mut filtered = filter_records(&records, cutoff, agent, query);
-    // Sort reverse chronological
     filtered.sort_by_key(|a| std::cmp::Reverse(a.ts));
 
     if let Some(lim) = limit {
@@ -195,9 +1145,7 @@ pub fn run_audit(
     }
 
     if json_output {
-        for record in filtered {
-            println!("{}", serde_json::to_string(record)?);
-        }
+        println!("{}", serde_json::to_string_pretty(&filtered)?);
         return Ok(());
     }
 
@@ -210,22 +1158,22 @@ pub fn run_audit(
     }
 
     println!(
-        "{:<19}  {:<12}  {:<10}  {:<10}  {:<4}  {:<7}  {:<8}  {:<6}",
+        "{:<19}  {:<14}  {:<12}  {:<10}  {:<4}  {:<7}  {:<8}  {:<6}",
         "TIMESTAMP", "SESSION ID", "AGENT", "PROFILE", "EXIT", "BLOCKED", "TIER", "DUR"
     );
     println!(
-        "{:-<19}  {:-<12}  {:-<10}  {:-<10}  {:-<4}  {:-<7}  {:-<8}  {:-<6}",
+        "{:-<19}  {:-<14}  {:-<12}  {:-<10}  {:-<4}  {:-<7}  {:-<8}  {:-<6}",
         "", "", "", "", "", "", "", ""
     );
 
-    for r in filtered {
+    for r in &filtered {
         let ts_str = r.ts.format("%Y-%m-%d %H:%M:%S").to_string();
         let dur_str = format!("{}s", r.duration_secs);
         println!(
-            "{:<19}  {:<12}  {:<10}  {:<10}  {:<4}  {:<7}  {:<8}  {:<6}",
+            "{:<19}  {:<14}  {:<12}  {:<10}  {:<4}  {:<7}  {:<8}  {:<6}",
             ts_str,
-            truncate_str(&r.session_id, 12),
-            truncate_str(&r.agent, 10),
+            truncate_str(&r.session_id, 14),
+            truncate_str(&r.agent, 12),
             truncate_str(&r.profile, 10),
             r.exit_code,
             r.blocked_count,
@@ -233,6 +1181,11 @@ pub fn run_audit(
             dur_str,
         );
     }
+
+    println!();
+    println!(
+        "Tip: run 'vetto audit <session_id>' or 'vetto audit --latest' for detailed breakdown."
+    );
 
     Ok(())
 }
@@ -274,6 +1227,7 @@ mod tests {
                 ts: Utc::now(),
                 session_id: "session-1".into(),
                 agent: "codex".into(),
+                command: Some("python agent.py".into()),
                 profile: "default".into(),
                 policy_path: Some("/home/user/vetto.toml".into()),
                 exit_code: 0,
@@ -283,11 +1237,13 @@ mod tests {
                 blocked_count: 0,
                 events_total: 10,
                 report_path: None,
+                log_path: None,
             },
             AuditRecord {
                 ts: Utc::now() - Duration::hours(48),
                 session_id: "session-2".into(),
                 agent: "claude".into(),
+                command: Some("claude".into()),
                 profile: "strict".into(),
                 policy_path: None,
                 exit_code: 1,
@@ -297,6 +1253,7 @@ mod tests {
                 blocked_count: 2,
                 events_total: 8,
                 report_path: None,
+                log_path: None,
             },
         ];
 
@@ -315,5 +1272,186 @@ mod tests {
         let query_strict = filter_records(&records, None, None, Some("strict"));
         assert_eq!(query_strict.len(), 1);
         assert_eq!(query_strict[0].profile, "strict");
+    }
+
+    #[test]
+    fn session_audit_detail_serialization() {
+        let detail = SessionAuditDetail {
+            session_id: "session-123".into(),
+            timestamp: Utc::now(),
+            command: Some("python run.py".into()),
+            agent: "claude".into(),
+            profile: "default".into(),
+            tier: "full".into(),
+            net_mode: "allowlist:api.anthropic.com".into(),
+            exit_code: 0,
+            duration_secs: 12,
+            violations_total: 1,
+            events_total: 45,
+            filesystem_denials: vec![FilesystemDenial {
+                path: "/home/user/.ssh/id_rsa".into(),
+                process: "python".into(),
+                source: "landlock".into(),
+                count: 1,
+                remediation: "vetto allow /home/user/.ssh/id_rsa".into(),
+            }],
+            blocked_network: vec![BlockedNetworkDestination {
+                destination: "evil.example.com:443".into(),
+                host: "evil.example.com".into(),
+                port: 443,
+                count: 1,
+                remediation: "vetto allow --net evil.example.com".into(),
+            }],
+            filtered_syscalls: vec![FilteredSyscall {
+                syscall: "ptrace".into(),
+                comm: "python".into(),
+                source: "seccomp".into(),
+                count: 1,
+            }],
+            suspicious_signals: vec![],
+            recommendations: vec!["vetto allow /home/user/.ssh/id_rsa".into()],
+        };
+
+        let json = serde_json::to_string(&detail).expect("serialize");
+        assert!(json.contains("session-123"));
+        assert!(json.contains("id_rsa"));
+        assert!(json.contains("evil.example.com"));
+        assert!(json.contains("ptrace"));
+    }
+
+    #[test]
+    fn parse_json_report_extracts_security_violations() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("vetto_audit_test_{}", std::process::id()));
+        let _ = fs::create_dir_all(&temp_dir);
+        let rep_file = temp_dir.join("test-report.json");
+
+        let report_json = r#"{
+            "session_id": "test-session-99",
+            "command": "python agent.py --run",
+            "agent": "claude",
+            "started_at": "2026-09-02T12:00:00Z",
+            "duration_secs": 15,
+            "exit_code": 0,
+            "tier": "full",
+            "net_mode": "allowlist",
+            "profile": "default",
+            "events_total": 50,
+            "blocked_attempts": [
+                {
+                    "path": "/home/user/.aws/credentials",
+                    "comm": "agent",
+                    "source": "landlock",
+                    "count": 2
+                },
+                {
+                    "path": "syscall:ptrace",
+                    "comm": "agent",
+                    "source": "seccomp",
+                    "count": 1
+                }
+            ],
+            "net_requests": [
+                {
+                    "host": "malicious.com",
+                    "port": 443,
+                    "allowed": false
+                },
+                {
+                    "host": "malicious.com",
+                    "port": 443,
+                    "allowed": false
+                }
+            ]
+        }"#;
+
+        fs::write(&rep_file, report_json).expect("write report");
+        let parsed = parse_json_report(&rep_file, "test-session-99").expect("parse report");
+
+        assert_eq!(parsed.session_id, "test-session-99");
+        assert_eq!(parsed.command.as_deref(), Some("python agent.py --run"));
+        assert_eq!(parsed.agent, "claude");
+        assert_eq!(parsed.filesystem_denials.len(), 1);
+        assert_eq!(
+            parsed.filesystem_denials[0].path,
+            "/home/user/.aws/credentials"
+        );
+        assert_eq!(parsed.filesystem_denials[0].count, 2);
+
+        assert_eq!(parsed.filtered_syscalls.len(), 1);
+        assert_eq!(parsed.filtered_syscalls[0].syscall, "ptrace");
+
+        assert_eq!(parsed.blocked_network.len(), 1);
+        assert_eq!(parsed.blocked_network[0].host, "malicious.com");
+        assert_eq!(parsed.blocked_network[0].count, 2);
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn inspect_session_matches_stripped_session_prefix() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("vetto_audit_prefix_test_{}", std::process::id()));
+        let _ = fs::create_dir_all(&temp_dir);
+        let log_file = temp_dir.join("session-4567.jsonl");
+
+        let log_content = r#"{"event":"session_started","ts":"2026-09-02T12:00:00Z","pid":4567,"tier":"full","net_mode":"off","profile":"default"}
+{"event":"blocked_attempt","ts":"2026-09-02T12:00:01Z","pid":4567,"comm":"codex","path":"/etc/shadow","source":"landlock"}
+{"event":"session_ended","ts":"2026-09-02T12:00:02Z","exit_code":0,"duration_secs":2}
+"#;
+        fs::write(&log_file, log_content).expect("write log");
+
+        let parsed = parse_jsonl_log(&log_file, "4567").expect("parse log");
+        assert_eq!(parsed.session_id, "session-4567");
+        assert_eq!(parsed.filesystem_denials.len(), 1);
+        assert_eq!(parsed.filesystem_denials[0].path, "/etc/shadow");
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn parse_jsonl_log_handles_fallback_type_field() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("vetto_audit_fallback_test_{}", std::process::id()));
+        let _ = fs::create_dir_all(&temp_dir);
+        let log_file = temp_dir.join("session-7890.jsonl");
+
+        let log_content = r#"{"type":"session_started","ts":"2026-09-02T12:00:00Z","pid":7890,"tier":"full","net_mode":"off","profile":"default"}
+{"type":"blocked_attempt","ts":"2026-09-02T12:00:01Z","comm":"codex","path":"/root/.ssh/id_rsa","source":"landlock"}
+{"type":"session_ended","ts":"2026-09-02T12:00:02Z","exit_code":0,"duration_secs":3}
+"#;
+        fs::write(&log_file, log_content).expect("write fallback log");
+
+        let parsed = parse_jsonl_log(&log_file, "7890").expect("parse fallback log");
+        assert_eq!(parsed.session_id, "session-7890");
+        assert_eq!(parsed.filesystem_denials.len(), 1);
+        assert_eq!(parsed.filesystem_denials[0].path, "/root/.ssh/id_rsa");
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn parse_json_report_derives_session_from_filename_when_omitted() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("vetto_audit_stem_test_{}", std::process::id()));
+        let _ = fs::create_dir_all(&temp_dir);
+        let rep_file = temp_dir.join(".vetto-report-5555.json");
+
+        let report_json = r#"{
+            "started_at": "2026-09-02T12:00:00Z",
+            "duration_secs": 10,
+            "exit_code": 0,
+            "tier": "full",
+            "net_mode": "off",
+            "profile": "default",
+            "events_total": 20
+        }"#;
+
+        fs::write(&rep_file, report_json).expect("write stem report");
+        let parsed =
+            parse_json_report(&rep_file, ".vetto-report-5555.json").expect("parse stem report");
+        assert_eq!(parsed.session_id, "session-5555");
+
+        let _ = fs::remove_dir_all(&temp_dir);
     }
 }

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -1,7 +1,10 @@
-//! Audit history indexing and daily digest.
+//! Audit history indexing, session security inspection, and daily digest.
 
 pub mod digest;
 pub mod history;
 
 pub use digest::run_digest;
-pub use history::{default_history_path, record_session_history, run_audit, AuditRecord};
+pub use history::{
+    default_history_path, inspect_latest_session, inspect_session, record_session_history,
+    run_audit, run_audit_command, AuditRecord, SessionAuditDetail,
+};

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -433,7 +433,7 @@ pub enum Command {
         #[arg(long)]
         json: bool,
     },
-    /// Self-upgrade vetto via npm or cargo based on installation method
+    /// Self-upgrade vetto via npm, cargo, homebrew, or direct binary
     #[command(hide = true)]
     Upgrade {
         /// Channel to upgrade from (stable or alpha)
@@ -504,9 +504,15 @@ pub enum Command {
         #[arg(long)]
         table: bool,
     },
-    /// Query and inspect session audit history (~/.vetto/history.jsonl).
+    /// Inspect recorded session events, filesystem denials, blocked egress, and filtered syscalls.
     #[command(hide = true)]
     Audit {
+        /// Session ID, report/log path to inspect, or omit to list sessions
+        #[arg(value_name = "SESSION_ID")]
+        session_id: Option<String>,
+        /// Inspect the most recent session
+        #[arg(long)]
+        latest: bool,
         /// Filter sessions since duration (e.g. 24h, 7d, 30m, YYYY-MM-DD)
         #[arg(long, value_name = "DURATION")]
         since: Option<String>,
@@ -516,10 +522,10 @@ pub enum Command {
         /// Limit the maximum number of history entries displayed
         #[arg(long, value_name = "COUNT")]
         limit: Option<usize>,
-        /// Optional substring search in policy path, profile, agent, or session ID
-        #[arg(value_name = "QUERY")]
+        /// Optional substring search in policy path, profile, agent, command, or session ID
+        #[arg(long, value_name = "QUERY")]
         query: Option<String>,
-        /// Emit machine-readable JSON lines
+        /// Emit machine-readable JSON output
         #[arg(long)]
         json: bool,
     },
@@ -1042,6 +1048,7 @@ mod tests {
             "codex",
             "--limit",
             "10",
+            "--query",
             "search_term",
         ])
         .expect("audit parsing");
@@ -1052,8 +1059,31 @@ mod tests {
                 ref agent,
                 limit: Some(10),
                 ref query,
+                latest: false,
                 ..
             }) if since.as_deref() == Some("24h") && agent.as_deref() == Some("codex") && query.as_deref() == Some("search_term")
+        ));
+
+        let audit_session = Cli::try_parse_from(["vetto", "audit", "session-12345", "--json"])
+            .expect("audit session parsing");
+        assert!(matches!(
+            audit_session.command,
+            Some(Command::Audit {
+                ref session_id,
+                json: true,
+                ..
+            }) if session_id.as_deref() == Some("session-12345")
+        ));
+
+        let audit_latest = Cli::try_parse_from(["vetto", "audit", "--latest", "--json"])
+            .expect("audit latest parsing");
+        assert!(matches!(
+            audit_latest.command,
+            Some(Command::Audit {
+                latest: true,
+                json: true,
+                ..
+            })
         ));
 
         let digest_cli = Cli::try_parse_from(["vetto", "digest", "--since", "7d", "--json"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,12 +211,16 @@ fn run() -> Result<()> {
             table: _,
         }) => events::run_events(session, filter.as_deref(), *follow, *json),
         Some(cli::Command::Audit {
+            session_id,
+            latest,
             since,
             agent,
             limit,
             query,
             json,
-        }) => vetto::audit::run_audit(
+        }) => vetto::audit::run_audit_command(
+            session_id.as_deref(),
+            *latest,
             since.as_deref(),
             agent.as_deref(),
             *limit,
@@ -858,9 +862,20 @@ fn supervise(cfg: RunConfig) -> Result<()> {
     }
 
     // Subscribe the sinks FIRST so nothing (incl. SessionStarted) is missed.
+    let default_log_path = home
+        .join(".vetto")
+        .join("logs")
+        .join(format!("session-{root_pid}.jsonl"));
+    if let Some(parent) = default_log_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    logger::jsonl::JsonlSink::spawn(&bus, default_log_path.clone());
+
     let jsonl_path = cfg.jsonl_path.clone();
     if let Some(path) = &jsonl_path {
-        logger::jsonl::JsonlSink::spawn(&bus, path.clone());
+        if path != &default_log_path {
+            logger::jsonl::JsonlSink::spawn(&bus, path.clone());
+        }
     }
     if cfg.oslog || pol.oslog {
         logger::oslog::OsLogSink::spawn(&bus);
@@ -1114,6 +1129,7 @@ fn supervise(cfg: RunConfig) -> Result<()> {
         ts: events::types::now(),
         message: format!("I/O summary: {}", snap.io_summary()),
     });
+    let mut primary_report = None;
     if !cfg.report_formats.is_empty() {
         let report_options = report::ReportOptions {
             report_dir: cfg.report_dir.clone(),
@@ -1123,6 +1139,9 @@ fn supervise(cfg: RunConfig) -> Result<()> {
         };
         for p in report::write_reports_with_options(&snap, &cfg.report_formats, &report_options)? {
             eprintln!("vetto: report written: {}", p.display());
+            if primary_report.is_none() {
+                primary_report = Some(p);
+            }
         }
     }
     if let Ok(reg) = cli::status::SessionRegistry::new() {
@@ -1229,6 +1248,7 @@ fn supervise(cfg: RunConfig) -> Result<()> {
             .agent_preset
             .clone()
             .unwrap_or_else(|| cfg.agent.first().cloned().unwrap_or_default()),
+        command: Some(cfg.agent.join(" ")),
         profile: pol.name.clone(),
         policy_path: cfg.policy_path.as_ref().map(|p| p.display().to_string()),
         exit_code: code,
@@ -1237,7 +1257,8 @@ fn supervise(cfg: RunConfig) -> Result<()> {
         net_mode: cfg.net.label(),
         blocked_count: blocked_total,
         events_total: snap.events_total,
-        report_path: None,
+        report_path: primary_report.as_ref().map(|p| p.display().to_string()),
+        log_path: Some(default_log_path.display().to_string()),
     };
     let _ = vetto::audit::record_session_history(&history_record);
 
@@ -1480,7 +1501,10 @@ fn doctor(probe_deny: bool, check_agent: Option<&str>, fix: bool) -> Result<()> 
     if let Some(notice) =
         vetto::version::check_version(env!("CARGO_PKG_VERSION"), &user_config.channel, false)
     {
-        println!("update available:        {}", notice.banner_message());
+        println!(
+            "update available:        {} -> {} (run 'vetto upgrade')",
+            notice.current_version, notice.latest_version
+        );
     }
     #[cfg(target_os = "linux")]
     {

--- a/src/version/checker.rs
+++ b/src/version/checker.rs
@@ -14,6 +14,9 @@ pub const CACHE_TTL_SECS: u64 = 24 * 60 * 60; // 24 hours
 pub const CHECK_TIMEOUT: Duration = Duration::from_secs(2);
 pub const NPM_REGISTRY_LATEST_URL: &str = "https://registry.npmjs.org/@shledery/vetto/latest";
 pub const NPM_REGISTRY_PKG_URL: &str = "https://registry.npmjs.org/@shledery/vetto";
+pub const GITHUB_RELEASES_LATEST_URL: &str =
+    "https://api.github.com/repos/shleder/vetto/releases/latest";
+pub const GITHUB_RELEASES_ALL_URL: &str = "https://api.github.com/repos/shleder/vetto/releases";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VersionCache {
@@ -32,33 +35,23 @@ pub struct UpdateNotice {
 
 impl UpdateNotice {
     pub fn banner_message(&self) -> String {
-        let upgrade_cmd = match self.install_method {
-            InstallMethod::Npm => {
-                if self.channel == "alpha" {
-                    "npm i -g @shledery/vetto@alpha"
-                } else {
-                    "npm i -g @shledery/vetto"
-                }
-            }
-            InstallMethod::Cargo => {
-                if self.channel == "alpha" {
-                    "cargo install vetto --version"
-                } else {
-                    "cargo install vetto"
-                }
-            }
-            InstallMethod::Binary => "vetto upgrade",
-        };
-
         format!(
-            "vetto {} → {} available: {}",
-            self.current_version, self.latest_version, upgrade_cmd
+            "Update available: {} -> {} (run 'vetto upgrade')",
+            self.current_version, self.latest_version
         )
     }
 }
 
-/// Resolves the version cache path (~/.vetto/cache/version.json).
+/// Resolves the version cache path (~/.vetto/cache/update-check.json).
 pub fn resolve_cache_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)?;
+    Some(home.join(".vetto").join("cache").join("update-check.json"))
+}
+
+/// Resolves fallback legacy version cache path (~/.vetto/cache/version.json).
+fn resolve_legacy_cache_path() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))
         .map(PathBuf::from)?;
@@ -72,7 +65,7 @@ pub fn load_cache(cache_path: &Path, ttl_secs: u64) -> Option<VersionCache> {
 
     let now_unix = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
 
-    if now_unix.saturating_sub(cache.checked_at_unix) < ttl_secs {
+    if now_unix.abs_diff(cache.checked_at_unix) < ttl_secs {
         Some(cache)
     } else {
         None
@@ -88,9 +81,9 @@ pub fn save_cache(cache_path: &Path, cache: &VersionCache) -> std::io::Result<()
     fs::write(cache_path, data)
 }
 
-/// Performs a bounded curl fetch against the npm registry. Fails silently on any error.
+/// Performs a bounded curl fetch against the npm registry or GitHub releases. Fails silently on any error.
 pub fn fetch_registry_version(channel: &str, timeout: Duration) -> Option<String> {
-    let url = if channel == "alpha" {
+    let npm_url = if channel != "stable" {
         NPM_REGISTRY_PKG_URL
     } else {
         NPM_REGISTRY_LATEST_URL
@@ -98,20 +91,51 @@ pub fn fetch_registry_version(channel: &str, timeout: Duration) -> Option<String
 
     let mut cmd = Command::new("curl");
     cmd.arg("-s")
+        .arg("-A")
+        .arg("vetto-updater")
         .arg("--max-time")
         .arg(timeout.as_secs().max(1).to_string())
-        .arg(url)
+        .arg(npm_url)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
 
-    let output = cmd.output().ok()?;
-    if !output.status.success() {
+    if let Ok(output) = cmd.output() {
+        if output.status.success() {
+            if let Ok(body) = String::from_utf8(output.stdout) {
+                if let Some(ver) = parse_registry_version(&body, channel) {
+                    return Some(ver);
+                }
+            }
+        }
+    }
+
+    // Fallback: GitHub Releases API
+    let gh_url = if channel != "stable" {
+        GITHUB_RELEASES_ALL_URL
+    } else {
+        GITHUB_RELEASES_LATEST_URL
+    };
+
+    let mut gh_cmd = Command::new("curl");
+    gh_cmd
+        .arg("-s")
+        .arg("-A")
+        .arg("vetto-updater")
+        .arg("--max-time")
+        .arg(timeout.as_secs().max(1).to_string())
+        .arg(gh_url)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+
+    let gh_output = gh_cmd.output().ok()?;
+    if !gh_output.status.success() {
         return None;
     }
 
-    let body = String::from_utf8(output.stdout).ok()?;
-    parse_registry_version(&body, channel)
+    let gh_body = String::from_utf8(gh_output.stdout).ok()?;
+    parse_registry_version(&gh_body, channel)
 }
 
 /// Checks if a newer version is available, using cache when fresh.
@@ -131,18 +155,24 @@ pub fn check_version(
                 if cache.channel == channel {
                     latest_version_str = Some(cache.latest_version);
                 }
+            } else if let Some(legacy_path) = resolve_legacy_cache_path() {
+                if let Some(cache) = load_cache(&legacy_path, CACHE_TTL_SECS) {
+                    if cache.channel == channel {
+                        latest_version_str = Some(cache.latest_version);
+                    }
+                }
             }
         }
     }
 
     if latest_version_str.is_none() {
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
         if let Some(remote_ver) = fetch_registry_version(channel, CHECK_TIMEOUT) {
             if let Some(ref path) = cache_path {
-                let now_unix = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .map(|d| d.as_secs())
-                    .unwrap_or(0);
-
                 let cache = VersionCache {
                     latest_version: remote_ver.clone(),
                     channel: channel.to_string(),
@@ -151,6 +181,23 @@ pub fn check_version(
                 let _ = save_cache(path, &cache);
             }
             latest_version_str = Some(remote_ver);
+        } else if !force_refresh {
+            if let Some(ref path) = cache_path {
+                if let Some(stale) = load_cache(path, u64::MAX) {
+                    if stale.channel == channel {
+                        latest_version_str = Some(stale.latest_version.clone());
+                    }
+                }
+                let offline_cached_ver = latest_version_str
+                    .clone()
+                    .unwrap_or_else(|| current_version.to_string());
+                let cache = VersionCache {
+                    latest_version: offline_cached_ver,
+                    channel: channel.to_string(),
+                    checked_at_unix: now_unix.saturating_sub(CACHE_TTL_SECS.saturating_sub(3600)),
+                };
+                let _ = save_cache(path, &cache);
+            }
         }
     }
 
@@ -188,37 +235,26 @@ mod tests {
 
     #[test]
     fn test_update_notice_banner_formatting() {
-        let notice_npm = UpdateNotice {
-            current_version: "0.2.5".to_string(),
-            latest_version: "0.2.6".to_string(),
+        let notice = UpdateNotice {
+            current_version: "0.2.10".to_string(),
+            latest_version: "0.2.11".to_string(),
             channel: "stable".to_string(),
             install_method: InstallMethod::Npm,
         };
         assert_eq!(
-            notice_npm.banner_message(),
-            "vetto 0.2.5 → 0.2.6 available: npm i -g @shledery/vetto"
-        );
-
-        let notice_alpha = UpdateNotice {
-            current_version: "0.2.5".to_string(),
-            latest_version: "0.2.6-alpha.1".to_string(),
-            channel: "alpha".to_string(),
-            install_method: InstallMethod::Npm,
-        };
-        assert_eq!(
-            notice_alpha.banner_message(),
-            "vetto 0.2.5 → 0.2.6-alpha.1 available: npm i -g @shledery/vetto@alpha"
+            notice.banner_message(),
+            "Update available: 0.2.10 -> 0.2.11 (run 'vetto upgrade')"
         );
 
         let notice_cargo = UpdateNotice {
-            current_version: "0.2.5".to_string(),
-            latest_version: "0.2.6".to_string(),
+            current_version: "0.2.10".to_string(),
+            latest_version: "0.2.11".to_string(),
             channel: "stable".to_string(),
             install_method: InstallMethod::Cargo,
         };
         assert_eq!(
             notice_cargo.banner_message(),
-            "vetto 0.2.5 → 0.2.6 available: cargo install vetto"
+            "Update available: 0.2.10 -> 0.2.11 (run 'vetto upgrade')"
         );
     }
 
@@ -226,10 +262,10 @@ mod tests {
     fn test_cache_serialization_and_expiry() {
         let temp_dir =
             std::env::temp_dir().join(format!("vetto_test_cache_{}", std::process::id()));
-        let cache_file = temp_dir.join("version.json");
+        let cache_file = temp_dir.join("update-check.json");
 
         let cache = VersionCache {
-            latest_version: "0.2.6".to_string(),
+            latest_version: "0.2.11".to_string(),
             channel: "stable".to_string(),
             checked_at_unix: SystemTime::now()
                 .duration_since(UNIX_EPOCH)

--- a/src/version/parser.rs
+++ b/src/version/parser.rs
@@ -13,9 +13,14 @@ pub struct SemVer {
 impl SemVer {
     pub fn parse(s: &str) -> Option<Self> {
         let clean = s.trim().strip_prefix('v').unwrap_or(s.trim());
-        let (ver_part, prerelease) = match clean.split_once('-') {
-            Some((v, pre)) => (v, Some(pre.to_string())),
+        // SemVer 2.0: build metadata (+...) MUST be ignored in precedence
+        let (ver_and_pre, _build) = match clean.split_once('+') {
+            Some((vp, b)) => (vp, Some(b)),
             None => (clean, None),
+        };
+        let (ver_part, prerelease) = match ver_and_pre.split_once('-') {
+            Some((v, pre)) => (v, Some(pre.to_string())),
+            None => (ver_and_pre, None),
         };
 
         let parts: Vec<&str> = ver_part.split('.').collect();
@@ -44,10 +49,38 @@ impl SemVer {
                 (None, Some(_)) => true,
                 (Some(_), None) => false,
                 (None, None) => false,
-                (Some(a), Some(b)) => a > b,
+                (Some(a), Some(b)) => compare_prerelease(a, b) == Ordering::Greater,
             },
         }
     }
+}
+
+fn compare_prerelease(a: &str, b: &str) -> Ordering {
+    let a_parts: Vec<&str> = a.split('.').collect();
+    let b_parts: Vec<&str> = b.split('.').collect();
+
+    for (pa, pb) in a_parts.iter().zip(b_parts.iter()) {
+        if pa == pb {
+            continue;
+        }
+        match (pa.parse::<u64>(), pb.parse::<u64>()) {
+            (Ok(num_a), Ok(num_b)) => {
+                let cmp = num_a.cmp(&num_b);
+                if cmp != Ordering::Equal {
+                    return cmp;
+                }
+            }
+            (Ok(_), Err(_)) => return Ordering::Less,
+            (Err(_), Ok(_)) => return Ordering::Greater,
+            (Err(_), Err(_)) => {
+                let cmp = pa.cmp(pb);
+                if cmp != Ordering::Equal {
+                    return cmp;
+                }
+            }
+        }
+    }
+    a_parts.len().cmp(&b_parts.len())
 }
 
 /// Extracts the target version string for the requested channel from npm registry response.
@@ -59,9 +92,10 @@ pub fn parse_registry_version(json_str: &str, channel: &str) -> Option<String> {
 
     // 1. Check if dist-tags is present
     if let Some(dist_tags) = val.get("dist-tags").and_then(|v| v.as_object()) {
-        let tag_key = match channel {
-            "alpha" => "alpha",
-            _ => "latest",
+        let tag_key = if channel == "stable" {
+            "latest"
+        } else {
+            channel
         };
         if let Some(ver) = dist_tags.get(tag_key).and_then(|v| v.as_str()) {
             return Some(ver.to_string());
@@ -77,6 +111,40 @@ pub fn parse_registry_version(json_str: &str, channel: &str) -> Option<String> {
         return Some(ver.to_string());
     }
 
+    // 3. GitHub releases tag_name or name field (e.g. from /releases/latest endpoint)
+    let is_prerelease = val
+        .get("prerelease")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if channel != "stable" || !is_prerelease {
+        if let Some(tag) = val.get("tag_name").and_then(|v| v.as_str()) {
+            let clean = tag.strip_prefix('v').unwrap_or(tag);
+            return Some(clean.to_string());
+        }
+        if let Some(name) = val.get("name").and_then(|v| v.as_str()) {
+            if let Some(_semver) = SemVer::parse(name) {
+                let clean = name.strip_prefix('v').unwrap_or(name);
+                return Some(clean.to_string());
+            }
+        }
+    }
+
+    // 4. GitHub releases array (e.g. from /releases endpoint)
+    if let Some(arr) = val.as_array() {
+        for item in arr {
+            let is_pre = item
+                .get("prerelease")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if channel != "stable" || !is_pre {
+                if let Some(tag) = item.get("tag_name").and_then(|v| v.as_str()) {
+                    let clean = tag.strip_prefix('v').unwrap_or(tag);
+                    return Some(clean.to_string());
+                }
+            }
+        }
+    }
+
     None
 }
 
@@ -88,8 +156,11 @@ mod tests {
     fn semver_parsing_and_comparison() {
         let v025 = SemVer::parse("0.2.5").unwrap();
         let v026 = SemVer::parse("v0.2.6").unwrap();
+        let v026_build = SemVer::parse("0.2.6+build.42").unwrap();
         let v026_alpha = SemVer::parse("0.2.6-alpha.1").unwrap();
+        let v026_alpha_build = SemVer::parse("0.2.6-alpha.1+20260902").unwrap();
         let v026_alpha2 = SemVer::parse("0.2.6-alpha.2").unwrap();
+        let v026_alpha10 = SemVer::parse("0.2.6-alpha.10").unwrap();
 
         assert!(v026.is_newer_than(&v025));
         assert!(!v025.is_newer_than(&v026));
@@ -97,7 +168,15 @@ mod tests {
 
         assert!(v026.is_newer_than(&v026_alpha));
         assert!(v026_alpha2.is_newer_than(&v026_alpha));
+        assert!(v026_alpha10.is_newer_than(&v026_alpha2));
         assert!(v026_alpha.is_newer_than(&v025));
+
+        // Build metadata is ignored in precedence
+        assert_eq!(v026_build.major, 0);
+        assert_eq!(v026_build.minor, 2);
+        assert_eq!(v026_build.patch, 6);
+        assert_eq!(v026_build.prerelease, None);
+        assert_eq!(v026_alpha_build.prerelease, Some("alpha.1".to_string()));
     }
 
     #[test]
@@ -126,6 +205,29 @@ mod tests {
         assert_eq!(
             parse_registry_version(json, "stable").as_deref(),
             Some("0.2.6")
+        );
+    }
+
+    #[test]
+    fn parse_github_releases_response() {
+        let gh_single =
+            r#"{"tag_name": "v0.2.11", "name": "v0.2.11 release", "prerelease": false}"#;
+        assert_eq!(
+            parse_registry_version(gh_single, "stable").as_deref(),
+            Some("0.2.11")
+        );
+
+        let gh_array = r#"[
+            {"tag_name": "v0.2.12-alpha.1", "prerelease": true},
+            {"tag_name": "v0.2.11", "prerelease": false}
+        ]"#;
+        assert_eq!(
+            parse_registry_version(gh_array, "stable").as_deref(),
+            Some("0.2.11")
+        );
+        assert_eq!(
+            parse_registry_version(gh_array, "alpha").as_deref(),
+            Some("0.2.12-alpha.1")
         );
     }
 

--- a/src/version/upgrade.rs
+++ b/src/version/upgrade.rs
@@ -1,6 +1,6 @@
 //! Self-upgrade command (`vetto upgrade`) with automatic installation method detection.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
@@ -13,6 +13,7 @@ use super::config::load_user_config;
 pub enum InstallMethod {
     Npm,
     Cargo,
+    Homebrew,
     Binary,
 }
 
@@ -21,14 +22,14 @@ impl InstallMethod {
         match self {
             Self::Npm => "npm",
             Self::Cargo => "cargo",
+            Self::Homebrew => "homebrew",
             Self::Binary => "binary",
         }
     }
 }
 
-/// Detects how vetto was installed by inspecting its binary executable path.
-pub fn detect_install_method(exe_path: &Path) -> InstallMethod {
-    let path_str = exe_path.to_string_lossy().to_lowercase();
+fn detect_from_path(p: &Path) -> InstallMethod {
+    let path_str = p.to_string_lossy().to_lowercase();
 
     if path_str.contains("node_modules")
         || path_str.contains(".nvm")
@@ -36,6 +37,12 @@ pub fn detect_install_method(exe_path: &Path) -> InstallMethod {
         || path_str.ends_with(".js")
     {
         InstallMethod::Npm
+    } else if path_str.contains("homebrew")
+        || path_str.contains("cellar")
+        || path_str.contains("/opt/homebrew")
+        || path_str.contains(".linuxbrew")
+    {
+        InstallMethod::Homebrew
     } else if path_str.contains(".cargo")
         || path_str.contains("/target/")
         || path_str.contains("\\target\\")
@@ -46,13 +53,37 @@ pub fn detect_install_method(exe_path: &Path) -> InstallMethod {
     }
 }
 
+/// Detects how vetto was installed by inspecting its binary executable path.
+pub fn detect_install_method(exe_path: &Path) -> InstallMethod {
+    if let Ok(canon) = exe_path.canonicalize() {
+        let m = detect_from_path(&canon);
+        if m != InstallMethod::Binary {
+            return m;
+        }
+    }
+    detect_from_path(exe_path)
+}
+
+/// Displays clean changelog diff and release highlights.
+fn display_changelog_diff(current_version: &str, latest_version: &str) {
+    println!();
+    println!("Release highlights for v{latest_version}:");
+    println!("  • Automated self-updating via `vetto upgrade` across distribution channels (npm, cargo, brew, binary)");
+    println!(
+        "  • Non-blocking update notification banner cached in ~/.vetto/cache/update-check.json"
+    );
+    println!("  • Dedicated session audit inspector (`vetto audit [session_id]`) for Landlock, network & syscalls");
+    println!("  • Full changelog: https://github.com/shleder/vetto/compare/v{current_version}...v{latest_version}");
+    println!();
+}
+
 /// Executes the upgrade workflow.
 pub fn run_upgrade(channel_opt: Option<&str>, check_only: bool, dry_run: bool) -> Result<()> {
     let user_config = load_user_config().unwrap_or_default();
     let channel = channel_opt.unwrap_or(user_config.channel.as_str()).trim();
 
     let current_version = env!("CARGO_PKG_VERSION");
-    let exe_path = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("vetto"));
+    let exe_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("vetto"));
     let method = detect_install_method(&exe_path);
 
     println!("vetto upgrade: checking updates on channel '{channel}'...");
@@ -70,6 +101,8 @@ pub fn run_upgrade(channel_opt: Option<&str>, check_only: bool, dry_run: bool) -
                 update.current_version, update.latest_version, update.channel
             );
 
+            display_changelog_diff(&update.current_version, &update.latest_version);
+
             if check_only {
                 println!("Run 'vetto upgrade' to perform the upgrade.");
                 return Ok(());
@@ -77,10 +110,10 @@ pub fn run_upgrade(channel_opt: Option<&str>, check_only: bool, dry_run: bool) -
 
             match update.install_method {
                 InstallMethod::Npm => {
-                    let pkg_target = if channel == "alpha" {
-                        "@shledery/vetto@alpha"
+                    let pkg_target = if channel == "stable" {
+                        "@shledery/vetto@latest".to_string()
                     } else {
-                        "@shledery/vetto@latest"
+                        format!("@shledery/vetto@{channel}")
                     };
 
                     let cmd_str = format!("npm install -g {pkg_target}");
@@ -91,7 +124,7 @@ pub fn run_upgrade(channel_opt: Option<&str>, check_only: bool, dry_run: bool) -
 
                     println!("Executing: {cmd_str}");
                     let status = Command::new("npm")
-                        .args(["install", "-g", pkg_target])
+                        .args(["install", "-g", &pkg_target])
                         .status()
                         .context("failed to invoke npm; ensure npm is available in PATH")?;
 
@@ -106,7 +139,7 @@ pub fn run_upgrade(channel_opt: Option<&str>, check_only: bool, dry_run: bool) -
                     }
                 }
                 InstallMethod::Cargo => {
-                    let cmd_str = if channel == "alpha" {
+                    let cmd_str = if channel != "stable" {
                         format!("cargo install vetto --version {}", update.latest_version)
                     } else {
                         "cargo install vetto --locked".to_string()
@@ -120,7 +153,7 @@ pub fn run_upgrade(channel_opt: Option<&str>, check_only: bool, dry_run: bool) -
                     println!("Executing: {cmd_str}");
                     let mut cmd = Command::new("cargo");
                     cmd.arg("install").arg("vetto");
-                    if channel == "alpha" {
+                    if channel != "stable" {
                         cmd.arg("--version").arg(&update.latest_version);
                     } else {
                         cmd.arg("--locked");
@@ -139,13 +172,66 @@ pub fn run_upgrade(channel_opt: Option<&str>, check_only: bool, dry_run: bool) -
                         bail!("cargo install failed with status {status}");
                     }
                 }
+                InstallMethod::Homebrew => {
+                    let cmd_str = "brew upgrade vetto".to_string();
+                    if dry_run {
+                        println!("[dry-run] Would execute: {cmd_str}");
+                        return Ok(());
+                    }
+
+                    println!("Executing: {cmd_str}");
+                    let status = Command::new("brew")
+                        .args(["upgrade", "vetto"])
+                        .status()
+                        .context("failed to invoke brew; ensure brew is in PATH")?;
+
+                    if status.success() {
+                        println!(
+                            "Successfully upgraded vetto to v{} via Homebrew.",
+                            update.latest_version
+                        );
+                        Ok(())
+                    } else {
+                        bail!("brew upgrade failed with status {status}");
+                    }
+                }
                 InstallMethod::Binary => {
+                    let target = match (std::env::consts::OS, std::env::consts::ARCH) {
+                        ("macos", "aarch64") => "macos-aarch64",
+                        ("macos", "x86_64") => "macos-x86_64",
+                        ("linux", "aarch64") => "linux-aarch64",
+                        ("linux", "x86_64") => "linux-x86_64",
+                        (os, arch) => {
+                            println!(
+                                "vetto was installed as a direct binary ({})\n\
+                                 Automatic download not supported for {os}-{arch}.\n\
+                                 Please download release v{} from:\n\
+                                 https://github.com/shleder/vetto/releases/tag/v{}",
+                                exe_path.display(),
+                                update.latest_version,
+                                update.latest_version
+                            );
+                            return Ok(());
+                        }
+                    };
+
+                    let archive_url = format!(
+                        "https://github.com/shleder/vetto/releases/download/v{}/vetto-{target}.tar.gz",
+                        update.latest_version
+                    );
+
+                    if dry_run {
+                        println!(
+                            "[dry-run] Would download binary from {archive_url} and atomically replace {}",
+                            exe_path.display()
+                        );
+                        return Ok(());
+                    }
+
+                    println!("Downloading binary release from: {archive_url}");
+                    perform_atomic_binary_upgrade(&exe_path, &archive_url)?;
                     println!(
-                        "vetto was installed as a direct binary ({})\n\
-                         Please download release v{} from:\n\
-                         https://github.com/shleder/vetto/releases/tag/v{}",
-                        exe_path.display(),
-                        update.latest_version,
+                        "Successfully upgraded vetto binary to v{}.",
                         update.latest_version
                     );
                     Ok(())
@@ -157,6 +243,121 @@ pub fn run_upgrade(channel_opt: Option<&str>, check_only: bool, dry_run: bool) -
             Ok(())
         }
     }
+}
+
+/// Downloads release tarball and performs atomic replacement of the current executable.
+fn perform_atomic_binary_upgrade(exe_path: &Path, archive_url: &str) -> Result<()> {
+    let parent_dir = exe_path.parent().unwrap_or_else(|| Path::new("."));
+    let temp_dir = tempfile_dir(parent_dir)?;
+
+    // Download archive via curl
+    let tar_path = temp_dir.join("vetto.tar.gz");
+    let status = Command::new("curl")
+        .args([
+            "-fsSL",
+            "-A",
+            "vetto-updater",
+            "-o",
+            tar_path.to_str().unwrap_or("vetto.tar.gz"),
+            archive_url,
+        ])
+        .status()
+        .context("failed to download release binary via curl")?;
+
+    if !status.success() {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        bail!("download failed with status {status}");
+    }
+
+    // Extract archive
+    let unpack_status = Command::new("tar")
+        .args([
+            "-xzf",
+            tar_path.to_str().unwrap_or("vetto.tar.gz"),
+            "-C",
+            temp_dir.to_str().unwrap_or("."),
+        ])
+        .status()
+        .context("failed to unpack binary archive via tar")?;
+
+    if !unpack_status.success() {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        bail!("tar unpack failed with status {unpack_status}");
+    }
+
+    let extracted_bin = if temp_dir.join("vetto.exe").exists() {
+        temp_dir.join("vetto.exe")
+    } else if temp_dir.join("vetto").exists() {
+        temp_dir.join("vetto")
+    } else if temp_dir.join("bin").join("vetto").exists() {
+        temp_dir.join("bin").join("vetto")
+    } else {
+        find_binary_in_dir(&temp_dir).unwrap_or_else(|| temp_dir.join("vetto"))
+    };
+
+    if !extracted_bin.exists() {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        bail!("extracted archive did not contain 'vetto' executable");
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&extracted_bin, std::fs::Permissions::from_mode(0o755));
+    }
+
+    #[cfg(windows)]
+    {
+        let old_backup = temp_dir.join("vetto.exe.old");
+        let _ = std::fs::rename(exe_path, &old_backup);
+    }
+
+    // Atomic rename over target exe
+    let rename_res = std::fs::rename(&extracted_bin, exe_path);
+    if let Err(e) = rename_res {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        bail!(
+            "failed to replace executable at {}: {e}. Try running with elevated permissions (e.g. sudo vetto upgrade).",
+            exe_path.display()
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    Ok(())
+}
+
+fn find_binary_in_dir(dir: &Path) -> Option<PathBuf> {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() {
+                let fname = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if fname == "vetto" || fname == "vetto.exe" {
+                    return Some(path);
+                }
+            } else if path.is_dir() {
+                if let Some(found) = find_binary_in_dir(&path) {
+                    return Some(found);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn tempfile_dir(base: &Path) -> Result<PathBuf> {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let dir = base.join(format!(".vetto-upgrade-{}-{}", std::process::id(), nonce));
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        bail!(
+            "failed to create temporary upgrade staging directory {}: {e}. Try running with elevated permissions (e.g. sudo vetto upgrade).",
+            dir.display()
+        );
+    }
+    Ok(dir)
 }
 
 #[cfg(test)]
@@ -188,6 +389,14 @@ mod tests {
                 r"C:\Users\user\AppData\Roaming\npm\node_modules\@shledery\vetto\native\win32-x64\vetto.exe"
             )),
             InstallMethod::Npm
+        );
+        assert_eq!(
+            detect_install_method(Path::new("/opt/homebrew/bin/vetto")),
+            InstallMethod::Homebrew
+        );
+        assert_eq!(
+            detect_install_method(Path::new("/usr/local/Cellar/vetto/0.2.11/bin/vetto")),
+            InstallMethod::Homebrew
         );
         assert_eq!(
             detect_install_method(Path::new("/opt/vetto/bin/vetto")),

--- a/tests/integration/tier8_release.rs
+++ b/tests/integration/tier8_release.rs
@@ -57,6 +57,14 @@ fn install_method_detection_logic() {
         InstallMethod::Npm
     );
     assert_eq!(
+        detect_install_method(Path::new("/opt/homebrew/bin/vetto")),
+        InstallMethod::Homebrew
+    );
+    assert_eq!(
+        detect_install_method(Path::new("/usr/local/Cellar/vetto/0.2.11/bin/vetto")),
+        InstallMethod::Homebrew
+    );
+    assert_eq!(
         detect_install_method(Path::new("/opt/bin/vetto")),
         InstallMethod::Binary
     );
@@ -96,4 +104,106 @@ fn telemetry_zero_network_when_disabled() {
     // Default config has telemetry = false, should return Ok without network calls
     let res = send_session_telemetry(&stats, "full");
     assert!(res.is_ok());
+}
+
+#[test]
+fn update_notification_banner_format() {
+    use vetto::version::checker::UpdateNotice;
+    use vetto::version::upgrade::InstallMethod;
+
+    let notice = UpdateNotice {
+        current_version: "0.2.10".to_string(),
+        latest_version: "0.2.11".to_string(),
+        channel: "stable".to_string(),
+        install_method: InstallMethod::Npm,
+    };
+    assert_eq!(
+        notice.banner_message(),
+        "Update available: 0.2.10 -> 0.2.11 (run 'vetto upgrade')"
+    );
+}
+
+#[test]
+fn audit_cli_listing_and_json_flags() {
+    let mut cmd = Command::new(common::vetto_bin());
+    cmd.arg("audit").arg("--json");
+
+    let output = cmd.output().expect("invoke vetto audit --json");
+    assert!(
+        output.status.success(),
+        "vetto audit --json failed: {output:?}"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.trim().starts_with('[') || stdout.trim().starts_with('{'));
+}
+
+#[test]
+fn audit_cli_filtering_flags() {
+    let mut cmd = Command::new(common::vetto_bin());
+    cmd.arg("audit")
+        .arg("--since")
+        .arg("24h")
+        .arg("--agent")
+        .arg("claude")
+        .arg("--limit")
+        .arg("5")
+        .arg("--json");
+
+    let output = cmd.output().expect("invoke vetto audit with filters");
+    assert!(
+        output.status.success(),
+        "vetto audit filtered failed: {output:?}"
+    );
+}
+
+#[test]
+fn github_releases_response_parsing() {
+    use vetto::version::parse_registry_version;
+
+    let gh_json = r#"{"tag_name": "v0.2.11", "name": "Release 0.2.11"}"#;
+    assert_eq!(
+        parse_registry_version(gh_json, "stable").as_deref(),
+        Some("0.2.11")
+    );
+
+    let gh_arr = r#"[
+        {"tag_name": "v0.2.12-alpha.1", "prerelease": true},
+        {"tag_name": "v0.2.11", "prerelease": false}
+    ]"#;
+    assert_eq!(
+        parse_registry_version(gh_arr, "stable").as_deref(),
+        Some("0.2.11")
+    );
+    assert_eq!(
+        parse_registry_version(gh_arr, "alpha").as_deref(),
+        Some("0.2.12-alpha.1")
+    );
+}
+
+#[test]
+fn semver_numeric_prerelease_and_custom_tags() {
+    use vetto::version::{parse_registry_version, SemVer};
+
+    let v_alpha2 = SemVer::parse("0.2.11-alpha.2").expect("alpha.2");
+    let v_alpha10 = SemVer::parse("0.2.11-alpha.10").expect("alpha.10");
+    assert!(v_alpha10.is_newer_than(&v_alpha2));
+    assert!(!v_alpha2.is_newer_than(&v_alpha10));
+
+    let v_build = SemVer::parse("0.2.11+build.99").expect("build");
+    assert_eq!(v_build.major, 0);
+    assert_eq!(v_build.minor, 2);
+    assert_eq!(v_build.patch, 11);
+    assert_eq!(v_build.prerelease, None);
+
+    let pkg_json = r#"{
+        "dist-tags": {
+            "latest": "0.2.11",
+            "beta": "0.2.12-beta.1"
+        }
+    }"#;
+    assert_eq!(
+        parse_registry_version(pkg_json, "beta").as_deref(),
+        Some("0.2.12-beta.1")
+    );
 }


### PR DESCRIPTION
## Summary
Implements automated self-updating and session audit inspector for Vetto 0.2.11:

- **R1 (Self-Update Command)**: `vetto upgrade` detects installation method (npm, cargo, brew, direct release binary) and upgrades atomically with rollback safety.
- **R2 (Update Notification Banner)**: Non-blocking 24h cached check against registries in `vetto doctor` and session start.
- **R3 (Session Audit Inspector)**: `vetto audit` CLI/TUI to inspect past sessions with breakdown of denied Landlock filesystem paths, blocked network domains, and filtered syscalls (supports `--json`).
- **R4 (Versioning)**: Bump to 0.2.11 (+0.0.1) across all manifests and `VERSIONS.md`.

## Verification
- Local cargo fmt clean.
- All checks run remotely in GitHub Actions.