### PR TITLE
chore(release): bump 0.2.16 -> 0.2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project are documented here. Format follows
 Keep a Changelog; versioning follows SemVer.
 
-## [Unreleased]
+## [0.2.17] — 2026-09-06
 
 ### Added
 
@@ -13,9 +13,24 @@ Keep a Changelog; versioning follows SemVer.
 - **Activation funnel telemetry** (#27): one-time opt-in `install` / `enable` /
   `first_session` milestones (version/OS/arch + name only, no PII, tracked in
   `~/.vetto/funnel.json`).
+- **Adversarial regression suite**: 12 hermetic isolation probes
+  (`tests/integration/adv_isolation.rs`) + property tests for parsers and
+  exit-code mapping.
 
 ### Fixed
 
+- **Scope traversal bypass**: `..` and symlinked-parent escapes could evade
+  deny-prefix checks — scope decisions now use fail-closed normalization
+  (longest-existing-ancestor canonicalization + lexical remainder).
+- **Secret reintroduction**: merged `env_extra` could restore stripped proxy
+  secrets — re-stripped fail-closed after merge (Linux + macOS).
+- **Snapshot TOCTOU**: `metadata.json` published atomically (tmp + rename).
+- **Parser panics**: non-ASCII hex input, lax signature-file parsing
+  (multiple signatures / duplicate key headers), `i32::MIN` negation.
+- **Fail-open unwraps**: crafted repair selectors, relay fd wiring, session-id
+  slicing, plus sandbox/policy failures mapped to typed exit codes (125/1).
+- **Flaky tests**: shim git-guard env race fixed with module lock + ambient
+  restore; pid-unique temp dirs.
 - **Exit recap flag**: timeout hint now points at the real `--timeout` flag
   (was `--session-timeout`, which does not exist).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vetto"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
 
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vetto"
-version = "0.2.16"
+version = "0.2.17"
 
 edition = "2021"
 rust-version = "1.75"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shledery/vetto",
-  "version": "0.2.16",
+  "version": "0.2.17",
 
   "description": "Cross-platform vetto sandbox and security layer for AI coding agents",
   "license": "Apache-2.0",

--- a/packaging/aur/vetto-git/.SRCINFO
+++ b/packaging/aur/vetto-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vetto-git
 	pkgdesc = Daemon-less sandbox and audit layer for AI coding agents
-	pkgver = 0.2.16.r0.g0000000
+	pkgver = 0.2.17.r0.g0000000
 	pkgrel = 1
 	url = https://github.com/shleder/vetto
 	arch = x86_64

--- a/packaging/aur/vetto-git/.SRCINFO
+++ b/packaging/aur/vetto-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = vetto-git
 	pkgdesc = Daemon-less sandbox and audit layer for AI coding agents
-	pkgver = 0.2.17.r0.g0000000
+	pkgver = 0.2.17
 	pkgrel = 1
 	url = https://github.com/shleder/vetto
 	arch = x86_64

--- a/packaging/aur/vetto-git/PKGBUILD
+++ b/packaging/aur/vetto-git/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: vetto contributors
 pkgname=vetto-git
-pkgver=0.2.16.r0.g0000000
+pkgver=0.2.17
 pkgrel=1
 pkgdesc='Daemon-less sandbox and audit layer for AI coding agents'
 arch=('x86_64' 'aarch64')

--- a/packaging/chocolatey/vetto.nuspec
+++ b/packaging/chocolatey/vetto.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vetto</id>
-    <version>0.2.16</version>
+    <version>0.2.17</version>
     <title>vetto</title>
     <authors>vetto contributors</authors>
     <projectUrl>https://github.com/shleder/vetto</projectUrl>

--- a/packaging/homebrew/vetto.rb
+++ b/packaging/homebrew/vetto.rb
@@ -1,7 +1,7 @@
 class Vetto < Formula
   desc "Daemon-less OS sandbox and subagent security layer for AI coding agents"
   homepage "https://github.com/shleder/vetto"
-  version "0.2.16"
+  version "0.2.17"
   license "Apache-2.0"
 
   on_macos do

--- a/packaging/rpm/vetto.spec
+++ b/packaging/rpm/vetto.spec
@@ -1,5 +1,5 @@
 Name:           vetto
-Version: 0.2.16
+Version: 0.2.17
 Release:        1%{?dist}
 Summary:        Daemon-less sandbox and audit layer for AI coding agents
 License:        Apache-2.0


### PR DESCRIPTION
Релизный бамп 0.2.17: воронка (дока + телеметрия) + багохота (4 PR влиты). VERSIONS-строка после проверки реестров. AUR stable/install-fallback/tap — пост-релиз.