### PR TITLE
fix(errors): close unwrap panics and map sandbox/policy failures to typed exit codes

### DIFF
--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -180,11 +180,7 @@ pub fn run_cli(json: bool) -> Result<()> {
     for s in &sessions {
         let uptime_secs = now_secs.saturating_sub(s.started_at_secs);
         let uptime_str = format_uptime(uptime_secs);
-        let short_sid = if s.session_id.len() > 8 {
-            &s.session_id[..8]
-        } else {
-            &s.session_id
-        };
+        let short_sid = short_session_id(&s.session_id);
         println!(
             "{:<10} {:<15} {:<12} {:<15} {:<10} {:<8}",
             s.pid, s.agent, s.policy, s.tier, uptime_str, short_sid
@@ -220,9 +216,41 @@ fn format_uptime(secs: u64) -> String {
     }
 }
 
+/// Truncate a session id for the status table without panicking.
+///
+/// Session ids arrive from on-disk registry files (user-controlled) and
+/// may contain multi-byte UTF-8: byte slicing at 8 could split a char
+/// boundary and panic. Floor the cut to the last valid boundary.
+fn short_session_id(session_id: &str) -> &str {
+    if session_id.len() <= 8 {
+        return session_id;
+    }
+    let mut end = 8;
+    while end > 0 && !session_id.is_char_boundary(end) {
+        end -= 1;
+    }
+    &session_id[..end]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn short_session_id_never_splits_utf8() {
+        assert_eq!(short_session_id("abc"), "abc");
+        assert_eq!(short_session_id("12345678"), "12345678");
+        assert_eq!(short_session_id("123456789"), "12345678");
+        // 8-byte cut inside a 2-byte char must floor, not panic.
+        let unicode = "ééééé"; // 10 bytes, 5 chars
+        let short = short_session_id(unicode);
+        assert!(short.len() <= 8);
+        assert!(unicode.is_char_boundary(short.len()));
+        // Emoji (4 bytes each): cut floors to a valid boundary.
+        let emoji = "😀😀😀";
+        let short_emoji = short_session_id(emoji);
+        assert!(emoji.is_char_boundary(short_emoji.len()));
+    }
 
     #[test]
     fn registry_lifecycle_and_pruning() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use anyhow::{bail, Result};
 use serde::Deserialize;
 
 use crate::cli::Cli;
+use crate::error::VettoError;
 use crate::policy::presets::{agent_network_allowlist, Preset};
 
 #[derive(Debug, Clone)]
@@ -230,7 +231,12 @@ impl RunConfig {
 
         let fail_on_block = cli.fail_on_block.or(global.fail_on_block);
         if fail_on_block == Some(0) {
-            bail!("--fail-on-block threshold must be greater than zero");
+            // Typed Policy (exit 1): the message names the flag, so the
+            // legacy "fail-on-block" substring would otherwise mis-map
+            // this CLI validation error to 126 (policy blocked).
+            return Err(anyhow::Error::new(VettoError::Policy(
+                "--fail-on-block threshold must be greater than zero".into(),
+            )));
         }
 
         let report_auto_cleanup = !cli.no_report_auto_cleanup;
@@ -556,6 +562,17 @@ mod tests {
         let cfg = config(&["--fail-on-block"]).expect("config");
         assert_eq!(cfg.fail_on_block, Some(1));
         assert!(config(&["--fail-on-block", "0"]).is_err());
+    }
+
+    #[test]
+    fn zero_fail_on_block_is_a_cli_error_not_policy_blocked() {
+        // The validation message names the flag, so it must be typed:
+        // exit 1 (agent/CLI error), never 126 (policy blocked).
+        let err = config(&["--fail-on-block", "0"]).expect_err("zero threshold rejected");
+        assert_eq!(
+            crate::exit_codes::map_error_to_exit_code(&err),
+            crate::exit_codes::EXIT_AGENT_ERROR
+        );
     }
 
     #[test]

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -21,6 +21,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
+#[cfg(any(not(unix), test))]
 use crate::error::VettoError;
 use crate::events::{Event, EventBus, FileAccess};
 

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -21,6 +21,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
+use crate::error::VettoError;
 use crate::events::{Event, EventBus, FileAccess};
 
 pub mod isolation;
@@ -186,7 +187,9 @@ pub fn run_cli(
     legacy_command: Vec<String>,
 ) -> Result<i32> {
     let _ = manifest_from_cli_inputs(manifest_path, repeated_agents, legacy_command)?;
-    bail!("multi-agent mode is unavailable on this platform; refusing to run unsandboxed")
+    Err(anyhow::Error::new(VettoError::UnsupportedPlatform(
+        "multi-agent",
+    )))
 }
 
 /// TOML manifest accepted by `vetto multi --manifest ...`.
@@ -747,5 +750,15 @@ mod tests {
         assert_eq!(p2, vec![48010, 48011, 48012, 48013, 48014]);
         assert_eq!(pool.allocate_relay_port(0), 47129);
         assert_eq!(pool.allocate_relay_port(1), 47130);
+    }
+
+    #[test]
+    fn unsupported_platform_maps_to_fail_closed() {
+        // Multi-agent on non-unix must exit 125 via the typed path.
+        let err = anyhow::Error::new(VettoError::UnsupportedPlatform("multi-agent"));
+        assert_eq!(
+            crate::exit_codes::map_error_to_exit_code(&err),
+            crate::exit_codes::EXIT_FAIL_CLOSED
+        );
     }
 }

--- a/src/multi/runtime.rs
+++ b/src/multi/runtime.rs
@@ -19,6 +19,7 @@ use std::time::Instant;
 
 #[cfg(unix)]
 use crate::config::NetMode;
+use crate::error::VettoError;
 #[cfg(unix)]
 use crate::events::Event;
 use crate::events::EventBus;
@@ -195,7 +196,9 @@ impl MultiRuntime {
                     for session in &mut pending {
                         session.terminate();
                     }
-                    bail!("multi-agent launch aborted; no unsandboxed fallback: {error:#}");
+                    return Err(anyhow::Error::new(VettoError::Sandbox(format!(
+                        "multi-agent launch aborted; no unsandboxed fallback: {error:#}"
+                    ))));
                 }
             }
         }
@@ -223,7 +226,9 @@ impl MultiRuntime {
 
     #[cfg(not(unix))]
     pub fn launch(_manifest: Manifest, _project: PathBuf, _home: PathBuf) -> Result<Self> {
-        bail!("multi-agent mode is unavailable on this platform; refusing to run unsandboxed")
+        Err(anyhow::Error::new(VettoError::UnsupportedPlatform(
+            "multi-agent",
+        )))
     }
 
     pub fn terminate(&self, index: usize) -> Result<()> {
@@ -627,6 +632,19 @@ mod tests {
         assert_ne!(
             manifest.agents[0].report_path(Some(root)),
             manifest.agents[1].report_path(Some(root))
+        );
+    }
+
+    #[test]
+    fn aborted_launch_maps_to_fail_closed() {
+        // "no unsandboxed fallback" must exit 125 via the typed path:
+        // the legacy substring fallback does not contain this message.
+        let err = anyhow::Error::new(crate::error::VettoError::Sandbox(
+            "multi-agent launch aborted; no unsandboxed fallback: boom".into(),
+        ));
+        assert_eq!(
+            crate::exit_codes::map_error_to_exit_code(&err),
+            crate::exit_codes::EXIT_FAIL_CLOSED
         );
     }
 

--- a/src/multi/runtime.rs
+++ b/src/multi/runtime.rs
@@ -32,9 +32,9 @@ use crate::report::{self, storage::ReportStorage, ReportOptions};
 use crate::sandbox::SandboxHandle;
 #[cfg(unix)]
 use crate::sandbox::{Backend, SpawnOptions, StdioMode};
-use anyhow::{Context, Result};
 #[cfg(unix)]
 use anyhow::bail;
+use anyhow::{Context, Result};
 
 #[cfg(unix)]
 use std::collections::HashMap;

--- a/src/multi/runtime.rs
+++ b/src/multi/runtime.rs
@@ -32,7 +32,9 @@ use crate::report::{self, storage::ReportStorage, ReportOptions};
 use crate::sandbox::SandboxHandle;
 #[cfg(unix)]
 use crate::sandbox::{Backend, SpawnOptions, StdioMode};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
+#[cfg(unix)]
+use anyhow::bail;
 
 #[cfg(unix)]
 use std::collections::HashMap;

--- a/src/rescue/adapter.rs
+++ b/src/rescue/adapter.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use std::path::Path;
 
 use super::types::{
@@ -28,6 +28,74 @@ pub trait RescueAdapter: Send + Sync {
         backup_dir: &Path,
     ) -> Result<RepairReceipt> {
         let _ = (context, session, backup_dir);
-        bail!("repair is not supported by adapter {}", self.id());
+        // Typed Policy (exit 1): the message says "not supported", so the
+        // legacy substring fallback would otherwise mis-map this generic
+        // adapter limitation to 125 (fail-closed sandbox error).
+        Err(anyhow::Error::new(crate::error::VettoError::Policy(
+            format!("repair is not supported by adapter {}", self.id()),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rescue::types::{Availability, RescueContext};
+
+    struct StubAdapter;
+
+    impl RescueAdapter for StubAdapter {
+        fn id(&self) -> &'static str {
+            "stub"
+        }
+
+        fn detect(&self, _context: &RescueContext) -> Result<AdapterStatus> {
+            Ok(AdapterStatus {
+                adapter: "stub".into(),
+                availability: Availability::Unavailable,
+                support_level: "stub".into(),
+                reason: None,
+            })
+        }
+
+        fn discover_sessions(&self, _context: &RescueContext) -> Result<Vec<SessionRef>> {
+            Ok(Vec::new())
+        }
+
+        fn diagnose(&self, _context: &RescueContext, session: &SessionRef) -> Result<SessionView> {
+            let _ = session;
+            anyhow::bail!("unimplemented for stub")
+        }
+
+        fn snapshot(
+            &self,
+            _context: &RescueContext,
+            _session: &SessionRef,
+            _destination: &Path,
+        ) -> Result<SnapshotReceipt> {
+            anyhow::bail!("unimplemented for stub")
+        }
+    }
+
+    #[test]
+    fn unsupported_repair_is_a_generic_error_not_fail_closed() {
+        // The default repair() message contains "not supported" but must
+        // exit 1 (agent error), never 125 (fail-closed).
+        let context = RescueContext::new(std::path::PathBuf::from("/tmp"));
+        let session = SessionRef {
+            adapter: "stub".into(),
+            key: "k".into(),
+            relative_path: "k".into(),
+            bytes: 0,
+            modified_unix_secs: None,
+            source_path: std::path::PathBuf::from("/tmp/k"),
+        };
+        let err = StubAdapter
+            .repair(&context, &session, Path::new("/tmp"))
+            .expect_err("stub repair unsupported");
+        assert_eq!(
+            crate::exit_codes::map_error_to_exit_code(&err),
+            crate::exit_codes::EXIT_AGENT_ERROR
+        );
     }
 }

--- a/src/rescue/codex.rs
+++ b/src/rescue/codex.rs
@@ -27,6 +27,23 @@ use super::types::{
 
 static CODEX_NONCE: AtomicU64 = AtomicU64::new(0);
 
+/// Build the atomic-commit staging name for a canonical repair target.
+///
+/// Returns an error (instead of panicking) when the target has no file
+/// name — e.g. `/` or `..` reaching the repair path via a crafted
+/// session selector.
+fn tmp_repair_name(canonical_target: &Path, nonce: u64) -> Result<String> {
+    let file_name = canonical_target
+        .file_name()
+        .context("target file has no filename")?;
+    Ok(format!(
+        ".{}.vetto_tmp.{}.{}",
+        file_name.to_string_lossy(),
+        std::process::id(),
+        nonce
+    ))
+}
+
 pub struct CodexAdapter;
 
 // Semantic inspection is intentionally separate from replay.  These limits
@@ -1168,12 +1185,7 @@ impl RescueAdapter for CodexAdapter {
         let parent_dir = canonical_target
             .parent()
             .context("canonical target has no parent")?;
-        let tmp_name = format!(
-            ".{}.vetto_tmp.{}.{}",
-            canonical_target.file_name().unwrap().to_string_lossy(),
-            std::process::id(),
-            nonce
-        );
+        let tmp_name = tmp_repair_name(&canonical_target, nonce)?;
         let tmp_path = parent_dir.join(tmp_name);
 
         let mut file = OpenOptions::new()
@@ -1694,5 +1706,15 @@ mod tests {
         assert_eq!(first["ordinal"], 0);
         let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
         assert_eq!(second["ordinal"], 1);
+    }
+
+    #[test]
+    fn tmp_repair_name_errors_without_filename() {
+        // A bare root has no file name: the repair path must error
+        // instead of panicking on user-controlled selectors.
+        assert!(tmp_repair_name(Path::new("/"), 1).is_err());
+        let ok = tmp_repair_name(Path::new("/tmp/state.sqlite"), 7).expect("named file");
+        assert!(ok.contains("state.sqlite"));
+        assert!(ok.contains(".vetto_tmp."));
     }
 }

--- a/src/rescue/cursor.rs
+++ b/src/rescue/cursor.rs
@@ -33,6 +33,22 @@ use super::wal::SqliteWalManager;
 
 static CURSOR_NONCE: AtomicU64 = AtomicU64::new(0);
 
+/// Build the atomic-commit staging name for a canonical repair target.
+///
+/// Returns an error (instead of panicking) when the target has no file
+/// name — e.g. `/` reaching the repair path via a crafted selector.
+fn tmp_repair_name(canonical_target: &Path, nonce: u64) -> Result<String> {
+    let file_name = canonical_target
+        .file_name()
+        .context("target file has no filename")?;
+    Ok(format!(
+        ".{}.vetto_tmp.{}.{}",
+        file_name.to_string_lossy(),
+        std::process::id(),
+        nonce
+    ))
+}
+
 const CURSOR_INTERESTING_KEYS: [&str; 4] = [
     "composer.composerData",
     "workbench.panel.chatSidebar",
@@ -548,12 +564,7 @@ impl RescueAdapter for CursorAdapter {
         let parent_dir = canonical_target
             .parent()
             .context("canonical target has no parent")?;
-        let tmp_name = format!(
-            ".{}.vetto_tmp.{}.{}",
-            canonical_target.file_name().unwrap().to_string_lossy(),
-            std::process::id(),
-            nonce
-        );
+        let tmp_name = tmp_repair_name(&canonical_target, nonce)?;
         let tmp_path = parent_dir.join(tmp_name);
 
         SqliteWalManager::copy_sqlite_set(&canonical_target, &tmp_path)?;
@@ -667,5 +678,15 @@ mod tests {
         assert!(serde_json::from_str::<serde_json::Value>(&val).is_ok());
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn tmp_repair_name_errors_without_filename() {
+        // A bare root has no file name: the repair path must error
+        // instead of panicking on user-controlled selectors.
+        assert!(tmp_repair_name(Path::new("/"), 1).is_err());
+        let ok = tmp_repair_name(Path::new("/tmp/state.vscdb"), 7).expect("named file");
+        assert!(ok.contains("state.vscdb"));
+        assert!(ok.contains(".vetto_tmp."));
     }
 }

--- a/src/sandbox/linux/mod.rs
+++ b/src/sandbox/linux/mod.rs
@@ -42,11 +42,12 @@ pub mod visibility;
 use std::ffi::CString;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 
 use super::handle::{KillStrategy, SandboxHandle, SpawnOptions, StdioMode};
 use super::Spawned;
 use crate::config::NetMode;
+use crate::error::VettoError;
 use crate::policy::{Policy, Tier};
 
 const SETUP_TIMEOUT_MS: i32 = 30_000;
@@ -261,6 +262,17 @@ fn child_fail(err_w: RawFd, code: i32, msg: &str) -> ! {
 fn child_exit(code: i32) -> ! {
     // SAFETY: immediate child exit.
     unsafe { libc::_exit(code) }
+}
+
+/// Resolve the relay fd for allowlist mode without panicking.
+///
+/// The forked child must fail closed via `child_fail`, never via `expect`:
+/// a wiring mismatch must report to the parent instead of aborting.
+fn resolve_relay_fd(relay_end: Option<RawFd>, relay_port: Option<u16>) -> Option<RawFd> {
+    match (relay_end, relay_port) {
+        (Some(fd), Some(_)) => Some(fd),
+        _ => None,
+    }
 }
 
 /// PDEATHSIG + the classic fork race check: if the parent died between fork
@@ -535,12 +547,14 @@ fn err_from_dead_child(pid: libc::pid_t, err_r: RawFd) -> anyhow::Error {
     let reason = drain_err_reason(err_r);
     let code = reap_child(pid);
     if reason.is_empty() {
-        anyhow!("sandbox child died during setup (exit {code})")
+        anyhow::Error::new(VettoError::Sandbox(format!(
+            "child died during setup (exit {code})"
+        )))
     } else {
-        anyhow!(
-            "sandbox setup failed (child exit {code}): {}",
+        anyhow::Error::new(VettoError::Sandbox(format!(
+            "child exit {code}: {}",
             reason.trim_start_matches("E:")
-        )
+        )))
     }
 }
 
@@ -1012,7 +1026,9 @@ unsafe fn child_full(a: FullChildArgs<'_>) -> ! {
     }
 
     if let Some(port) = relay_port {
-        let relay_fd = relay_end.expect("relay fd wired for allowlist mode");
+        let Some(relay_fd) = resolve_relay_fd(relay_end, relay_port) else {
+            child_fail(err_w, 115, "relay fd missing for allowlist mode");
+        };
         if let Err(e) = mounts::blackhole_resolv_conf() {
             child_fail(err_w, 121, &format!("blackhole resolv.conf: {e}"));
         }
@@ -1154,10 +1170,10 @@ fn spawn_full(
     if let Err(e) = read_exact_timeout(map_r.as_raw_fd(), &mut pid_buf, SETUP_TIMEOUT_MS) {
         let code = kill_and_reap(pid);
         let reason = drain_err_reason(err_r.as_raw_fd());
-        return Err(anyhow!(
+        return Err(anyhow::Error::new(VettoError::Sandbox(format!(
             "userns handshake failed ({e}, child exit {code}): {}",
             reason.trim_start_matches("E:")
-        ));
+        ))));
     }
     let child_pid = u32::from_le_bytes(pid_buf) as libc::pid_t;
     let maps_ok = namespaces::write_id_maps(child_pid).is_ok();
@@ -1166,10 +1182,10 @@ fn spawn_full(
     let _ = unsafe { libc::write(ack_w.as_raw_fd(), ack.as_ptr().cast(), ack.len()) };
     if !maps_ok {
         let code = reap_child(pid);
-        return Err(anyhow!(
+        return Err(anyhow::Error::new(VettoError::Sandbox(format!(
             "writing uid_map/gid_map failed (child exit {code}); \
              unprivileged userns may be restricted here"
-        ));
+        ))));
     }
     drop(map_r);
     drop(ack_w);
@@ -1182,13 +1198,15 @@ fn spawn_full(
         }
         ByteRead::Byte(other) => {
             let code = reap_child(pid);
-            return Err(anyhow!(
-                "unexpected setup byte {other:#x} from sandbox child (exit {code})"
-            ));
+            return Err(anyhow::Error::new(VettoError::Sandbox(format!(
+                "unexpected setup byte {other:#x} from child (exit {code})"
+            ))));
         }
         ByteRead::Timeout => {
             let code = kill_and_reap(pid);
-            return Err(anyhow!("sandbox setup timed out (child exit {code})"));
+            return Err(anyhow::Error::new(VettoError::Sandbox(format!(
+                "setup timed out (child exit {code})"
+            ))));
         }
     }
 
@@ -1423,13 +1441,15 @@ fn spawn_fs_only(policy: &Policy, opts: SpawnOptions, observe: bool) -> Result<S
         }
         ByteRead::Byte(other) => {
             let code = reap_child(pid);
-            return Err(anyhow!(
-                "unexpected setup byte {other:#x} from sandbox child (exit {code})"
-            ));
+            return Err(anyhow::Error::new(VettoError::Sandbox(format!(
+                "unexpected setup byte {other:#x} from child (exit {code})"
+            ))));
         }
         ByteRead::Timeout => {
             let code = kill_and_reap(pid);
-            return Err(anyhow!("sandbox setup timed out (child exit {code})"));
+            return Err(anyhow::Error::new(VettoError::Sandbox(format!(
+                "setup timed out (child exit {code})"
+            ))));
         }
     }
 
@@ -1603,13 +1623,15 @@ fn spawn_seccomp_only(policy: &Policy, opts: SpawnOptions, observe: bool) -> Res
         }
         ByteRead::Byte(other) => {
             let code = reap_child(pid);
-            return Err(anyhow!(
-                "unexpected setup byte {other:#x} from sandbox child (exit {code})"
-            ));
+            return Err(anyhow::Error::new(VettoError::Sandbox(format!(
+                "unexpected setup byte {other:#x} from child (exit {code})"
+            ))));
         }
         ByteRead::Timeout => {
             let code = kill_and_reap(pid);
-            return Err(anyhow!("sandbox setup timed out (child exit {code})"));
+            return Err(anyhow::Error::new(VettoError::Sandbox(format!(
+                "setup timed out (child exit {code})"
+            ))));
         }
     }
 
@@ -1637,4 +1659,29 @@ fn spawn_seccomp_only(policy: &Policy, opts: SpawnOptions, observe: bool) -> Res
         relay_port: None,
         notif_listener,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::exit_codes::EXIT_FAIL_CLOSED;
+
+    #[test]
+    fn relay_fd_resolves_only_when_both_ends_wired() {
+        assert_eq!(resolve_relay_fd(Some(7), Some(8080)), Some(7));
+        assert_eq!(resolve_relay_fd(None, Some(8080)), None);
+        assert_eq!(resolve_relay_fd(Some(7), None), None);
+        assert_eq!(resolve_relay_fd(None, None), None);
+    }
+
+    #[test]
+    fn sandbox_setup_failures_map_to_fail_closed() {
+        // Typed sandbox errors must exit 125 without relying on the
+        // legacy substring fallback in map_error_to_exit_code.
+        let err = anyhow::Error::new(VettoError::Sandbox("setup timed out".into()));
+        assert_eq!(
+            crate::exit_codes::map_error_to_exit_code(&err),
+            EXIT_FAIL_CLOSED
+        );
+    }
 }

--- a/src/sandbox/macos/mod.rs
+++ b/src/sandbox/macos/mod.rs
@@ -24,11 +24,12 @@ pub mod seatbelt;
 use std::ffi::CString;
 use std::os::fd::{AsRawFd, RawFd};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 
 use super::handle::{KillStrategy, SandboxHandle, SpawnOptions, StdioMode};
 use super::Spawned;
 use crate::config::NetMode;
+use crate::error::VettoError;
 use crate::policy::Policy;
 
 pub struct MacosSandbox {
@@ -118,11 +119,15 @@ impl MacosSandbox {
             (1, b'R') => {}
             (1, b'E') => {
                 let code = reap(pid);
-                return Err(anyhow!("sandbox setup failed (child exit {code})"));
+                return Err(anyhow::Error::new(VettoError::Sandbox(format!(
+                    "child exit {code} during setup"
+                ))));
             }
             _ => {
                 let code = reap(pid);
-                return Err(anyhow!("sandbox child died during setup (exit {code})"));
+                return Err(anyhow::Error::new(VettoError::Sandbox(format!(
+                    "child died during setup (exit {code})"
+                ))));
             }
         }
 
@@ -444,9 +449,26 @@ fn build_envp(policy: &Policy, opts: &SpawnOptions) -> Vec<CString> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::exit_codes::EXIT_FAIL_CLOSED;
 
     #[test]
     fn seatbelt_available_does_not_panic() {
         let _ = MacosSandbox::seatbelt_available();
+    }
+
+    #[test]
+    fn child_setup_failures_map_to_fail_closed() {
+        // Both child-setup branches must exit 125 via the typed path,
+        // not via the legacy substring fallback.
+        let reported = anyhow::Error::new(VettoError::Sandbox("child exit 1 during setup".into()));
+        assert_eq!(
+            crate::exit_codes::map_error_to_exit_code(&reported),
+            EXIT_FAIL_CLOSED
+        );
+        let died = anyhow::Error::new(VettoError::Sandbox("child died during setup".into()));
+        assert_eq!(
+            crate::exit_codes::map_error_to_exit_code(&died),
+            EXIT_FAIL_CLOSED
+        );
     }
 }

--- a/src/sandbox/windows/mod.rs
+++ b/src/sandbox/windows/mod.rs
@@ -30,6 +30,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use anyhow::{anyhow, bail, Context, Result};
 
 use crate::config::NetMode;
+use crate::error::VettoError;
 use crate::policy::{Policy, ResourceLimits};
 use crate::sandbox::handle::{KillStrategy, SandboxHandle, SpawnOptions};
 use crate::sandbox::Spawned;
@@ -431,26 +432,35 @@ impl WindowsSandbox {
     pub fn new(net: NetMode) -> Result<Self> {
         let capabilities = probe();
         if !capabilities.job_object_kill_on_close {
-            bail!("Windows Job Object kill-on-close is unavailable; refusing to run")
+            return Err(anyhow::Error::new(VettoError::Sandbox(
+                "Windows Job Object kill-on-close is unavailable; refusing to run".into(),
+            )));
         }
         if !capabilities.restricted_token || !capabilities.low_integrity_token {
-            bail!("restricted low-integrity token setup is unavailable; refusing to run")
+            return Err(anyhow::Error::new(VettoError::Sandbox(
+                "restricted low-integrity token setup is unavailable; refusing to run".into(),
+            )));
         }
         if !capabilities.appcontainer_api {
-            bail!("AppContainer capability APIs are unavailable; refusing to run")
+            return Err(anyhow::Error::new(VettoError::Sandbox(
+                "AppContainer capability APIs are unavailable; refusing to run".into(),
+            )));
         }
         if !capabilities.experimental_create_process_in_sandbox {
-            bail!(
-                "Experimental_CreateProcessInSandbox is unavailable; refusing an unsandboxed Windows fallback"
-            )
+            return Err(anyhow::Error::new(VettoError::Sandbox(
+                "Experimental_CreateProcessInSandbox is unavailable; refusing an unsandboxed Windows fallback".into(),
+            )));
         }
         if !capabilities.filesystem_policy || !capabilities.network_policy {
-            bail!("Windows process sandbox policy capabilities are incomplete; refusing to run")
+            return Err(anyhow::Error::new(VettoError::Sandbox(
+                "Windows process sandbox policy capabilities are incomplete; refusing to run"
+                    .into(),
+            )));
         }
         if !matches!(&net, &NetMode::Off) {
-            bail!(
-                "Windows experimental process sandbox needs a compiled IP/port policy; vetto's domain network modes have no DNS-to-IP compiler on this backend, refusing a weaker network policy"
-            )
+            return Err(anyhow::Error::new(VettoError::Sandbox(
+                "Windows experimental process sandbox needs a compiled IP/port policy; vetto's domain network modes have no DNS-to-IP compiler on this backend, refusing a weaker network policy".into(),
+            )));
         }
         Ok(Self { capabilities, net })
     }
@@ -460,12 +470,14 @@ impl WindowsSandbox {
             bail!("empty agent command")
         }
         if !self.capabilities.enforcement_ready() {
-            bail!("Windows sandbox capabilities are not enforcement-ready; refusing to run")
+            return Err(anyhow::Error::new(VettoError::Sandbox(
+                "Windows sandbox capabilities are not enforcement-ready; refusing to run".into(),
+            )));
         }
         if !matches!(opts.stdio, crate::sandbox::handle::StdioMode::Inherit) {
-            bail!(
-                "Windows backend currently supports inherited stdio only; refusing to detach output handles"
-            )
+            return Err(anyhow::Error::new(VettoError::Sandbox(
+                "Windows backend currently supports inherited stdio only; refusing to detach output handles".into(),
+            )));
         }
         if opts.agent_cmd.iter().any(|arg| arg.contains('\0')) {
             bail!("Windows agent command contains an embedded NUL")
@@ -1386,5 +1398,26 @@ mod tests {
         assert!(!status.enabled);
         assert!(status.requires_admin);
         assert!(status.reason.contains("optional WFP lease"));
+    }
+
+    #[test]
+    fn sandbox_unavailable_maps_to_fail_closed() {
+        // Fail-closed Windows setup errors must exit 125 via the typed
+        // path, including messages without the legacy "refusing to run"
+        // substring (e.g. weaker-network-policy, detach).
+        let err = anyhow::Error::new(crate::error::VettoError::Sandbox(
+            "Windows sandbox capabilities are not enforcement-ready; refusing to run".into(),
+        ));
+        assert_eq!(
+            crate::exit_codes::map_error_to_exit_code(&err),
+            crate::exit_codes::EXIT_FAIL_CLOSED
+        );
+        let weaker = anyhow::Error::new(crate::error::VettoError::Sandbox(
+            "refusing a weaker network policy".into(),
+        ));
+        assert_eq!(
+            crate::exit_codes::map_error_to_exit_code(&weaker),
+            crate::exit_codes::EXIT_FAIL_CLOSED
+        );
     }
 }


### PR DESCRIPTION
Аудит error-path: unwraps на user-контролируемых путях + дыры в маппинге на exit-коды (docs/exit-codes.md). Без расширения substring-fallback в map_error_to_exit_code — только typed VettoError. Прецедент PR #32 (unwrap -> Result+context).

Исправленные пути (паники -> Result+context):
- src/rescue/codex.rs — второй file_name().unwrap() в atomic-commit staging; вынесен tmp_repair_name() -> Result; crafted selector без filename теперь ошибка
- src/rescue/cursor.rs — то же самое для Cursor repair
- src/sandbox/linux/mod.rs — relay_end.expect() в форкнутом child; теперь fail-closed child_fail через resolve_relay_fd()
- src/cli/status.rs — session_id[..8] байт-слайс (паника на не-границе UTF-8 из on-disk registry); теперь short_session_id() с floor до char boundary

Неверные exit-коды (сверено с docs/exit-codes.md):
- src/sandbox/linux/mod.rs (spawn_full/fs_only/seccomp_only): userns handshake, uid_map, unexpected setup byte, setup timeout, dead-child empty-reason — уходили в 1 вместо 125; теперь VettoError::Sandbox
- src/sandbox/macos/mod.rs child setup: died-during-setup ветка — 1 вместо 125; обе ветки теперь typed Sandbox
- src/sandbox/windows/mod.rs: setup/spawn гарды, включая weaker-network-policy и detach без legacy-триггера — 1 вместо 125 (остальные шли в 125 через substring, теперь детерминированно через typed)
- src/multi/runtime.rs aborted launch no-unsandboxed-fallback — 1 вместо 125; теперь typed Sandbox
- src/multi/mod.rs + runtime.rs non-unix unavailable — теперь typed UnsupportedPlatform (125)
- src/config.rs --fail-on-block=0: валидация CLI уходила в 126 через ложное срабатывание fail-on-block; теперь typed Policy -> 1
- src/rescue/adapter.rs default repair() not-supported: уходил в 125 через ложное not-supported; теперь typed Policy -> 1

Тесты: на каждую правку unit-тест триггера (ошибочный вход напрямую, без fs/env где возможно; где нужен fs — существующие pid-unique tempdir хелперы, без мутации process-global env).

Проверки: rustfmt чист; cargo build/test не запускались на хосте per repo policy — CI досмотрит.