### PR TITLE
fix(tests): hermetic shim git-guard tests, lock env-mutating tests

### DIFF
--- a/src/cli/enable.rs
+++ b/src/cli/enable.rs
@@ -297,7 +297,10 @@ pub fn get_wrapped_agents(scope: HookScope) -> Result<Vec<WrappedAgentInfo>> {
 mod tests {
     use super::*;
     use clap::Parser;
+    use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[derive(Parser, Debug)]
     struct TestCli {
@@ -313,7 +316,8 @@ mod tests {
 
     fn temp_test_dir(name: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
-            "vetto-enable-test-{name}-{}",
+            "vetto-enable-test-{name}-{}-{}",
+            std::process::id(),
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
@@ -360,6 +364,9 @@ mod tests {
 
     #[test]
     fn enable_creates_shim_and_disable_removes_it() {
+        // Mutates process-global PATH: serialize under lock so parallel
+        // tests resolving binaries never observe the fake bin_dir.
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = temp_test_dir("lifecycle");
         let shims_dir = dir.join("shims");
 

--- a/src/shim/mod.rs
+++ b/src/shim/mod.rs
@@ -438,6 +438,48 @@ fn is_executable_file(p: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Holds the module env lock and restores cleared vars on drop.
+    ///
+    /// `is_destructive_git_command` reads process-global
+    /// `VETTO_ALLOW_DESTRUCTIVE_GIT` and `parse_shim_args` reads
+    /// `VETTO_COMMAND_TIMEOUT`. Unit tests run on parallel threads of one
+    /// process, so a sibling test's `set_var` is visible here: without the
+    /// lock + clear, `detects_destructive_git_commands` flakes whenever it
+    /// overlaps `allows_destructive_git_bypass_and_override`.
+    struct EnvLock {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl EnvLock {
+        fn cleared(vars: &[&'static str]) -> Self {
+            let guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let mut saved = Vec::with_capacity(vars.len());
+            for name in vars {
+                saved.push((*name, env::var_os(name)));
+                env::remove_var(name);
+            }
+            Self {
+                _guard: guard,
+                saved,
+            }
+        }
+    }
+
+    impl Drop for EnvLock {
+        fn drop(&mut self) {
+            for (name, value) in self.saved.drain(..) {
+                match value {
+                    Some(v) => env::set_var(name, v),
+                    None => env::remove_var(name),
+                }
+            }
+        }
+    }
 
     #[test]
     fn detects_shim_directory_patterns() {
@@ -452,6 +494,11 @@ mod tests {
 
     #[test]
     fn recursion_barrier_checks_environment() {
+        let _env = EnvLock::cleared(&[
+            ENV_VETTO_SANDBOXED,
+            ENV_VETTO_SHIM_ACTIVE,
+            ENV_VETTO_WRAPPED,
+        ]);
         env::remove_var(ENV_VETTO_SANDBOXED);
         env::remove_var(ENV_VETTO_SHIM_ACTIVE);
         env::remove_var(ENV_VETTO_WRAPPED);
@@ -484,6 +531,9 @@ mod tests {
 
     #[test]
     fn detects_destructive_git_push_variants() {
+        // `is_destructive_git_push` honors VETTO_ALLOW_DESTRUCTIVE_GIT: clear
+        // it under lock so ambient CI env or a sibling test can't flip asserts.
+        let _env = EnvLock::cleared(&["VETTO_ALLOW_DESTRUCTIVE_GIT"]);
         assert!(is_destructive_git_push(&["push".into(), "--force".into()]).is_some());
         assert!(is_destructive_git_push(&["push".into(), "-f".into()]).is_some());
         assert!(is_destructive_git_push(&["push".into(), "--force-with-lease".into()]).is_some());
@@ -505,6 +555,9 @@ mod tests {
 
     #[test]
     fn detects_destructive_git_commands() {
+        // Same bypass-env hazard as above: `reset --hard` asserts return
+        // None while a sibling test holds VETTO_ALLOW_DESTRUCTIVE_GIT=1.
+        let _env = EnvLock::cleared(&["VETTO_ALLOW_DESTRUCTIVE_GIT"]);
         // Hard reset
         assert!(is_destructive_git_command(&["reset".into(), "--hard".into()]).is_some());
         assert!(
@@ -596,6 +649,7 @@ mod tests {
 
     #[test]
     fn allows_safe_git_commands() {
+        let _env = EnvLock::cleared(&["VETTO_ALLOW_DESTRUCTIVE_GIT"]);
         assert!(is_destructive_git_command(&["status".into()]).is_none());
         assert!(
             is_destructive_git_command(&["commit".into(), "-m".into(), "msg".into()]).is_none()
@@ -619,6 +673,9 @@ mod tests {
 
     #[test]
     fn allows_destructive_git_bypass_and_override() {
+        // Sole writer of VETTO_ALLOW_DESTRUCTIVE_GIT in this module: hold the
+        // lock for the whole body; Drop restores the ambient value.
+        let _env = EnvLock::cleared(&["VETTO_ALLOW_DESTRUCTIVE_GIT"]);
         // Flag override
         assert!(is_destructive_git_command(&[
             "reset".into(),
@@ -637,6 +694,8 @@ mod tests {
 
     #[test]
     fn parse_shim_args_timeout_extraction() {
+        // `parse_shim_args` falls back to VETTO_COMMAND_TIMEOUT; isolate it.
+        let _env = EnvLock::cleared(&["VETTO_COMMAND_TIMEOUT"]);
         let args = vec![
             "--timeout".to_string(),
             "45s".to_string(),

--- a/src/shim/registry.rs
+++ b/src/shim/registry.rs
@@ -343,7 +343,8 @@ mod tests {
 
     fn temp_test_dir(name: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
-            "vetto-shim-reg-{name}-{}",
+            "vetto-shim-reg-{name}-{}-{}",
+            std::process::id(),
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()


### PR DESCRIPTION
## Корень флака (факт, статический анализ)

`is_destructive_git_command` (`src/shim/mod.rs:200-206`) первым делом читает process-global env: при `VETTO_ALLOW_DESTRUCTIVE_GIT=1` возвращает `None` на любых аргументах.

В том же модуле тест `allows_destructive_git_bypass_and_override` (`:631`) делал `env::set_var("VETTO_ALLOW_DESTRUCTIVE_GIT", "1")` **без лока**, а `detects_destructive_git_commands` (`:507-513`) в это время assert'ил `is_destructive_git_command(&["reset","--hard","HEAD~1"]).is_some()`.

Rust юнит-тесты бегут параллельными тредами одного процесса (`cargo test --all-features`, см. `ci.yml:116,131`), env process-global => гонка: попал тред в окно чужого `set_var` — `reset --hard` вернул `None`, assert упал. Отсюда push-ран красный / PR-ран зелёный на том же коммите: разный шедулинг тредов на разных раннерах. В workflowsenv не задан (`rg VETTO_ .github/` пуст), т.е. внешний env ни при чём — только intra-process race. Тот же класс: `recursion_barrier_checks_environment` мутировал 3 env без лока; `parse_shim_args` читает `VETTO_COMMAND_TIMEOUT`.

## Фикс (минимальный, паттерн TEST_LOCK из bundle.rs/undo.rs/watchdog)

- `src/shim/mod.rs`: `static TEST_LOCK` + `EnvLock` guard (lock + clear под замком, restore ambient в `Drop`, poison-safe через `into_inner`). Все env-зависимые тесты берут guard; писатель env — тоже. Новых мутаций env не добавлено.
- `src/cli/enable.rs`: мутация process-global `PATH` под `TEST_LOCK`; temp-имена pid-unique.
- `src/shim/registry.rs`: temp-имена pid-unique (были только nanos).

## Аудит остальных (без изменений — осознанно)

- `tests/`: ноль `set_var/remove_var/set_current_dir` — интеграционные hermetic (env/cwd только в child `Command`).
- `bundle/undo/watchdog` unit-тесты: уже под `TEST_LOCK` + pid-unique dirs.
- `watchdog::test_watchdog_resets_on_workspace_modification`: mtime в nanos + sleep 50ms — не флаки на ext4/tmpfs/apfs.
- Найдено вне скоупа: `tests/integration/linux_netmodes.rs::allowlist_permits_listed_domain_only` ходит в реальную сеть (`curl https://example.com`, assert на тело ответа) — честно помечаю, не трогаю без отдельного решения (нужен либо gate на OFFLINE, либо workflow-флаг).
- Делимитеры: `{}/`()`[]` сбалансированы в обоих правленых файлах с тестами env (в registry.rs перекос 3x`)` — предсуществующий, мой diff нейтрален.

## Проверка

Локальный запуск запрещён протоколом задачи — верификация только этим CI. CI досматривает автор.