### PR TITLE
feat(tests): property-based bughunt for parsers and exit codes

### DIFF
--- a/src/cli/bundle.rs
+++ b/src/cli/bundle.rs
@@ -527,6 +527,159 @@ mod tests {
         assert!(err_str.contains("not found"));
     }
 
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            self.0
+        }
+
+        fn below(&mut self, bound: u64) -> u64 {
+            if bound == 0 {
+                0
+            } else {
+                self.next() % bound
+            }
+        }
+    }
+
+    fn pick_piece(rng: &mut Lcg) -> &'static str {
+        match rng.below(12) {
+            0 => "a",
+            1 => "Z",
+            2 => "0",
+            3 => "é",
+            4 => "€",
+            5 => "😀",
+            6 => "\"",
+            7 => "\\",
+            8 => "\n",
+            9 => "\0",
+            10 => "/",
+            _ => "",
+        }
+    }
+
+    fn arb_string(rng: &mut Lcg, max_len: usize) -> String {
+        let len = rng.below(max_len as u64 + 1) as usize;
+        let mut s = String::new();
+        for _ in 0..len {
+            s.push_str(pick_piece(rng));
+        }
+        s
+    }
+
+    fn arb_vec(rng: &mut Lcg) -> Vec<String> {
+        let n = rng.below(5) as usize;
+        let mut v = Vec::new();
+        for _ in 0..n {
+            v.push(arb_string(rng, 24));
+        }
+        v
+    }
+
+    #[test]
+    fn prop_bundle_manifest_roundtrip() {
+        let mut rng = Lcg(0x1234_5678_9abc_def0);
+        for _ in 0..128 {
+            let orig = BundleManifest {
+                format_version: rng.next() as u32,
+                session_id: arb_string(&mut rng, 32),
+                created_at: arb_string(&mut rng, 32),
+                project_dir: arb_string(&mut rng, 48),
+                files_count: rng.below(100_000) as usize,
+                snapshot_size_bytes: rng.next(),
+                blocked_filesystem_count: rng.below(1000) as usize,
+                blocked_network_count: rng.below(1000) as usize,
+                allowed_domains: arb_vec(&mut rng),
+            };
+            let json = serde_json::to_vec(&orig).expect("serialize");
+            let back: BundleManifest = serde_json::from_slice(&json).expect("parse");
+            assert_eq!(orig, back);
+        }
+    }
+
+    #[test]
+    fn prop_bug_report_roundtrip() {
+        let mut rng = Lcg(0xdead_beef_cafe_f00d);
+        for _ in 0..128 {
+            let orig = BugReport {
+                format_version: rng.next() as u32,
+                vetto_version: arb_string(&mut rng, 24),
+                os: arb_string(&mut rng, 16),
+                arch: arb_string(&mut rng, 16),
+                session_id: arb_string(&mut rng, 32),
+                created_at: arb_string(&mut rng, 32),
+                blocked_filesystem_count: rng.below(1000) as usize,
+                blocked_network_count: rng.below(1000) as usize,
+                blocked_file_paths: arb_vec(&mut rng),
+                blocked_network_destinations: arb_vec(&mut rng),
+            };
+            let json = serde_json::to_vec(&orig).expect("serialize");
+            let back: BugReport = serde_json::from_slice(&json).expect("parse");
+            assert_eq!(orig.format_version, back.format_version);
+            assert_eq!(orig.vetto_version, back.vetto_version);
+            assert_eq!(orig.os, back.os);
+            assert_eq!(orig.arch, back.arch);
+            assert_eq!(orig.session_id, back.session_id);
+            assert_eq!(orig.created_at, back.created_at);
+            assert_eq!(orig.blocked_filesystem_count, back.blocked_filesystem_count);
+            assert_eq!(orig.blocked_network_count, back.blocked_network_count);
+            assert_eq!(orig.blocked_file_paths, back.blocked_file_paths);
+            assert_eq!(
+                orig.blocked_network_destinations,
+                back.blocked_network_destinations
+            );
+        }
+    }
+
+    #[test]
+    fn prop_bundle_manifest_huge_unicode() {
+        let huge = "é€😀a".repeat(8192);
+        let orig = BundleManifest {
+            format_version: u32::MAX,
+            session_id: huge.clone(),
+            created_at: String::new(),
+            project_dir: "/tmp/ünicode/€".to_string(),
+            files_count: usize::MAX,
+            snapshot_size_bytes: u64::MAX,
+            blocked_filesystem_count: usize::MAX,
+            blocked_network_count: 0,
+            allowed_domains: vec![huge.clone(), String::new()],
+        };
+        let json = serde_json::to_vec(&orig).expect("serialize huge");
+        let back: BundleManifest = serde_json::from_slice(&json).expect("parse huge");
+        assert_eq!(orig, back);
+    }
+
+    #[test]
+    fn prop_bundle_manifest_rejects_garbage() {
+        for bad in ["", "{", "{\"format_version\":1", "null", "[]", "{}"] {
+            let res: Result<BundleManifest, _> = serde_json::from_str(bad);
+            assert!(res.is_err(), "input {bad:?} must fail");
+        }
+        for bad in ["", "{}", "null", "{\"format_version\":1}"] {
+            let res: Result<BugReport, _> = serde_json::from_str(bad);
+            assert!(res.is_err(), "input {bad:?} must fail");
+        }
+        let mut rng = Lcg(0x9e37_79b9_7f4a_7c15);
+        for _ in 0..256 {
+            let s = arb_string(&mut rng, 48);
+            let a: Result<BundleManifest, _> = serde_json::from_str(&s);
+            if let Ok(v) = a {
+                let _ = serde_json::to_vec(&v).expect("reserialize");
+            }
+            let b: Result<BugReport, _> = serde_json::from_str(&s);
+            if let Ok(v) = b {
+                let _ = serde_json::to_vec(&v).expect("reserialize");
+            }
+        }
+    }
+
     #[test]
     fn test_pack_and_unpack_roundtrip() {
         let _guard = TEST_LOCK.lock().unwrap();

--- a/src/exit_codes.rs
+++ b/src/exit_codes.rs
@@ -39,7 +39,7 @@ pub fn map_session_exit_code(
     }
     if raw_exit_code < 0 {
         // Negative return indicates signal termination (e.g. -9 -> 128 + 9 = 137).
-        let sig = -raw_exit_code;
+        let sig = raw_exit_code.saturating_neg();
         return EXIT_SIGNAL_BASE.saturating_add(sig);
     }
     raw_exit_code
@@ -208,5 +208,114 @@ mod tests {
         let contained = recap_hint(EXIT_SUCCESS, 4, false).expect("contained recap");
         assert!(contained.contains('4'));
         assert!(contained.contains("vetto audit --latest"));
+    }
+
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            self.0
+        }
+
+        fn below(&mut self, bound: u64) -> u64 {
+            if bound == 0 {
+                0
+            } else {
+                self.next() % bound
+            }
+        }
+    }
+
+    fn arb_raw(rng: &mut Lcg) -> i32 {
+        match rng.below(8) {
+            0 => i32::MIN,
+            1 => i32::MAX,
+            2 => -1,
+            3 => 0,
+            4 => rng.below(256) as i32,
+            5 => -(rng.below(64) as i32 + 1),
+            6 => 124 + rng.below(10) as i32,
+            _ => rng.next() as i32,
+        }
+    }
+
+    #[test]
+    fn prop_timeout_dominates_everything() {
+        let mut rng = Lcg(0x1234_5678_9abc_def0);
+        for _ in 0..512 {
+            let raw = arb_raw(&mut rng);
+            let fail = rng.below(2) == 1;
+            assert_eq!(map_session_exit_code(raw, true, fail), EXIT_TIMEOUT);
+        }
+        assert_eq!(map_session_exit_code(i32::MIN, true, true), EXIT_TIMEOUT);
+        assert_eq!(map_session_exit_code(i32::MAX, true, true), EXIT_TIMEOUT);
+    }
+
+    #[test]
+    fn prop_signals_map_to_128_plus_n() {
+        assert_eq!(map_session_exit_code(-9, false, false), 137);
+        assert_eq!(map_session_exit_code(-15, false, false), 143);
+        assert_eq!(map_session_exit_code(-2, false, false), 130);
+        assert_eq!(map_session_exit_code(-1, false, false), 129);
+        for sig in 1..=64 {
+            assert_eq!(map_session_exit_code(-sig, false, false), 128 + sig);
+        }
+        let mut rng = Lcg(0xabcdef01_23456789);
+        for _ in 0..256 {
+            let sig = rng.below(64) as i32 + 1;
+            assert_eq!(map_session_exit_code(-sig, false, false), 128 + sig);
+        }
+    }
+
+    #[test]
+    fn prop_min_signal_never_panics() {
+        let got = map_session_exit_code(i32::MIN, false, false);
+        assert_eq!(got, i32::MAX);
+        assert!(got >= EXIT_SIGNAL_BASE);
+        let got_fail = map_session_exit_code(i32::MIN, false, true);
+        assert_eq!(got_fail, EXIT_POLICY_BLOCKED);
+    }
+
+    #[test]
+    fn prop_nonnegative_passthrough() {
+        let mut rng = Lcg(0x0bad_f00d_dead_beef);
+        for _ in 0..512 {
+            let raw = arb_raw(&mut rng);
+            if raw >= 0 {
+                assert_eq!(map_session_exit_code(raw, false, false), raw);
+            }
+        }
+        for raw in [0, 1, 42, 124, 125, 126, 127, 137, 255, 1000, i32::MAX] {
+            assert_eq!(map_session_exit_code(raw, false, false), raw);
+        }
+    }
+
+    #[test]
+    fn prop_fail_block_dominates_signal_but_not_timeout() {
+        assert_eq!(map_session_exit_code(-9, false, true), EXIT_POLICY_BLOCKED);
+        assert_eq!(map_session_exit_code(0, false, true), EXIT_POLICY_BLOCKED);
+        assert_eq!(map_session_exit_code(0, true, true), EXIT_TIMEOUT);
+        assert_eq!(map_session_exit_code(-9, true, true), EXIT_TIMEOUT);
+    }
+
+    #[test]
+    fn prop_recap_none_only_on_clean() {
+        let mut rng = Lcg(0x51ab_3c5d_7e9f_1a2b);
+        for _ in 0..1024 {
+            let code = arb_raw(&mut rng);
+            let blocked = rng.below(5);
+            let timed_out = rng.below(2) == 1;
+            let got = recap_hint(code, blocked, timed_out);
+            let clean = code == 0 && blocked == 0 && !timed_out;
+            assert_eq!(got.is_none(), clean, "code={code} blocked={blocked}");
+        }
+        assert_eq!(recap_hint(0, 0, false), None);
+        assert!(recap_hint(0, 1, false).is_some());
+        assert!(recap_hint(1, 0, false).is_some());
+        assert!(recap_hint(0, 0, true).is_some());
     }
 }

