### PR TITLE
feat(funnel): troubleshooting top-3 + opt-in funnel milestones (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project are documented here. Format follows
 Keep a Changelog; versioning follows SemVer.
 
+## [Unreleased]
+
+### Added
+
+- **Troubleshooting guide**: `docs/troubleshooting.md` covers the top-3 silent
+  failure modes (auth hang, outer-boundary misattribution, shim bypass) with
+  one distinguishing check and one action each.
+- **Activation funnel telemetry** (#27): one-time opt-in `install` / `enable` /
+  `first_session` milestones (version/OS/arch + name only, no PII, tracked in
+  `~/.vetto/funnel.json`).
+
+### Fixed
+
+- **Exit recap flag**: timeout hint now points at the real `--timeout` flag
+  (was `--session-timeout`, which does not exist).
+
 ## [0.2.16] — 2026-09-06
 
 ### Added

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -36,6 +36,10 @@ agent itself fail? Rules of thumb:
 - Timeouts (`124`) with repeated identical failures beforehand suggest a runaway
   retry loop — see `vetto watchdog` rather than raising limits.
 
+Silent failures with no useful error at the failure site get their own page:
+[troubleshooting.md](troubleshooting.md) (auth hangs, outer-boundary
+misattribution, shim bypass).
+
 ## Exit recap and bug reports
 
 A fully clean session (exit `0`, no denials) exits quietly. Any other outcome

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -86,3 +86,20 @@ You can verify that zero network activity occurs when telemetry is off by runnin
 # Verify no network packets are sent with default configuration
 vetto -- /bin/echo "testing privacy"
 ```
+
+## 6. Activation funnel milestones (issue #27)
+
+Beyond per-session counters, three one-time milestones track the install →
+enable → first-session funnel, under the same opt-in gate and anonymity
+guarantees (version/OS/arch + milestone name only, no PII):
+
+| Milestone | Sent when |
+|---|---|
+| `install` | first-ever vetto run |
+| `enable` | first `vetto enable <agent>` that wraps an agent |
+| `first_session` | first supervised session completes |
+
+Each milestone is sent at most once (tracked in `~/.vetto/funnel.json`).
+With telemetry off (default), nothing is sent and nothing is recorded.
+Payload shape: `{"schema_version": 1, "vetto_version": "…", "os": "…",
+"arch": "…", "event": "enable"}`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,46 @@
+# Troubleshooting silent failures
+
+Three failure shapes produce no useful error where they happen. Each section
+gives one distinguishing check and exactly one next action.
+
+## 1. Silent auth hang: agent waits forever with no output
+
+**Symptom.** An in-sandbox agent that cannot authenticate produces no stderr,
+no events, no diagnosis — then a retry that hangs identically. From outside it
+looks like slowness.
+
+**Distinguish.** If the session exceeds its normal startup time with zero
+events (`vetto audit --latest` shows nothing new), treat it as auth, not load.
+
+**Action.** Kill it and re-run with an explicit deadline instead of waiting:
+`vetto --timeout 120s -- <agent>`. A timeout exits `124` with a recap
+line instead of hanging. Then fix the credential path (broker or pushed
+credentials — never a long-lived key copied into the sandbox) and re-run.
+For the report bundle: `vetto pack --bug -o bug.vetto-pack`.
+
+## 2. Outer-boundary denial misread as an agent failure
+
+**Symptom.** `Operation not permitted` / `EACCES` / `EPERM` inside the agent,
+followed by escalation, approval, or a product-bug hunt — when the denial came
+from a boundary *outside* vetto (outer container, eval harness, host policy).
+
+**Distinguish.** Run the same failing command in an ordinary terminal with
+equivalent inputs. If it succeeds there but fails inside the agent session,
+the boundary is outside the agent — retrying or approving inside cannot fix it.
+
+**Action.** Attribute first, act second: vetto exit `125` means the outer
+boundary denied it — inspect with `vetto audit --latest` (denied Landlock
+paths), not with re-runs. See [exit-codes.md](exit-codes.md#attributing-failures-sandbox-denial-vs-agent-error).
+
+## 3. Agent runs unsandboxed without notice (shim bypass)
+
+**Symptom.** Everything works, zero denials, zero audit events — because the
+agent never entered the sandbox: the shell resolved the real binary before the
+shim (`PATH` order), or the agent was launched by absolute path.
+
+**Distinguish.** One command: `vetto status`. If your agent is not listed as
+wrapped, the session you just ran was unwrapped.
+
+**Action.** Re-run `vetto enable <agent>` and confirm it reports the shim
+first in `PATH` (`command -v <agent>` must point inside `~/.vetto/shims`).
+Re-run the session; verify with `vetto audit --latest` that events exist.

--- a/src/cli/enable.rs
+++ b/src/cli/enable.rs
@@ -149,6 +149,9 @@ pub fn enable_agent(agent: &str, force: bool, scope: HookScope) -> Result<()> {
         }
     }
 
+    // Activation funnel milestone (issue #27): agent wrapped. Once-only.
+    let _ = crate::telemetry::record_funnel_milestone("enable");
+
     Ok(())
 }
 

--- a/src/exit_codes.rs
+++ b/src/exit_codes.rs
@@ -54,7 +54,7 @@ pub fn map_session_exit_code(
 pub fn recap_hint(final_code: i32, blocked_total: u64, timed_out: bool) -> Option<String> {
     if timed_out || final_code == EXIT_TIMEOUT {
         return Some(
-            "session hit the deadline — re-run with a larger --session-timeout or split the task"
+            "session hit the deadline — re-run with a larger --timeout or split the task"
                 .to_string(),
         );
     }
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn recap_points_at_one_action_per_outcome() {
         let timeout = recap_hint(EXIT_TIMEOUT, 0, true).expect("timeout recap");
-        assert!(timeout.contains("--session-timeout"));
+        assert!(timeout.contains("--timeout"));
 
         let blocked = recap_hint(EXIT_POLICY_BLOCKED, 7, false).expect("blocked recap");
         assert!(blocked.contains('7'));

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,9 @@ fn fast_tier_detect() -> &'static str {
 }
 
 fn run() -> Result<()> {
+    // Activation funnel milestone (issue #27): first-ever run. Once-only via
+    // marker file; silent unless telemetry is explicitly opted in.
+    let _ = vetto::telemetry::record_funnel_milestone("install");
     let raw_args: Vec<String> = std::env::args().collect();
     let has_version = raw_args.iter().any(|a| a == "--version" || a == "-V");
     let has_json = raw_args.iter().any(|a| a == "--json");
@@ -1280,6 +1283,8 @@ fn supervise(cfg: RunConfig) -> Result<()> {
 
     let snap = stats.snapshot();
     let _ = vetto::telemetry::send_session_telemetry(&snap, tier_label(tier));
+    // Activation funnel milestone (issue #27): first supervised session done.
+    let _ = vetto::telemetry::record_funnel_milestone("first_session");
     let diff = report::diff_project::ProjectDiff::compute(&initial_manifest, &project);
     if !diff.is_empty() {
         bus.publish(Event::Notice {

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -10,6 +10,7 @@
 pub mod otel;
 pub use otel::{spawn_telemetry_subscriber, TelemetrySession};
 
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -97,6 +98,120 @@ pub fn send_session_telemetry(stats: &SessionStats, tier: &str) -> Result<()> {
     Ok(())
 }
 
+/// Funnel milestone events for the activation funnel (issue #27):
+/// `install` (first-ever run) → `enable` (first agent wrapped) →
+/// `first_session` (first supervised session completed).
+///
+/// Same opt-in gate and anonymity guarantees as session telemetry: each event
+/// carries only version/OS/arch plus the milestone name — no paths, commands,
+/// identifiers, or any PII. Each milestone is sent at most once (tracked in
+/// `~/.vetto/funnel.json`); when telemetry is off, nothing is recorded.
+pub const FUNNEL_EVENTS: [&str; 3] = ["install", "enable", "first_session"];
+
+/// Anonymous funnel milestone payload (schema v1, same envelope as sessions).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FunnelEvent {
+    pub schema_version: u32,
+    pub vetto_version: String,
+    pub os: String,
+    pub arch: String,
+    pub event: String,
+}
+
+impl FunnelEvent {
+    pub fn new(event: &str) -> Self {
+        Self {
+            schema_version: TELEMETRY_SCHEMA_VERSION,
+            vetto_version: env!("CARGO_PKG_VERSION").to_string(),
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            event: event.to_string(),
+        }
+    }
+}
+
+fn funnel_marker_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)?;
+    Some(home.join(".vetto").join("funnel.json"))
+}
+
+fn funnel_already_sent(event: &str) -> bool {
+    let path = match funnel_marker_path() {
+        Some(p) => p,
+        None => return true,
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    let sent: Vec<String> = serde_json::from_str(&text).unwrap_or_default();
+    sent.iter().any(|e| e == event)
+}
+
+fn funnel_mark_sent(event: &str) {
+    let path = match funnel_marker_path() {
+        Some(p) => p,
+        None => return,
+    };
+    let mut sent: Vec<String> = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|t| serde_json::from_str(&t).ok())
+        .unwrap_or_default();
+    if sent.iter().any(|e| e == event) {
+        return;
+    }
+    sent.push(event.to_string());
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(text) = serde_json::to_string(&sent) {
+        let _ = std::fs::write(&path, text);
+    }
+}
+
+/// Records a funnel milestone exactly once. No-op for unknown event names,
+/// for already-recorded milestones, and unless telemetry is explicitly opted
+/// in with an endpoint configured.
+pub fn record_funnel_milestone(event: &str) -> Result<()> {
+    if !FUNNEL_EVENTS.contains(&event) {
+        return Ok(());
+    }
+    if funnel_already_sent(event) {
+        return Ok(());
+    }
+    let config = match load_user_config() {
+        Ok(cfg) => cfg,
+        Err(_) => return Ok(()),
+    };
+    if !config.telemetry || config.telemetry_endpoint.trim().is_empty() {
+        return Ok(());
+    }
+    let payload_json = match serde_json::to_string(&FunnelEvent::new(event)) {
+        Ok(j) => j,
+        Err(_) => return Ok(()),
+    };
+    let endpoint = config.telemetry_endpoint.trim().to_string();
+    let _ = Command::new("curl")
+        .arg("-s")
+        .arg("--max-time")
+        .arg(TELEMETRY_TIMEOUT.as_secs().max(1).to_string())
+        .arg("-X")
+        .arg("POST")
+        .arg("-H")
+        .arg("Content-Type: application/json")
+        .arg("-d")
+        .arg(&payload_json)
+        .arg(&endpoint)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    funnel_mark_sent(event);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,5 +275,18 @@ mod tests {
         let stats = SessionStats::default();
         // Should execute cleanly without error
         assert!(send_session_telemetry(&stats, "none").is_ok());
+    }
+
+    #[test]
+    fn test_funnel_event_shape_and_allowlist() {
+        for event in FUNNEL_EVENTS {
+            let payload = FunnelEvent::new(event);
+            assert_eq!(payload.schema_version, TELEMETRY_SCHEMA_VERSION);
+            assert_eq!(payload.event, event);
+            let json = serde_json::to_string(&payload).unwrap();
+            assert!(json.contains(event));
+        }
+        // Unknown events are a silent no-op (no fs touch, no network).
+        assert!(record_funnel_milestone("not-a-milestone").is_ok());
     }
 }


### PR DESCRIPTION
Остаток воронки #27 (recap уже в main).\n\n- Дока тихих фейлов из живых тредов: auth-hang (devclaw-форма), outer-denial (slowdini-форма), shim-bypass. Флаги сверены с cli (--timeout).\n- Funnel-события install/enable/first_session: тот же opt-in гейт, без PII, once-only через маркер; неизвестные имена и выкл — silent no-op. Тесты без мутаций env (урок bundle-теста).\n- Попутно фикс неверного флага в recap_hint из #50.\n- Локально не билдилось — только CI.