### PR TITLE
chore(release): post-0.2.16 taps

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,8 @@ set -eu
 GITHUB_REPO="shleder/vetto"
 # Last version verified published on ALL channels (GitHub tag + npm + crates.io).
 # Bump only after the release-train publish + registry verification for the new
-# version succeed (see pages/ops/release-process.md). Verified 2026-09-05.
-DEFAULT_FALLBACK_VERSION="0.2.15"
+# version succeed (see pages/ops/release-process.md). Verified 2026-09-06.
+DEFAULT_FALLBACK_VERSION="0.2.16"
 
 # Initialize colors if stdout is connected to a terminal
 if [ -t 1 ]; then

--- a/packaging/aur/vetto/.SRCINFO
+++ b/packaging/aur/vetto/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vetto
 	pkgdesc = Daemon-less sandbox and audit layer for AI coding agents
-	pkgver = 0.2.15
+	pkgver = 0.2.16
 	pkgrel = 1
 	url = https://github.com/shleder/vetto
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = vetto
 	provides = vetto
 	conflicts = vetto
 	conflicts = vetto-git
-	source = vetto-0.2.15.tar.gz::https://github.com/shleder/vetto/archive/refs/tags/v0.2.15.tar.gz
-	sha256sums = abd0dff06da41af1a7692fe1c35135d1d46221f498da6897ad03165dd64cbad9
+	source = vetto-0.2.16.tar.gz::https://github.com/shleder/vetto/archive/refs/tags/v0.2.16.tar.gz
+	sha256sums = 049020935faa90f47298000fc06e6aea5b5b789bc5da7e3f8fb03ac61ad120b8
 
 pkgname = vetto

--- a/packaging/aur/vetto/PKGBUILD
+++ b/packaging/aur/vetto/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: vetto contributors
 pkgname=vetto
-pkgver=0.2.15
+pkgver=0.2.16
 pkgrel=1
 pkgdesc='Daemon-less sandbox and audit layer for AI coding agents'
 arch=('x86_64' 'aarch64')
@@ -10,7 +10,7 @@ makedepends=('cargo')
 provides=('vetto')
 conflicts=('vetto' 'vetto-git')
 source=("vetto-$pkgver.tar.gz::https://github.com/shleder/vetto/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('abd0dff06da41af1a7692fe1c35135d1d46221f498da6897ad03165dd64cbad9')
+sha256sums=('049020935faa90f47298000fc06e6aea5b5b789bc5da7e3f8fb03ac61ad120b8')
 
 build() {
   cd "vetto-$pkgver"

--- a/packaging/homebrew/vetto.rb
+++ b/packaging/homebrew/vetto.rb
@@ -6,21 +6,21 @@ class Vetto < Formula
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.15/vetto-macos-aarch64.tar.gz"
-      sha256 "5992d31b879ceecedfa7440ac7e0811888174e0f25a4dccadbafb537812c729f"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.16/vetto-macos-aarch64.tar.gz"
+      sha256 "a84da1a82c8a672e040ce92193a272713d335aee8cc6d190b99f25dac6898548"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.15/vetto-macos-x86_64.tar.gz"
-      sha256 "bde9091d5cb8ddc4115971d3e0bf4ec60a2358f6b3e38072062d1e76993d99d4"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.16/vetto-macos-x86_64.tar.gz"
+      sha256 "1d16fbbf7427e84d7776b1712601c14417920526fa28ede1e976fc8a84794346"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.15/vetto-linux-aarch64.tar.gz"
-      sha256 "3a52accb9b702546b0924f5a64baef5e383aeb9c282cd8dda3e3e895e78ccb11"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.16/vetto-linux-aarch64.tar.gz"
+      sha256 "816aae420aa4bf352f9311e779d4e7d6ba538195f343ffb6db9e2a8eb3c13202"
     else
-      url "https://github.com/shleder/vetto/releases/download/v0.2.15/vetto-linux-x86_64.tar.gz"
-      sha256 "2f2b33232adb1f60e15a474d6d04a46423a236d66866ba2bfd82f518c39894ce"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.16/vetto-linux-x86_64.tar.gz"
+      sha256 "c2f785e0517bf3d7ea89482892460758b77600ac22cd2c1c41eefd65afdbd645"
     end
   end
 


### PR DESCRIPTION
Пост-релизное закрытие 0.2.16 (прецедент PR #43/#45): install.sh fallback → 0.2.16, AUR stable → 0.2.16 (sha 04902093 сверен скачиванием тегового тарбола), in-repo brew формула → релизные sha. Внешний tap shleder/homebrew-tap обновлен напрямую (fddc804). Scoop/choco: choco-шаблон с mandatory checksum — проверить/обновить следующим шагом при наличии/отсутствии автоматики.