### PR TITLE
feat(release): 0.2.14 stabilization (secret-proxy, rescue, policy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project are documented here. Format follows
 Keep a Changelog; versioning follows SemVer.
 
+## [0.2.14] — 2026-09-04
+
+### Fixed
+
+- **Secret-proxy fail-open closed**: `filter_proxy_secrets` ran only in the Linux backend, so broker-managed secrets reached the agent environment unstripped on macOS/Windows. macOS now strips in `build_envp`; non-Unix targets refuse to start with `secrets.proxy` set (fail-closed).
+- **Rescue repair hardening**: removed `unwrap` from the two-phase atomic commit path; swallowed project-index reconcile errors are now recorded on the repair receipt.
+- **Policy editing without panics**: `vetto allow`/`deny` return errors (with context) on malformed policy documents instead of panicking; builtin profile lookup degrades to an error.
+- **Hermetic snapshot tests**: snapshot resolution rooted at an explicit store path, ending flakes from the shared per-user store.
+
 ## [0.2.13] — 2026-09-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vetto"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
 
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vetto"
-version = "0.2.13"
+version = "0.2.14"
 
 edition = "2021"
 rust-version = "1.75"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shledery/vetto",
-  "version": "0.2.13",
+  "version": "0.2.14",
 
   "description": "Cross-platform vetto sandbox and security layer for AI coding agents",
   "license": "Apache-2.0",

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: vetto contributors
 pkgname=vetto-git
-pkgver=0.2.13.r0.g0000000
+pkgver=0.2.14.r0.g0000000
 pkgrel=1
 pkgdesc='Daemon-less sandbox and audit layer for AI coding agents'
 arch=('x86_64' 'aarch64')

--- a/packaging/chocolatey/vetto.nuspec
+++ b/packaging/chocolatey/vetto.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vetto</id>
-    <version>0.2.13</version>
+    <version>0.2.14</version>
     <title>vetto</title>
     <authors>vetto contributors</authors>
     <projectUrl>https://github.com/shleder/vetto</projectUrl>

--- a/packaging/homebrew/vetto.rb
+++ b/packaging/homebrew/vetto.rb
@@ -1,25 +1,25 @@
 class Vetto < Formula
   desc "Daemon-less OS sandbox and subagent security layer for AI coding agents"
   homepage "https://github.com/shleder/vetto"
-  version "0.2.13"
+  version "0.2.14"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.13/vetto-macos-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.14/vetto-macos-aarch64.tar.gz"
       sha256 "9710e5b94bc2c28e7a644a875189f58f3b01b157e0bc620025de62a4ef8a8b1f"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.13/vetto-macos-x86_64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.14/vetto-macos-x86_64.tar.gz"
       sha256 "6345e1b81ff5cb1faa5e1c1839d39305e83740b2a2b27e10caf65cc134bf4b41"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.13/vetto-linux-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.14/vetto-linux-aarch64.tar.gz"
       sha256 "f7c9fcde23c0fd6983ef2dde511b88053b0c03e817e66bf5c886f0f0e3f3bc63"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.13/vetto-linux-x86_64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.14/vetto-linux-x86_64.tar.gz"
       sha256 "deaca44700919a84a93f306c1220f2f338bab515bd2da9473df5823b7bab0369"
     end
   end

--- a/packaging/rpm/vetto.spec
+++ b/packaging/rpm/vetto.spec
@@ -1,5 +1,5 @@
 Name:           vetto
-Version:        0.2.13
+Version:        0.2.14
 Release:        1%{?dist}
 Summary:        Daemon-less sandbox and audit layer for AI coding agents
 License:        Apache-2.0
@@ -34,6 +34,9 @@ cp -a profiles/. %{buildroot}%{_datadir}/vetto/profiles/
 %{_datadir}/vetto/profiles
 
 %changelog
+* Thu Sep 04 2026 vetto contributors - 0.2.14-1
+- Stabilization: secret-proxy fail-open closed, rescue/policy hardening, hermetic tests.
+
 * Thu Sep 03 2026 vetto contributors - 0.2.13-1
 - Sync the source-only recipe with the published 0.2.13 release.
 


### PR DESCRIPTION
Patch release with the stabilization backlog since 0.2.13: secret-proxy fail-open closed (macOS strip + non-Unix fail-closed bail), rescue repair hardening, allow/deny without panics, hermetic snapshot tests. Follow-ups filed separately: in-repo brew sha staleness, scoop template wiring.