### PR TITLE
feat(recap): end-of-session security recap hook + audit --recap

### DIFF
--- a/src/audit/history.rs
+++ b/src/audit/history.rs
@@ -1003,6 +1003,7 @@ pub fn run_audit_command(
     limit: Option<usize>,
     query: Option<&str>,
     json_output: bool,
+    recap_only: bool,
 ) -> Result<()> {
     if latest || session_id.is_some() {
         let detail = if latest {
@@ -1023,6 +1024,9 @@ pub fn run_audit_command(
             }
         };
 
+        if recap_only {
+            return render_session_recap(&detail, json_output);
+        }
         if json_output {
             println!("{}", serde_json::to_string_pretty(&detail)?);
         } else {
@@ -1032,6 +1036,78 @@ pub fn run_audit_command(
     }
 
     run_audit(since, agent, limit, query, json_output)
+}
+
+/// Render the end-of-session security recap for a stored audit detail.
+/// Shared formatter with the live exit-path hook (see [`super::recap`]).
+pub fn render_session_recap(detail: &SessionAuditDetail, json_output: bool) -> Result<()> {
+    use super::recap::{format_session_recap, SessionRecapInput};
+    use std::collections::BTreeMap;
+
+    let mut top: BTreeMap<(&str, &str, &str), u64> = BTreeMap::new();
+    for d in &detail.filesystem_denials {
+        *top.entry((d.path.as_str(), d.process.as_str(), d.source.as_str())).or_insert(0) +=
+            d.count;
+    }
+    let mut top_denied: Vec<(String, u64)> = top
+        .into_iter()
+        .map(|((path, _, _), c)| (path.to_string(), c))
+        .collect();
+    top_denied.sort_by(|a, b| b.1.cmp(&a.1));
+
+    let egress_denied: Vec<(String, u64)> = {
+        let mut m: BTreeMap<String, u64> = BTreeMap::new();
+        for n in &detail.blocked_network {
+            *m.entry(format!("{}:{}", n.host, n.port)).or_insert(0) += n.count;
+        }
+        let mut v: Vec<_> = m.into_iter().collect();
+        v.sort_by(|a, b| b.1.cmp(&a.1));
+        v
+    };
+    // Allowed egress is not stored in the audit detail — leave empty post-hoc.
+    let egress_allowed: Vec<String> = Vec::new();
+
+    let input = SessionRecapInput {
+        exit_code: detail.exit_code,
+        duration_secs: detail.duration_secs,
+        events_total: detail.events_total,
+        denials_total: detail.violations_total,
+        top_denied,
+        egress_denied,
+        egress_allowed,
+        op_counts: BTreeMap::new(),
+        files_changed: 0,
+        verify_status: "off".into(),
+    };
+    match format_session_recap(&input) {
+        None => {
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::json!({"recap": null, "note": "clean session, nothing contained"})
+                );
+            } else {
+                println!("vetto: recap: clean session, nothing contained");
+            }
+        }
+        Some(lines) => {
+            if json_output {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "session_id": detail.session_id,
+                        "exit_code": detail.exit_code,
+                        "recap": lines,
+                    })
+                );
+            } else {
+                for line in lines {
+                    println!("vetto: recap: {line}");
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Formats and renders a detailed session audit to stdout.

--- a/src/audit/history.rs
+++ b/src/audit/history.rs
@@ -995,6 +995,20 @@ fn build_detail_from_history_record(rec: &AuditRecord) -> SessionAuditDetail {
 }
 
 /// Dispatches the `vetto audit` CLI subcommand with session inspection or listing.
+/// Options for [`run_audit_command`] — struct form avoids too-many-args lint.
+#[derive(Debug, Clone, Copy)]
+pub struct AuditCommandOptions<'a> {
+    pub session_id: Option<&'a str>,
+    pub latest: bool,
+    pub since: Option<&'a str>,
+    pub agent: Option<&'a str>,
+    pub limit: Option<usize>,
+    pub query: Option<&'a str>,
+    pub json_output: bool,
+    pub recap_only: bool,
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn run_audit_command(
     session_id: Option<&str>,
     latest: bool,
@@ -1046,14 +1060,14 @@ pub fn render_session_recap(detail: &SessionAuditDetail, json_output: bool) -> R
 
     let mut top: BTreeMap<(&str, &str, &str), u64> = BTreeMap::new();
     for d in &detail.filesystem_denials {
-        *top.entry((d.path.as_str(), d.process.as_str(), d.source.as_str())).or_insert(0) +=
-            d.count;
+        *top.entry((d.path.as_str(), d.process.as_str(), d.source.as_str()))
+            .or_insert(0) += d.count;
     }
     let mut top_denied: Vec<(String, u64)> = top
         .into_iter()
         .map(|((path, _, _), c)| (path.to_string(), c))
         .collect();
-    top_denied.sort_by(|a, b| b.1.cmp(&a.1));
+    top_denied.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
 
     let egress_denied: Vec<(String, u64)> = {
         let mut m: BTreeMap<String, u64> = BTreeMap::new();
@@ -1061,7 +1075,7 @@ pub fn render_session_recap(detail: &SessionAuditDetail, json_output: bool) -> R
             *m.entry(format!("{}:{}", n.host, n.port)).or_insert(0) += n.count;
         }
         let mut v: Vec<_> = m.into_iter().collect();
-        v.sort_by(|a, b| b.1.cmp(&a.1));
+        v.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
         v
     };
     // Allowed egress is not stored in the audit detail — leave empty post-hoc.

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -2,9 +2,11 @@
 
 pub mod digest;
 pub mod history;
+pub mod recap;
 
 pub use digest::run_digest;
 pub use history::{
     default_history_path, inspect_latest_session, inspect_session, record_session_history,
     run_audit, run_audit_command, AuditRecord, SessionAuditDetail,
 };
+pub use recap::{format_session_recap, SessionRecapInput, RECAP_TOP_N};

--- a/src/audit/recap.rs
+++ b/src/audit/recap.rs
@@ -1,0 +1,153 @@
+//! End-of-session security recap: 3-5 lines from in-memory stats.
+//!
+//! Pure formatter, no I/O. Called from the exit path in `main.rs` with the
+//! already-available snapshot — zero extra syscalls, zero log parsing.
+//! Post-hoc mode (`vetto audit --latest --recap`) reuses the same rendering
+//! over [`SessionRecapInput`] built from [`crate::audit::SessionAuditDetail`].
+
+use std::collections::BTreeMap;
+
+/// Top-N truncation for recap lists (counters are never truncated).
+pub const RECAP_TOP_N: usize = 3;
+
+/// Pre-aggregated input for the recap formatter.
+///
+/// Built either from the live [`crate::report::SessionStats`] snapshot
+/// (exit path) or from [`crate::audit::SessionAuditDetail`] (post-hoc).
+#[derive(Debug, Clone, Default)]
+pub struct SessionRecapInput {
+    pub exit_code: i32,
+    pub duration_secs: u64,
+    pub events_total: u64,
+    /// (path, count) sorted desc by count.
+    pub top_denied: Vec<(String, u64)>,
+    pub denials_total: u64,
+    /// (host:port, count) for denied egress, sorted desc.
+    pub egress_denied: Vec<(String, u64)>,
+    /// Allowed egress hosts (deduped).
+    pub egress_allowed: Vec<String>,
+    /// op name -> count (fs-read, fs-write, exec, net).
+    pub op_counts: BTreeMap<String, u64>,
+    pub files_changed: usize,
+    /// verify preflight status ("off" when disabled).
+    pub verify_status: String,
+}
+
+/// Render the recap lines (without the `vetto: recap: ` prefix).
+/// Returns `None` when the session was fully clean — stay silent like before.
+pub fn format_session_recap(input: &SessionRecapInput) -> Option<Vec<String>> {
+    if input.denials_total == 0
+        && input.egress_denied.is_empty()
+        && input.files_changed == 0
+    {
+        return None;
+    }
+    let mut lines = Vec::with_capacity(5);
+    lines.push(format!(
+        "exit {}, {} denial{} contained, net denied {} (events {}, {}s)",
+        input.exit_code,
+        input.denials_total,
+        if input.denials_total == 1 { "" } else { "s" },
+        input.egress_denied.iter().map(|(_, c)| c).sum::<u64>(),
+        input.events_total,
+        input.duration_secs,
+    ));
+    if !input.top_denied.is_empty() {
+        let top: Vec<String> = input
+            .top_denied
+            .iter()
+            .take(RECAP_TOP_N)
+            .map(|(p, c)| format!("{p} x{c}"))
+            .collect();
+        let rest = input.top_denied.len().saturating_sub(RECAP_TOP_N);
+        lines.push(format!(
+            "top denied: {}{}",
+            top.join(", "),
+            if rest > 0 {
+                format!(" (+{rest} more)")
+            } else {
+                String::new()
+            }
+        ));
+    }
+    if !input.egress_denied.is_empty() || !input.egress_allowed.is_empty() {
+        let denied: Vec<String> = input
+            .egress_denied
+            .iter()
+            .take(RECAP_TOP_N)
+            .map(|(h, c)| format!("{h} x{c}"))
+            .collect();
+        let mut seg = String::new();
+        if !denied.is_empty() {
+            seg.push_str(&format!("denied: {}", denied.join(", ")));
+        }
+        if !input.egress_allowed.is_empty() {
+            let allowed: Vec<String> =
+                input.egress_allowed.iter().take(RECAP_TOP_N).cloned().collect();
+            if !seg.is_empty() {
+                seg.push_str("; ");
+            }
+            seg.push_str(&format!("allowed: {}", allowed.join(", ")));
+        }
+        lines.push(format!("egress {seg}"));
+    }
+    if !input.op_counts.is_empty() || input.files_changed > 0 {
+        let ops: Vec<String> = ["fs-read", "fs-write", "exec", "net"]
+            .iter()
+            .filter_map(|k| input.op_counts.get(*k).map(|c| format!("{k} {c}")))
+            .collect();
+        lines.push(format!(
+            "intent: {}files changed {} → 'vetto audit --latest'",
+            if ops.is_empty() {
+                String::new()
+            } else {
+                format!("{}, ", ops.join(" / "))
+            },
+            input.files_changed,
+        ));
+    }
+    Some(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> SessionRecapInput {
+        SessionRecapInput {
+            exit_code: 0,
+            duration_secs: 4,
+            events_total: 340,
+            top_denied: vec![
+                ("/etc/shadow".into(), 5),
+                ("~/.aws/credentials".into(), 3),
+                ("/proc/x".into(), 2),
+                ("/other".into(), 1),
+            ],
+            denials_total: 11,
+            egress_denied: vec![("api.example.com:443".into(), 2)],
+            egress_allowed: vec!["registry.npmjs.org".into()],
+            op_counts: [("fs-read".into(), 120), ("exec".into(), 6)]
+                .into_iter()
+                .collect(),
+            files_changed: 4,
+            verify_status: "off".into(),
+        }
+    }
+
+    #[test]
+    fn clean_session_stays_silent() {
+        assert!(format_session_recap(&SessionRecapInput::default()).is_none());
+    }
+
+    #[test]
+    fn recap_top_is_truncated_counters_intact() {
+        let lines = format_session_recap(&sample()).expect("recap");
+        assert!(lines[0].contains("11 denials"));
+        assert!(lines[1].contains("/etc/shadow x5"));
+        assert!(lines[1].contains("(+1 more)"));
+        assert!(lines[2].contains("api.example.com:443 x2"));
+        assert!(lines[2].contains("registry.npmjs.org"));
+        assert!(lines[3].contains("files changed 4"));
+    }
+}

--- a/src/audit/recap.rs
+++ b/src/audit/recap.rs
@@ -36,10 +36,7 @@ pub struct SessionRecapInput {
 /// Render the recap lines (without the `vetto: recap: ` prefix).
 /// Returns `None` when the session was fully clean — stay silent like before.
 pub fn format_session_recap(input: &SessionRecapInput) -> Option<Vec<String>> {
-    if input.denials_total == 0
-        && input.egress_denied.is_empty()
-        && input.files_changed == 0
-    {
+    if input.denials_total == 0 && input.egress_denied.is_empty() && input.files_changed == 0 {
         return None;
     }
     let mut lines = Vec::with_capacity(5);
@@ -82,8 +79,12 @@ pub fn format_session_recap(input: &SessionRecapInput) -> Option<Vec<String>> {
             seg.push_str(&format!("denied: {}", denied.join(", ")));
         }
         if !input.egress_allowed.is_empty() {
-            let allowed: Vec<String> =
-                input.egress_allowed.iter().take(RECAP_TOP_N).cloned().collect();
+            let allowed: Vec<String> = input
+                .egress_allowed
+                .iter()
+                .take(RECAP_TOP_N)
+                .cloned()
+                .collect();
             if !seg.is_empty() {
                 seg.push_str("; ");
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -582,6 +582,9 @@ pub enum Command {
         /// Emit machine-readable JSON output
         #[arg(long)]
         json: bool,
+        /// Render the end-of-session security recap instead of the full detail
+        #[arg(long)]
+        recap: bool,
     },
     /// Generate an aggregated daily audit digest from session history.
     #[command(hide = true)]
@@ -1242,6 +1245,18 @@ mod tests {
             Some(Command::Audit {
                 latest: true,
                 json: true,
+                recap: false,
+                ..
+            })
+        ));
+
+        let audit_recap = Cli::try_parse_from(["vetto", "audit", "--latest", "--recap"])
+            .expect("audit recap parsing");
+        assert!(matches!(
+            audit_recap.command,
+            Some(Command::Audit {
+                latest: true,
+                recap: true,
                 ..
             })
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,7 @@ fn run() -> Result<()> {
             limit,
             query,
             json,
+            recap,
         }) => vetto::audit::run_audit_command(
             session_id.as_deref(),
             *latest,
@@ -310,6 +311,7 @@ fn run() -> Result<()> {
             *limit,
             query.as_deref(),
             *json,
+            *recap,
         ),
         Some(cli::Command::Digest { since, json }) => vetto::audit::run_digest(Some(since), *json),
         Some(cli::Command::DiffSessions {
@@ -1408,6 +1410,54 @@ fn supervise(cfg: RunConfig) -> Result<()> {
         );
         if let Some(hint) = exit_codes::recap_hint(code, blocked_total, timed_out) {
             eprintln!("vetto: recap: {hint}");
+        }
+        // Session security recap: top denied paths, egress split, intent —
+        // from the in-memory snapshot, zero extra I/O. Silent on clean runs.
+        if !cfg.ci {
+            let mut top_denied: Vec<(String, u64)> = snap
+                .blocked_attempts
+                .iter()
+                .map(|b| (b.path.clone(), b.count))
+                .collect();
+            top_denied.sort_by(|a, b| b.1.cmp(&a.1));
+            let mut egress_map: std::collections::BTreeMap<String, u64> =
+                std::collections::BTreeMap::new();
+            let mut egress_allowed: Vec<String> = Vec::new();
+            for r in &snap.net_requests {
+                if r.allowed {
+                    let h = format!("{}:{}", r.host, r.port);
+                    if !egress_allowed.contains(&h) {
+                        egress_allowed.push(h);
+                    }
+                } else {
+                    *egress_map
+                        .entry(format!("{}:{}", r.host, r.port))
+                        .or_insert(0) += 1;
+                }
+            }
+            let mut egress_denied: Vec<(String, u64)> =
+                egress_map.into_iter().collect();
+            egress_denied.sort_by(|a, b| b.1.cmp(&a.1));
+            let recap_input = vetto::audit::SessionRecapInput {
+                exit_code,
+                duration_secs,
+                events_total: snap.events_total,
+                top_denied,
+                denials_total: blocked_total,
+                egress_denied,
+                egress_allowed,
+                op_counts: snap.op_counts.clone(),
+                files_changed: diff.total_changed(),
+                verify_status: verify_outcome
+                    .as_ref()
+                    .map(|report| report.status().to_string())
+                    .unwrap_or_else(|| "off".to_string()),
+            };
+            if let Some(lines) = vetto::audit::format_session_recap(&recap_input) {
+                for line in lines {
+                    eprintln!("vetto: recap: {line}");
+                }
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1419,7 +1419,7 @@ fn supervise(cfg: RunConfig) -> Result<()> {
                 .iter()
                 .map(|b| (b.path.clone(), b.count))
                 .collect();
-            top_denied.sort_by(|a, b| b.1.cmp(&a.1));
+            top_denied.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
             let mut egress_map: std::collections::BTreeMap<String, u64> =
                 std::collections::BTreeMap::new();
             let mut egress_allowed: Vec<String> = Vec::new();
@@ -1435,9 +1435,8 @@ fn supervise(cfg: RunConfig) -> Result<()> {
                         .or_insert(0) += 1;
                 }
             }
-            let mut egress_denied: Vec<(String, u64)> =
-                egress_map.into_iter().collect();
-            egress_denied.sort_by(|a, b| b.1.cmp(&a.1));
+            let mut egress_denied: Vec<(String, u64)> = egress_map.into_iter().collect();
+            egress_denied.sort_by_key(|(_, c)| std::cmp::Reverse(*c));
             let recap_input = vetto::audit::SessionRecapInput {
                 exit_code,
                 duration_secs,


### PR DESCRIPTION
Auto session recap: top-3 denied paths, egress split, intent counters from in-memory snapshot (zero I/O, silent on clean runs). Post-hoc: vetto audit --latest --recap. CI green.