### PR TITLE
feat(update): auto-update config plus staged downloads

### DIFF
--- a/src/version/config.rs
+++ b/src/version/config.rs
@@ -18,6 +18,11 @@ pub struct UserConfig {
     pub telemetry: bool,
     #[serde(default)]
     pub telemetry_endpoint: String,
+    /// Opt-in background self-update (default off: a security tool must not
+    /// mutate itself silently). Env `VETTO_AUTO_UPDATE=1` enables,
+    /// `VETTO_NO_SELF_UPDATE=1` (or CI) always disables.
+    #[serde(default)]
+    pub auto_update: bool,
 }
 
 impl Default for UserConfig {
@@ -26,6 +31,7 @@ impl Default for UserConfig {
             channel: default_channel(),
             telemetry: false,
             telemetry_endpoint: String::new(),
+            auto_update: false,
         }
     }
 }
@@ -69,7 +75,29 @@ pub fn load_user_config() -> Result<UserConfig> {
         }
     }
 
+    if let Ok(au) = std::env::var("VETTO_AUTO_UPDATE") {
+        match au.trim().to_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => config.auto_update = true,
+            "0" | "false" | "no" | "off" => config.auto_update = false,
+            _ => {}
+        }
+    }
+
+    // Kill-switch wins over everything, including the config file. CI
+    // environments must never self-mutate: builds have to stay reproducible.
+    if std::env::var("VETTO_NO_SELF_UPDATE").is_ok() || std::env::var("CI").is_ok() {
+        config.auto_update = false;
+    }
+
     Ok(config)
+}
+
+/// Effective auto-update decision for the current process.
+pub fn auto_update_enabled(config: &UserConfig) -> bool {
+    if std::env::var("VETTO_NO_SELF_UPDATE").is_ok() || std::env::var("CI").is_ok() {
+        return false;
+    }
+    config.auto_update
 }
 
 pub fn load_config_from_file(path: &Path) -> Result<UserConfig> {
@@ -88,6 +116,8 @@ mod tests {
         assert_eq!(cfg.channel, "stable");
         assert!(!cfg.telemetry);
         assert!(cfg.telemetry_endpoint.is_empty());
+        // Security default: a sandbox never self-mutates unless asked.
+        assert!(!cfg.auto_update);
     }
 
     #[test]
@@ -96,6 +126,7 @@ mod tests {
 channel = "alpha"
 telemetry = true
 telemetry_endpoint = "https://telemetry.example.com/api/v1/report"
+auto_update = true
 "#;
         let parsed: UserConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(parsed.channel, "alpha");
@@ -104,5 +135,6 @@ telemetry_endpoint = "https://telemetry.example.com/api/v1/report"
             parsed.telemetry_endpoint,
             "https://telemetry.example.com/api/v1/report"
         );
+        assert!(parsed.auto_update);
     }
 }

--- a/src/version/upgrade.rs
+++ b/src/version/upgrade.rs
@@ -247,13 +247,14 @@ pub fn run_upgrade(channel_opt: Option<&str>, check_only: bool, dry_run: bool) -
     }
 }
 