--- a/src/policy/crypto.rs
+++ b/src/policy/crypto.rs
@@ -394,7 +394,7 @@ mod tests {
 
     #[test]
     fn prop_parse_sig_rejects_truncated_and_bad_lengths() {
-        let short_sig = "ab".repeat(1);
+        let short_sig = "ab".to_string();
         let sig_63 = "ab".repeat(63);
         let sig_65 = "ab".repeat(65);
         let cases = [
@@ -466,11 +466,8 @@ mod tests {
                     }
                 }
             }
-            match parse_signature_file(&s) {
-                Ok((sig, _)) => {
-                    assert_eq!(to_hex(&sig.to_bytes()).len(), 128);
-                }
-                Err(_) => {}
+            if let Ok((sig, _)) = parse_signature_file(&s) {
+                assert_eq!(to_hex(&sig.to_bytes()).len(), 128);
             }
         }
     }

--- a/src/policy/crypto.rs
+++ b/src/policy/crypto.rs
@@ -373,17 +373,12 @@ mod tests {
 
     #[test]
     fn prop_from_hex_never_panics_on_garbage() {
-        for bad in ["€€", "😀", "éé", "a€b€", "zz", "abc"] {
+        for bad in ["€€", "😀", "éé", "a€b€", "zz", "abc", "\u{feff}ab"] {
             let res = from_hex(bad);
             assert!(res.is_err(), "input {bad:?} must be Err");
         }
-        // Empty input decodes to empty output; a leading BOM is whitespace
-        // trimmed before parsing — both are valid, not errors.
+        // Empty input decodes to empty output — valid, not an error.
         assert_eq!(from_hex("").expect("empty hex is valid"), Vec::<u8>::new());
-        assert_eq!(
-            from_hex("\u{feff}ab").expect("BOM-trimmed hex is valid"),
-            vec![0xab]
-        );
         let mut rng = Lcg(0xdead_beef_cafe_f00d);
         for _ in 0..512 {
             let mut s = String::new();

--- a/src/policy/crypto.rs
+++ b/src/policy/crypto.rs
@@ -380,7 +380,10 @@ mod tests {
         // Empty input decodes to empty output; a leading BOM is whitespace
         // trimmed before parsing — both are valid, not errors.
         assert_eq!(from_hex("").expect("empty hex is valid"), Vec::<u8>::new());
-        assert_eq!(from_hex("\u{feff}ab").expect("BOM-trimmed hex is valid"), vec![0xab]);
+        assert_eq!(
+            from_hex("\u{feff}ab").expect("BOM-trimmed hex is valid"),
+            vec![0xab]
+        );
         let mut rng = Lcg(0xdead_beef_cafe_f00d);
         for _ in 0..512 {
             let mut s = String::new();

--- a/src/policy/crypto.rs
+++ b/src/policy/crypto.rs
@@ -36,6 +36,9 @@ pub fn from_hex(hex_str: &str) -> Result<Vec<u8>> {
     if hex_str.len() % 2 != 0 {
         bail!("invalid hex string length");
     }
+    if !hex_str.is_ascii() {
+        bail!("invalid hex character: non-ascii input");
+    }
     let mut bytes = Vec::with_capacity(hex_str.len() / 2);
     for i in (0..hex_str.len()).step_by(2) {
         let byte = u8::from_str_radix(&hex_str[i..i + 2], 16)
@@ -122,15 +125,20 @@ pub fn create_signature_file_content(sig: &Signature, pubkey: &VerifyingKey) -> 
 
 /// Parses a `.sig` file to extract the Ed25519 signature and optional public key.
 pub fn parse_signature_file(content: &str) -> Result<(Signature, Option<VerifyingKey>)> {
-    let mut sig_hex = None;
-    let mut pub_hex = None;
+    let mut sig_hex: Option<String> = None;
+    let mut pub_hex: Option<String> = None;
 
     for line in content.lines() {
         let line = line.trim();
-        if line.starts_with("# Public Key:") {
-            let key_str = line.trim_start_matches("# Public Key:").trim();
-            pub_hex = Some(key_str.to_string());
+        if let Some(rest) = line.strip_prefix("# Public Key:") {
+            if pub_hex.is_some() {
+                bail!("duplicate public key header in .sig file");
+            }
+            pub_hex = Some(rest.trim().to_string());
         } else if !line.starts_with('#') && !line.is_empty() {
+            if sig_hex.is_some() {
+                bail!("multiple signature lines in .sig file");
+            }
             sig_hex = Some(line.to_string());
         }
     }
@@ -307,5 +315,163 @@ mod tests {
         let (parsed_sig, parsed_pub) = parse_signature_file(&text).expect("parse sig");
         assert_eq!(sig, parsed_sig);
         assert_eq!(Some(pubkey), parsed_pub);
+    }
+
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            self.0
+        }
+
+        fn below(&mut self, bound: u64) -> u64 {
+            if bound == 0 {
+                0
+            } else {
+                self.next() % bound
+            }
+        }
+    }
+
+    fn pick_hex_piece(rng: &mut Lcg) -> &'static str {
+        match rng.below(10) {
+            0 => "00",
+            1 => "ab",
+            2 => "zz",
+            3 => " ",
+            4 => "€",
+            5 => "😀",
+            6 => "é",
+            7 => "#",
+            8 => ":",
+            _ => "\n",
+        }
+    }
+
+    fn pick_line_kind(rng: &mut Lcg) -> u64 {
+        rng.below(5)
+    }
+
+    #[test]
+    fn prop_hex_roundtrip_random_bytes() {
+        let mut rng = Lcg(0x1234_5678_9abc_def0);
+        for _ in 0..256 {
+            let len = rng.below(65) as usize;
+            let mut bytes = Vec::with_capacity(len);
+            for _ in 0..len {
+                bytes.push(rng.below(256) as u8);
+            }
+            let hex = to_hex(&bytes);
+            let back = from_hex(&hex).expect("roundtrip must succeed");
+            assert_eq!(bytes, back);
+        }
+    }
+
+    #[test]
+    fn prop_from_hex_never_panics_on_garbage() {
+        for bad in ["€€", "😀", "éé", "a€b€", "\u{feff}ab", "zz", "abc", ""] {
+            let res = from_hex(bad);
+            assert!(res.is_err(), "input {bad:?} must be Err");
+        }
+        let mut rng = Lcg(0xdead_beef_cafe_f00d);
+        for _ in 0..512 {
+            let mut s = String::new();
+            let n = rng.below(4) as usize;
+            for _ in 0..n {
+                s.push_str(pick_hex_piece(&mut rng));
+            }
+            let res = from_hex(&s);
+            if res.is_ok() {
+                assert_eq!(s.trim().len() % 2, 0);
+                assert!(s.trim().is_ascii());
+            }
+        }
+    }
+
+    #[test]
+    fn prop_parse_sig_rejects_truncated_and_bad_lengths() {
+        let short_sig = "ab".repeat(1);
+        let sig_63 = "ab".repeat(63);
+        let sig_65 = "ab".repeat(65);
+        let cases = [
+            "",
+            "   \n  \n",
+            "# VETTO POLICY SIGNATURE (ED25519)\n",
+            "zz\n",
+            "abc\n",
+            "# comment\nzz\n",
+        ];
+        for c in cases {
+            assert!(parse_signature_file(c).is_err(), "case {c:?} must fail");
+        }
+        assert!(parse_signature_file(&short_sig).is_err());
+        assert!(parse_signature_file(&sig_63).is_err());
+        assert!(parse_signature_file(&sig_65).is_err());
+        assert!(parse_signature_file("gg").is_err());
+    }
+
+    #[test]
+    fn prop_parse_sig_rejects_trailing_garbage() {
+        let key = SigningKey::generate(&mut OsRng);
+        let pubkey = key.verifying_key();
+        let sig = key.sign(b"prop-input");
+        let valid = create_signature_file_content(&sig, &pubkey);
+        let sig_hex = to_hex(&sig.to_bytes());
+        let pub_hex = to_hex(pubkey.as_bytes());
+        let with_extra_sig = format!("{valid}{sig_hex}\n");
+        assert!(parse_signature_file(&with_extra_sig).is_err());
+        let with_extra_line = format!("{valid}extra-garbage-line\n");
+        assert!(parse_signature_file(&with_extra_line).is_err());
+        let mut dup_pub = String::from("# VETTO POLICY SIGNATURE (ED25519)\n");
+        dup_pub.push_str("# Public Key: ");
+        dup_pub.push_str(&pub_hex);
+        dup_pub.push_str("\n# Public Key: ");
+        dup_pub.push_str(&pub_hex);
+        dup_pub.push('\n');
+        dup_pub.push_str(&sig_hex);
+        dup_pub.push('\n');
+        assert!(parse_signature_file(&dup_pub).is_err());
+        assert!(parse_signature_file(&valid).is_ok());
+    }
+
+    #[test]
+    fn prop_parse_sig_fuzz_no_panic() {
+        let mut rng = Lcg(0x9e37_79b9_7f4a_7c15);
+        for _ in 0..512 {
+            let mut s = String::new();
+            let lines = rng.below(4) as usize;
+            for _ in 0..lines {
+                match pick_line_kind(&mut rng) {
+                    0 => {
+                        s.push_str("# comment\n");
+                    }
+                    1 => {
+                        s.push_str("# Public Key: ");
+                        s.push_str(pick_hex_piece(&mut rng));
+                        s.push('\n');
+                    }
+                    2 => {
+                        s.push_str(pick_hex_piece(&mut rng));
+                        s.push('\n');
+                    }
+                    3 => {
+                        s.push_str("ab00ff\n");
+                    }
+                    _ => {
+                        s.push('\n');
+                    }
+                }
+            }
+            match parse_signature_file(&s) {
+                Ok((sig, _)) => {
+                    assert_eq!(to_hex(&sig.to_bytes()).len(), 128);
+                }
+                Err(_) => {}
+            }
+        }
     }
 }

--- a/src/policy/crypto.rs
+++ b/src/policy/crypto.rs
@@ -373,10 +373,14 @@ mod tests {
 
     #[test]
     fn prop_from_hex_never_panics_on_garbage() {
-        for bad in ["€€", "😀", "éé", "a€b€", "\u{feff}ab", "zz", "abc", ""] {
+        for bad in ["€€", "😀", "éé", "a€b€", "zz", "abc"] {
             let res = from_hex(bad);
             assert!(res.is_err(), "input {bad:?} must be Err");
         }
+        // Empty input decodes to empty output; a leading BOM is whitespace
+        // trimmed before parsing — both are valid, not errors.
+        assert_eq!(from_hex("").expect("empty hex is valid"), Vec::<u8>::new());
+        assert_eq!(from_hex("\u{feff}ab").expect("BOM-trimmed hex is valid"), vec![0xab]);
         let mut rng = Lcg(0xdead_beef_cafe_f00d);
         for _ in 0..512 {
             let mut s = String::new();


### PR DESCRIPTION
Property-based bughunt без новых зависимостей (std LCG, без мутации env).

Найденные баги (все с регресс-тестами):

1. `src/policy/crypto.rs::from_hex` — паника на non-ascii.
   Что: `&hex_str[i..i+2]` режет по байтам, на `€€`/`😀` (четная длина, разрез внутри UTF-8) паникует `byte index is not a char boundary`, обязан вернуть Err.
   Фикс: `if !hex_str.is_ascii() { bail!("invalid hex character: non-ascii input") }` — ascii гарантирует границы.
   Тест: `prop_from_hex_never_panics_on_garbage`.

2. `src/policy/crypto.rs::parse_signature_file` — молчаливый Ok на мусоре.
   Что: брал последнюю не-коммент строку в `sig_hex`, лишний мусор/вторая валидная подпись возвращали Ok; дубли `# Public Key:` тоже молча перезаписывались. Плюс `trim_start_matches` вместо `strip_prefix`.
   Фикс: `strip_prefix` + `bail!"multiple signature lines"` / `bail!"duplicate public key header"`.
   Тесты: `prop_parse_sig_rejects_trailing_garbage`, `prop_parse_sig_fuzz_no_panic`.

3. `src/exit_codes.rs::map_session_exit_code` — паника на `i32::MIN`.
   Что: `let sig = -raw_exit_code` паникует в debug на MIN (overflow), обязан маппить без паники.
   Фикс: `raw_exit_code.saturating_neg()` + существующий `saturating_add` → MIN дает `i32::MAX`, инвариант >=128 сохранен.
   Тесты: `prop_min_signal_never_panics`, `prop_timeout_dominates_everything`, `prop_signals_map_to_128_plus_n`.

Не баги (зафиксированы инвариантами):
- `BundleManifest`/`BugReport` serde roundtrip держит unicode/пустые/огромные (u32::MAX/usize::MAX/u64::MAX, 82KB строки) — `prop_bundle_manifest_roundtrip`, `prop_bug_report_roundtrip`, `prop_bundle_manifest_huge_unicode`.
- `map_session_exit_code`: timeout доминирует, неотрицательные сквозят — `prop_timeout_dominates_everything`, `prop_nonnegative_passthrough`.
- `recap_hint`: None только при 0/0/false — `prop_recap_none_only_on_clean` (1024 случайных кейса).

Дисциплина: без proptest (lock нельзя обновить без cargo) — ручной LCG на std; только чистые функции, без set_var/HOME/PATH; rustfmt нового тулчейна чист (`rustfmt --check` 0); баланс делимитеров проверен python-подсчетом вне строк; `cargo build/test/check` локально не запускались — проверка через CI.