### PR TITLE
feat(release): minisign-sign all release archives in release-train

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -376,6 +376,43 @@ jobs:
           fi
           python3 -c "import json; m=json.load(open('all-assets/vetto.json')); print('scoop manifest OK:', m['version'], m['architecture']['64bit']['hash'][:12])"
 
+      - name: Sign and verify release archives (minisign)
+        env:
+          TAG: ${{ needs.version-check.outputs.tag }}
+          RELEASE_SIGNING_KEY: ${{ secrets.RELEASE_SIGNING_KEY }}
+          RELEASE_SIGNING_KEY_PASSWORD: ${{ secrets.RELEASE_SIGNING_KEY_PASSWORD }}
+          MINISIGN_TARBALL_SHA256: 9a599b48ba6eb7b1e80f12f36b94ceca7c00b7a5173c95c3efc88d9822957e73
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          archives=(all-assets/vetto-linux-*.tar.gz all-assets/vetto-macos-*.tar.gz all-assets/vetto-windows-*.zip)
+          if [[ -z "${RELEASE_SIGNING_KEY:-}" ]]; then
+            echo "::warning ::RELEASE_SIGNING_KEY is not set; shipping unsigned archives."
+            exit 0
+          fi
+          [[ "${#archives[@]}" -gt 0 ]] || { echo "::error ::no release archives found to sign"; exit 1; }
+          work="$(mktemp -d)"
+          trap 'rm -rf "$work"' EXIT
+          curl -fsSL --retry 3 -o "$work/minisign.tar.gz" \
+            "https://github.com/jedisct1/minisign/releases/download/0.12/minisign-0.12-linux.tar.gz"
+          echo "$MINISIGN_TARBALL_SHA256  $work/minisign.tar.gz" | sha256sum -c -
+          tar -xzf "$work/minisign.tar.gz" -C "$work"
+          ms="$work/minisign-linux/x86_64/minisign"
+          [[ -x "$ms" ]] || { echo "::error ::minisign binary missing from pinned tarball"; exit 1; }
+          key="$work/release.key"
+          printf '%s' "$RELEASE_SIGNING_KEY" > "$key"
+          chmod 600 "$key"
+          for archive in "${archives[@]}"; do
+            printf '%s\n' "${RELEASE_SIGNING_KEY_PASSWORD:-}" | "$ms" -S \
+              -s "$key" -m "$archive" -t "vetto $TAG" >/dev/null
+          done
+          for sig in all-assets/*.minisig; do
+            "$ms" -V -p packaging/release.pub -m "${sig%.minisig}" -x "$sig" >/dev/null \
+              || { echo "::error ::signature verify failed: $sig"; exit 1; }
+          done
+          echo "::notice ::signed and verified ${#archives[@]} release archives (minisign)"
+
       - uses: actions/setup-node@v4
         with:
           node-version: 24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Keep a Changelog; versioning follows SemVer.
 
 ### Added
 
+- **Minisign release signatures**: every release archive ships a `.minisig`
+  (key id `75ECEC9B5080C590`, public key `packaging/release.pub`); release-train
+  signs and re-verifies before publishing. Verify with
+  `minisign -V -p packaging/release.pub -m <archive>`.
+
+### Added
+
 - **Exit recap**: every non-clean session ends with one `vetto: recap:` line
   pointing at exactly one next action per exit code (`--session-timeout`,
   `vetto audit --latest`, `vetto doctor`, `vetto enable <agent>`).

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ npx @shledery/vetto doctor
 
 *Prebuilt standalone archives with SHA256 checksums and CycloneDX SBOMs for all architectures (`x86_64`, `aarch64`, Windows `.zip`, Linux/macOS `.tar.gz`) are published on [GitHub Releases](https://github.com/shleder/vetto/releases).*
 
+*Every release archive is signed with minisign (key id `75ECEC9B5080C590`, public key: `packaging/release.pub`). Verify before running:*
+
+```bash
+# one-time: install minisign (cargo install minisign / apt install minisign / brew install minisign)
+minisign -V -p packaging/release.pub -m vetto-linux-x86_64.tar.gz
+# → "Signature and comment signature verified"
+```
+
 ---
 
 ## Quick Start

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,6 +13,10 @@ uploads an artifact, or changes an external package registry.
 - `scoop/vetto.json.template`: rendered by release-train (`Render Scoop manifest`
   step) into `vetto.json` from the real Windows archive + its `.sha256`
   sidecar and attached to the GitHub Release. Never hand-edit checksums.
+- `release.pub`: minisign public key for release archives (key id
+  `75ECEC9B5080C590`). The private key lives only in the `RELEASE_SIGNING_KEY`
+  GitHub secret (+ `RELEASE_SIGNING_KEY_PASSWORD`); release-train signs every
+  archive and verifies each `.minisig` against this file before publishing.
 - `chocolatey/`: local Chocolatey package template with mandatory checksum.
 - the root `flake.nix`: reproducible Nix build from the checked-out source.
 

--- a/packaging/release.pub
+++ b/packaging/release.pub
@@ -1,0 +1,2 @@
+untrusted comment: vetto release signing key (2026-09-06, key id 75ECEC9B5080C590)
+RWSQxYBQm+zsdZ2AtKoK4TEXD5FZ9aTivKPkblpO3M7BEF8UmmTHV/Kj


### PR DESCRIPTION
Ed25519-подписи релизов из очереди 0.2.16. Ключи: приват в RELEASE_SIGNING_KEY/_PASSWORD secrets (уже положены), паблик packaging/release.pub (key id 75ECEC9B5080C590).\n\n- Новый степ Sign and verify: pin minisign 0.12 по sha256, подпись всех архивов, re-verify каждого .minisig против release.pub до паблиша. .minisig цепляются к релизу через all-assets/*.\n- Fail-closed при отсутствии архивов/битом сайдкаре; warn-and-ship только если секрета нет вообще (прецедент npm/crates).\n- README-инструкция проверки + CHANGELOG Unreleased.\n- Локально не билдилось; команды подписи проверены вживую при генерации ключей (sign→verify круг сошелся).