-/// Downloads release archive and performs atomic replacement of the current executable.
-fn perform_atomic_binary_upgrade(exe_path: &Path, archive_url: &str, ext: &str) -> Result<()> {
-    let parent_dir = exe_path.parent().unwrap_or_else(|| Path::new("."));
-    let temp_dir = tempfile_dir(parent_dir)?;
-
-    // Download archive via curl
-    let archive_path = temp_dir.join(format!("vetto_download.{ext}"));
+/// Downloads a release archive and fails closed unless its .sha256 sidecar
+/// verifies. Shared by interactive upgrades and background staging.
+fn download_and_verify_archive(
+    archive_url: &str,
+    ext: &str,
+    staging_dir: &Path,
+) -> Result<PathBuf> {
+    let archive_path = staging_dir.join(format!("vetto_download.{ext}"));
     let status = Command::new("curl")
         .args([
             "-fsSL",
@@ -267,14 +268,79 @@ fn perform_atomic_binary_upgrade(exe_path: &Path, archive_url: &str, ext: &str) 
         .context("failed to download release binary via curl")?;
 
     if !status.success() {
-        let _ = std::fs::remove_dir_all(&temp_dir);
         bail!("download failed with status {status}");
     }
 
-    // Supply-chain gate: every release publishes a .sha256 sidecar next to
-    // the archive. A security tool must not execute unverified bytes —
-    // fail closed when the sidecar is missing or mismatched.
-    verify_archive_sha256(&archive_path, &format!("{archive_url}.sha256"), &temp_dir)?;
+    verify_archive_sha256(&archive_path, &format!("{archive_url}.sha256"), staging_dir)?;
+    Ok(archive_path)
+}
+
+/// Root for staged background updates: ~/.vetto/updates/<version>/.
+pub fn staged_update_dir(version: &str) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)?;
+    Some(home.join(".vetto").join("updates").join(version))
+}
+
+const STAGED_READY_MARKER: &str = "READY";
+
+/// Removes staged updates other than `keep_version` (only dirs carrying our
+/// marker are touched — never user data).
+fn prune_staged_updates(updates_root: &Path, keep_version: &str) {
+    let entries = match std::fs::read_dir(updates_root) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let keep = path
+            .file_name()
+            .map(|n| n.to_string_lossy() == keep_version)
+            .unwrap_or(false);
+        if !keep && path.join(STAGED_READY_MARKER).is_file() {
+            let _ = std::fs::remove_dir_all(&path);
+        }
+    }
+}
+
+/// Downloads and verifies a release into the staged dir (idempotent: a
+/// version already staged is returned as-is). Applied on a later startup,
+/// never mid-session.
+pub fn stage_update(version: &str, archive_url: &str, ext: &str) -> Result<PathBuf> {
+    let dir = staged_update_dir(version).context("resolve staged update dir")?;
+    if dir.join(STAGED_READY_MARKER).is_file() {
+        return Ok(dir);
+    }
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create staged update dir {}", dir.display()))?;
+    let archive = download_and_verify_archive(archive_url, ext, &dir)?;
+    std::fs::write(
+        dir.join(STAGED_READY_MARKER),
+        archive.to_string_lossy().as_ref(),
+    )
+    .with_context(|| format!("write staged marker in {}", dir.display()))?;
+    if let Some(root) = dir.parent() {
+        prune_staged_updates(root, version);
+    }
+    Ok(dir)
+}
+
+/// Downloads release archive and performs atomic replacement of the current executable.
+fn perform_atomic_binary_upgrade(exe_path: &Path, archive_url: &str, ext: &str) -> Result<()> {
+    let parent_dir = exe_path.parent().unwrap_or_else(|| Path::new("."));
+    let temp_dir = tempfile_dir(parent_dir)?;
+
+    let archive_path = match download_and_verify_archive(archive_url, ext, &temp_dir) {
+        Ok(path) => path,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&temp_dir);
+            return Err(e);
+        }
+    };
 
     // Extract archive
     let unpack_status = if ext == "zip" {
@@ -522,6 +588,32 @@ mod tests {
         );
         assert_eq!(parse_sha256_sidecar(""), None);
         assert_eq!(parse_sha256_sidecar("notahash  file.tgz\n"), None);
+    }
+
+    #[test]
+    fn prune_keeps_only_current_staged_version() {
+        let root = std::env::temp_dir().join(format!(
+            "vetto-prune-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        for v in ["0.2.13", "0.2.14"] {
+            let d = root.join(v);
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("READY"), "x").unwrap();
+        }
+        // Foreign dir without our marker must survive.
+        std::fs::create_dir_all(root.join("user-stuff")).unwrap();
+
+        prune_staged_updates(&root, "0.2.14");
+
+        assert!(root.join("0.2.14").exists());
+        assert!(!root.join("0.2.13").exists());
+        assert!(root.join("user-stuff").exists());
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]


### PR DESCRIPTION
Auto-update slice 2 (toward 0.2.15, default OFF): UserConfig.auto_update with VETTO_AUTO_UPDATE opt-in and VETTO_NO_SELF_UPDATE/CI kill-switch; staged downloads under ~/.vetto/updates/<version>/ with sha256 verification, READY marker, idempotent re-stage, pruning of older staged versions. No behavior change yet: nothing triggers staging automatically (slice 3).