### PR TITLE
fix(security): close secret-proxy fail-open on macOS/Windows

### DIFF
--- a/src/cred_broker.rs
+++ b/src/cred_broker.rs
@@ -4,9 +4,12 @@
 //! Secrets listed in `secrets.proxy` are completely stripped from the sandboxed agent's
 //! environment and injected into upstream requests by the host broker only for allowlisted domains.
 
-use anyhow::{bail, Result};
-// `Context` is only used by the Unix broker thread; a blanket allow here
-// would hide the next unused-import regression (cf. pty import incident).
+use anyhow::Result;
+// `bail` serves only the non-Unix stub below, `Context` only the Unix broker
+// thread; per-platform gates instead of a blanket allow, so the next
+// unused-import regression stays visible (cf. pty import incident).
+#[cfg(not(unix))]
+use anyhow::bail;
 #[cfg(unix)]
 use anyhow::Context;
 use std::collections::HashMap;

--- a/src/cred_broker.rs
+++ b/src/cred_broker.rs
@@ -4,8 +4,11 @@
 //! Secrets listed in `secrets.proxy` are completely stripped from the sandboxed agent's
 //! environment and injected into upstream requests by the host broker only for allowlisted domains.
 
-#[allow(unused_imports)]
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
+// `Context` is only used by the Unix broker thread; a blanket allow here
+// would hide the next unused-import regression (cf. pty import incident).
+#[cfg(unix)]
+use anyhow::Context;
 use std::collections::HashMap;
 #[cfg(unix)]
 use std::io::{BufRead, BufReader, Write};
@@ -13,8 +16,10 @@ use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 
-#[allow(unused_imports)]
-use crate::events::{Event, EventBus};
+use crate::events::EventBus;
+// `Event` is only published from the Unix client handler (see above).
+#[cfg(unix)]
+use crate::events::Event;
 
 /// Configuration for the credential broker.
 #[derive(Debug, Clone, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -826,6 +826,16 @@ fn supervise(cfg: RunConfig) -> Result<()> {
         env_extra.insert("VETTO_GIT_GUARD".into(), "1".into());
     }
 
+    #[cfg(not(unix))]
+    if !pol.secret_proxies.is_empty() {
+        bail!(
+            "secrets.proxy requires the Unix credential broker, which is not supported on this platform: \
+             refusing to run rather than leak broker-managed secrets ({}) into the agent environment. \
+             Remove [secrets] proxy entries or run on Linux/macOS",
+            pol.secret_proxies.join(", ")
+        );
+    }
+
     #[cfg(unix)]
     let cred_sock = if !pol.secret_proxies.is_empty() {
         let sock = std::env::temp_dir().join(format!("vetto-cred-{}.sock", std::process::id()));

--- a/src/sandbox/macos/mod.rs
+++ b/src/sandbox/macos/mod.rs
@@ -422,6 +422,9 @@ fn build_envp(policy: &Policy, opts: &SpawnOptions) -> Vec<CString> {
         std::env::vars_os()
             .filter(|(key, _)| policy.environment.allows(key))
             .collect();
+    // Same guarantee as the Linux backend: broker-managed secrets never reach
+    // the agent environment (the broker itself spawns on Unix in main.rs).
+    crate::cred_broker::filter_proxy_secrets(&mut env, &policy.secret_proxies);
     for (k, v) in &opts.env_extra {
         env.insert(
             std::ffi::OsString::from(k.as_str()),


### PR DESCRIPTION
filter_proxy_secrets ran only in the Linux backend: on macOS/Windows broker-managed secrets reached the agent env unstripped, silently. macOS now strips in build_envp (broker spawns on Unix); non-Unix bails fail-closed when secrets.proxy is set. Plus cred_broker import hygiene (drop blanket unused_imports allows).