### PR TITLE
feat(release): 0.2.15 opt-in auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 All notable changes to this project are documented here. Format follows
 Keep a Changelog; versioning follows SemVer.
 
-## [Unreleased]
+## [0.2.15] — 2026-09-05
 
 ### Added
 
 - **Opt-in background self-update (default off)**: `auto_update` user config + `VETTO_AUTO_UPDATE=1`, kill-switch `VETTO_NO_SELF_UPDATE`/`CI`. Verified release archives stage under `~/.vetto/updates/<version>/` and apply on next startup (never mid-session; skipped for shims, `--version` and `upgrade` itself). v1 scope: direct-binary installs.
 - **`vetto upgrade --rollback`**: restores the last-good binary copy kept next to the executable.
 - **Supply-chain gate**: binary upgrades fetch the release `.sha256` sidecar and fail closed on missing/mismatch.
+- **SBPL dispute matrix**: 6 binaries × 7 profile shapes across macOS runners with a fail-closed leak gate (evidence for the read-denial dispute).
+- **`scripts/canary.sh`**: zero-dependency host security audit probe.
 
 ## [0.2.14] — 2026-09-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vetto"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
 
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vetto"
-version = "0.2.14"
+version = "0.2.15"
 
 edition = "2021"
 rust-version = "1.75"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shledery/vetto",
-  "version": "0.2.14",
+  "version": "0.2.15",
 
   "description": "Cross-platform vetto sandbox and security layer for AI coding agents",
   "license": "Apache-2.0",

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: vetto contributors
 pkgname=vetto-git
-pkgver=0.2.14.r0.g0000000
+pkgver=0.2.15.r0.g0000000
 pkgrel=1
 pkgdesc='Daemon-less sandbox and audit layer for AI coding agents'
 arch=('x86_64' 'aarch64')

--- a/packaging/chocolatey/vetto.nuspec
+++ b/packaging/chocolatey/vetto.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vetto</id>
-    <version>0.2.14</version>
+    <version>0.2.15</version>
     <title>vetto</title>
     <authors>vetto contributors</authors>
     <projectUrl>https://github.com/shleder/vetto</projectUrl>

--- a/packaging/homebrew/vetto.rb
+++ b/packaging/homebrew/vetto.rb
@@ -1,25 +1,25 @@
 class Vetto < Formula
   desc "Daemon-less OS sandbox and subagent security layer for AI coding agents"
   homepage "https://github.com/shleder/vetto"
-  version "0.2.14"
+  version "0.2.15"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.14/vetto-macos-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.15/vetto-macos-aarch64.tar.gz"
       sha256 "5992d31b879ceecedfa7440ac7e0811888174e0f25a4dccadbafb537812c729f"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.14/vetto-macos-x86_64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.15/vetto-macos-x86_64.tar.gz"
       sha256 "bde9091d5cb8ddc4115971d3e0bf4ec60a2358f6b3e38072062d1e76993d99d4"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.14/vetto-linux-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.15/vetto-linux-aarch64.tar.gz"
       sha256 "3a52accb9b702546b0924f5a64baef5e383aeb9c282cd8dda3e3e895e78ccb11"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.14/vetto-linux-x86_64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.15/vetto-linux-x86_64.tar.gz"
       sha256 "2f2b33232adb1f60e15a474d6d04a46423a236d66866ba2bfd82f518c39894ce"
     end
   end

--- a/packaging/rpm/vetto.spec
+++ b/packaging/rpm/vetto.spec
@@ -1,5 +1,5 @@
 Name:           vetto
-Version:        0.2.14
+Version:        0.2.15
 Release:        1%{?dist}
 Summary:        Daemon-less sandbox and audit layer for AI coding agents
 License:        Apache-2.0
@@ -34,6 +34,9 @@ cp -a profiles/. %{buildroot}%{_datadir}/vetto/profiles/
 %{_datadir}/vetto/profiles
 
 %changelog
+* Fri Sep 05 2026 vetto contributors - 0.2.15-1
+- Opt-in background self-update, upgrade rollback, supply-chain gate.
+
 * Thu Sep 04 2026 vetto contributors - 0.2.14-1
 - Stabilization: secret-proxy fail-open closed, rescue/policy hardening, hermetic tests.
 


### PR DESCRIPTION
Release: background self-update stack (config, staging, apply, rollback, sha gate), SBPL dispute matrix plus canary probe, brew sha sync. Default off everywhere; no behavior change unless opted in.