### PR TITLE
chore(release): installer fallback to verified 0.2.14

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,8 @@ set -eu
 GITHUB_REPO="shleder/vetto"
 # Last version verified published on ALL channels (GitHub tag + npm + crates.io).
 # Bump only after the release-train publish + registry verification for the new
-# version succeed (see pages/ops/release-process.md). Verified 2026-09-03.
-DEFAULT_FALLBACK_VERSION="0.2.9"
+# version succeed (see pages/ops/release-process.md). Verified 2026-09-04.
+DEFAULT_FALLBACK_VERSION="0.2.14"
 
 # Initialize colors if stdout is connected to a terminal
 if [ -t 1 ]; then


### PR DESCRIPTION
Release closure: DEFAULT_FALLBACK_VERSION 0.2.9 -> 0.2.14 (tag + npm + crates.io + tap all verified).