### PR TITLE
feat(update): apply staged updates at startup plus background staging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,18 @@ fn run() -> Result<()> {
         return shim::run_cli(Some(binary), args);
     }
 
+    // Apply a previously staged auto-update before doing anything else.
+    // Skipped for shims (agent hot path), --version (observation only) and
+    // the upgrade command itself (it manages its own lifecycle).
+    let first_arg = raw_args.get(1).map(|s| s.as_str()).unwrap_or("");
+    if first_arg != "upgrade" {
+        match vetto::version::apply_pending_staged_update() {
+            Ok(true) => println!("vetto: continuing with the updated binary on next invocation."),
+            Ok(false) => {}
+            Err(e) => eprintln!("vetto: warning: staged update not applied: {e:#}"),
+        }
+    }
+
     let args = cli::Cli::parse();
     logger::init_flags(args.quiet, args.verbose);
 
@@ -603,6 +615,15 @@ fn supervise(cfg: RunConfig) -> Result<()> {
         env!("CARGO_PKG_VERSION"),
         &user_config.channel,
     );
+
+    // Opt-in background staging (default off): when a newer release is known
+    // and this is a direct-binary install, download+verify it now so a later
+    // startup can apply it. Synchronous and cache-gated (24h), so at most one
+    // download per day. Managed installs (npm/cargo/brew) are left to their
+    // package managers.
+    if vetto::version::auto_update_enabled(&user_config) {
+        stage_update_if_available(&user_config);
+    }
 
     let backend_res = sandbox::Backend::detect_with_backend(
         cfg.net.clone(),
@@ -1644,10 +1665,37 @@ fn install_sigint_forwarder(root_pid: u32, tier: Option<policy::Tier>) {
 #[cfg(windows)]
 fn install_sigint_forwarder(_root_pid: u32, _tier: Option<policy::Tier>) {}
 
+/// Opt-in background staging hook (see call site in supervise()).
+/// Direct-binary installs only; managed installs stay with npm/cargo/brew.
+fn stage_update_if_available(user_config: &vetto::version::UserConfig) {
+    let exe_path = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    if vetto::version::detect_install_method(&exe_path) != vetto::version::InstallMethod::Binary {
+        return;
+    }
+    let Some(notice) =
+        vetto::version::check_version(env!("CARGO_PKG_VERSION"), &user_config.channel, false)
+    else {
+        return;
+    };
+    let Some((url, ext)) = vetto::version::binary_archive_url(&notice.latest_version) else {
+        return;
+    };
+    match vetto::version::stage_update(&notice.latest_version, &url, ext) {
+        Ok(dir) => println!(
+            "vetto: update v{} staged, applies on next startup ({}).",
+            notice.latest_version,
+            dir.display()
+        ),
+        Err(e) => eprintln!("vetto: warning: background staging failed: {e:#}"),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // doctor
 // ---------------------------------------------------------------------------
-
 fn doctor(probe_deny: bool, check_agent: Option<&str>, fix: bool) -> Result<()> {
     println!("vetto v{} doctor", env!("CARGO_PKG_VERSION"));
     let user_config = vetto::version::load_user_config().unwrap_or_default();

--- a/src/version/config.rs
+++ b/src/version/config.rs
@@ -21,6 +21,8 @@ pub struct UserConfig {
     /// Opt-in background self-update (default off: a security tool must not
     /// mutate itself silently). Env `VETTO_AUTO_UPDATE=1` enables,
     /// `VETTO_NO_SELF_UPDATE=1` (or CI) always disables.
+    /// v1 scope: direct-binary installs (npm/cargo/brew stay with their
+    /// package managers and keep showing the banner instead).
     #[serde(default)]
     pub auto_update: bool,
 }

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -9,6 +9,9 @@ pub use checker::{
     check_version, print_banner_if_update_available, resolve_cache_path, UpdateNotice,
     VersionCache, CACHE_TTL_SECS, CHECK_TIMEOUT,
 };
-pub use config::{load_user_config, UserConfig};
+pub use config::{auto_update_enabled, load_user_config, UserConfig};
 pub use parser::{parse_registry_version, SemVer};
-pub use upgrade::{detect_install_method, run_rollback, run_upgrade, InstallMethod};
+pub use upgrade::{
+    apply_pending_staged_update, binary_archive_url, detect_install_method, run_rollback,
+    run_upgrade, stage_update, InstallMethod,
+};

--- a/src/version/upgrade.rs
+++ b/src/version/upgrade.rs
@@ -329,6 +329,185 @@ pub fn stage_update(version: &str, archive_url: &str, ext: &str) -> Result<PathB
     Ok(dir)
 }
 
+/// Archive URL + extension for a direct-binary release, if this OS/arch
+/// combination is published. Shared by interactive upgrades and staging.
+pub fn binary_archive_url(version: &str) -> Option<(String, &'static str)> {
+    let (target, ext) = match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => ("macos-aarch64", "tar.gz"),
+        ("macos", "x86_64") => ("macos-x86_64", "tar.gz"),
+        ("linux", "aarch64") => ("linux-aarch64", "tar.gz"),
+        ("linux", "x86_64") => ("linux-x86_64", "tar.gz"),
+        ("windows", "x86_64") => ("windows-x86_64", "zip"),
+        _ => return None,
+    };
+    Some((
+        format!(
+            "https://github.com/shleder/vetto/releases/download/v{version}/vetto-{target}.{ext}"
+        ),
+        ext,
+    ))
+}
+
+/// Newest staged version dir carrying a READY marker, if any.
+fn newest_staged_update() -> Option<(String, PathBuf)> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)?;
+    let root = home.join(".vetto").join("updates");
+    let entries = std::fs::read_dir(&root).ok()?;
+    let mut best: Option<(super::parser::SemVer, String, PathBuf)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() || !path.join(STAGED_READY_MARKER).is_file() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let ver = super::parser::SemVer::parse(&name)?;
+        let replace = match &best {
+            Some((cur, _, _)) => ver.is_newer_than(cur),
+            None => true,
+        };
+        if replace {
+            best = Some((ver, name, path));
+        }
+    }
+    best.map(|(_, name, path)| (name, path))
+}
+
+/// Applies a staged update (if any) by installing its verified archive over
+/// the current executable. Runs at startup, never mid-session. Returns true
+/// when an update was applied.
+pub fn apply_pending_staged_update() -> Result<bool> {
+    let current = env!("CARGO_PKG_VERSION");
+    let (version, dir) = match newest_staged_update() {
+        Some(v) => v,
+        None => return Ok(false),
+    };
+    // Stale stage (user upgraded manually meanwhile): drop it silently.
+    let is_newer = super::parser::SemVer::parse(&version)
+        .and_then(|v| super::parser::SemVer::parse(current).map(|c| v.is_newer_than(&c)))
+        .unwrap_or(false);
+    if !is_newer {
+        let _ = std::fs::remove_dir_all(&dir);
+        return Ok(false);
+    }
+    let marker = std::fs::read_to_string(dir.join(STAGED_READY_MARKER))
+        .with_context(|| format!("read staged marker in {}", dir.display()))?;
+    let archive_path = PathBuf::from(marker.trim());
+    if !archive_path.exists() {
+        let _ = std::fs::remove_dir_all(&dir);
+        bail!("staged update {version} is incomplete; re-staging on next run");
+    }
+    let ext = if archive_path.extension().and_then(|e| e.to_str()) == Some("zip") {
+        "zip"
+    } else {
+        "tar.gz"
+    };
+    let exe_path = std::env::current_exe().context("resolve current executable")?;
+    println!("vetto: applying staged update v{current} → v{version}...");
+    install_archive_over_exe(&exe_path, &archive_path, ext, &dir)?;
+    let _ = std::fs::remove_dir_all(&dir);
+    println!("vetto: updated to v{version} (previous copy kept for `vetto upgrade --rollback`).");
+    Ok(true)
+}
+
+/// Extracts a verified archive and atomically replaces the executable,
+/// keeping a last-good backup. `scratch` hosts extraction temp state.
+fn install_archive_over_exe(
+    exe_path: &Path,
+    archive_path: &Path,
+    ext: &str,
+    scratch: &Path,
+) -> Result<()> {
+    let unpack_dir = scratch.join("unpack");
+    std::fs::create_dir_all(&unpack_dir)
+        .with_context(|| format!("create {}", unpack_dir.display()))?;
+    let unpack_status = if ext == "zip" {
+        // Built-in tar on Windows 10/11 handles zip, otherwise fall back to powershell
+        let tar_res = Command::new("tar")
+            .args([
+                "-xf",
+                archive_path.to_str().unwrap_or("vetto_download.zip"),
+                "-C",
+                unpack_dir.to_str().unwrap_or("."),
+            ])
+            .status();
+        match tar_res {
+            Ok(s) if s.success() => s,
+            _ => Command::new("powershell")
+                .args([
+                    "-NoProfile",
+                    "-Command",
+                    &format!(
+                        "Expand-Archive -Path '{}' -DestinationPath '{}' -Force",
+                        archive_path.display(),
+                        unpack_dir.display()
+                    ),
+                ])
+                .status()
+                .context("failed to unpack zip archive via tar or powershell")?,
+        }
+    } else {
+        Command::new("tar")
+            .args([
+                "-xzf",
+                archive_path.to_str().unwrap_or("vetto_download.tar.gz"),
+                "-C",
+                unpack_dir.to_str().unwrap_or("."),
+            ])
+            .status()
+            .context("failed to unpack binary archive via tar")?
+    };
+
+    if !unpack_status.success() {
+        bail!("archive unpack failed with status {unpack_status}");
+    }
+
+    let extracted_bin = if unpack_dir.join("vetto.exe").exists() {
+        unpack_dir.join("vetto.exe")
+    } else if unpack_dir.join("vetto").exists() {
+        unpack_dir.join("vetto")
+    } else if unpack_dir.join("bin").join("vetto").exists() {
+        unpack_dir.join("bin").join("vetto")
+    } else {
+        find_binary_in_dir(&unpack_dir).unwrap_or_else(|| unpack_dir.join("vetto"))
+    };
+
+    if !extracted_bin.exists() {
+        bail!("extracted archive did not contain 'vetto' executable");
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&extracted_bin, std::fs::Permissions::from_mode(0o755));
+    }
+
+    let durable_backup = backup_path_for(exe_path);
+    std::fs::copy(exe_path, &durable_backup).with_context(|| {
+        format!(
+            "failed to back up current executable to {}",
+            durable_backup.display()
+        )
+    })?;
+
+    #[cfg(windows)]
+    {
+        // Renaming a running image aside is allowed; overwriting is not.
+        let _ = std::fs::rename(exe_path, exe_path.with_extension("stale-tmp"));
+    }
+
+    std::fs::rename(&extracted_bin, exe_path).with_context(|| {
+        format!(
+            "failed to replace executable at {}. Try running with elevated permissions (e.g. sudo).",
+            exe_path.display()
+        )
+    })?;
+    // Best-effort cleanup of the Windows move-aside leftover (no-op on Unix).
+    let _ = std::fs::remove_file(exe_path.with_extension("stale-tmp"));
+    Ok(())
+}
+
 /// Downloads release archive and performs atomic replacement of the current executable.
 fn perform_atomic_binary_upgrade(exe_path: &Path, archive_url: &str, ext: &str) -> Result<()> {
     let parent_dir = exe_path.parent().unwrap_or_else(|| Path::new("."));


### PR DESCRIPTION
Auto-update slice 3 (default OFF): startup applies pending staged update (skipped for shims, --version and upgrade itself); supervise() stages verified downloads in background when auto enabled on direct-binary installs; CI and VETTO_NO_SELF_UPDATE kill-switch always win.