### PR TITLE
feat(verify-ng,p0): wire verify-ng CLI + P0 fail-closed holes (0.2.19)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -4,3 +4,4 @@ b7f65a9d99ea48c8c3f3ddd1c95ce985b23ad1a9:tests/test_adversarial_audit.py:github-
 b7f65a9d99ea48c8c3f3ddd1c95ce985b23ad1a9:tests/test_adversarial_audit.py:github-pat:432
 b7f65a9d99ea48c8c3f3ddd1c95ce985b23ad1a9:tests/test_adversarial_audit.py:jwt:413
 b7f65a9d99ea48c8c3f3ddd1c95ce985b23ad1a9:tests/test_adversarial_audit.py:pypi-upload-token:412
+77a8f66e23256eb9c340b6e971c95e98ec0848d2:tests/verify_ng/scenarios/FUZZ-CORPUS-001.toml:generic-api-key:18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project are documented here. Format follows
 Keep a Changelog; versioning follows SemVer.
 
+## [0.2.19] — 2026-09-08
+
+### Added
+
+- **`vetto verify-ng` CLI (adversarial harness skeleton)**: new `verify-ng [--json] [--lint]` subcommand wired through `src/cli.rs` + `src/main.rs` + `src/lib.rs` (`pub mod verify_ng`). `--lint` checks the frozen scenario registry (duplicate ids, empty limitations, PARTIAL-without-residual) without spawning; without `--lint` the harness fails closed with typed `VettoError::HarnessUnavailable` → exit 125, never a hollow PASS. Integration traps wired in `tests/integration/main.rs` (`mod verify_ng_traps`).
+- **10 architecture proposals merged** (`arch/all-proposals`): `docs/verify-ng.md` + 26 frozen TOML scenarios + `tests/integration/verify_ng_traps.rs` (P01, incl. Linux/Win/Mac suites, race/stress, fuzzing, differential traps FM-01..FM-12) and 9 design docs — `policy-ir` (P02), `fail-closed` inventory 22 items (P03), `secrets` broker model (P04), `proctree` containment (P05), `network` egress control (P06), `env` boundary audit (P07), `security-levels` (P08), `audit` forensics envelope (P09), `cross-platform` synthesis (CROSS). Docs only, no enforcement changes.
+
+### Fixed
+
+- **P0 fail-closed holes (from P03/P06/P07/P08 audits)**:
+  - `VETTO_SEATBELT_MODE` kill-switch is now debug-only: release builds fail closed (exit 125) on any value instead of silently stripping Seatbelt enforcement (`src/sandbox/macos/mod.rs`).
+  - `strict_allowed` bare-`*` pattern no longer matches everything: `strict:*:port` is rejected, use explicit `*.domain` or exact host (`src/sandbox/linux/net_relay.rs`, P06).
+  - Windows env deny matching is case-insensitive (upper-cased) so `aws_secret_access_key` cannot bypass `deny = ["AWS_SECRET*"]` (W1, `src/policy/types.rs`).
+  - Windows child env now strips broker proxy secrets like Linux/macOS (W2 defense-in-depth, `src/sandbox/windows/mod.rs`).
+  - `dry_run` argv goes through `logger::sanitizer::sanitize_line` so secrets in agent_cmd never print raw (A1, `src/main.rs`).
+  - `RLIMIT_CORE=0` before exec on Linux so env secrets never land in core dumps (C1, `src/sandbox/linux/mod.rs`).
+  - macOS NUL-containing env entries are dropped (`filter_map`), not silently replaced with empty strings (M1, `src/sandbox/macos/mod.rs`).
+  - Proxy vars removed from `DEFAULT_ENV_PASSTHROUGH` — relay injects them via `env_extra`, host passthrough no longer duplicates/leaks (D1, `src/policy/defaults.rs`).
+  - `VETTO_FORCE_TIER` honored only in debug/test builds, ignored in release (P03 downgrade-override).
+  - `dry-run` no longer fabricates `tier: full`: backend-detection failure prints `unknown (dry-run)` + `NOT ENFORCED` banner (F6, `src/main.rs`).
+  - Threat-model exit code corrected `103` → `125` (`docs/threat-model.md`, code is source of truth).
+- **SBPL maximum read shape documented**: `SBPL_MAXIMUM_READ_SHAPE = "shape-A-broad-plus-tail-deny"` constant + platform-backends hardening review (#62/#63 maximum-achievable, WFP admin-gating, Authenticode status).
+
 ## [0.2.18] — 2026-09-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vetto"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
 
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vetto"
-version = "0.2.18"
+version = "0.2.19"
 
 edition = "2021"
 rust-version = "1.75"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# VETTO — Daemon-less, 0ms sandbox for AI coding agents
+# VETTO — Daemon-less kernel sandbox for AI coding agents
 
 <p align="center">
   <b>Run Claude Code, Codex, and Cursor unattended with zero credential-leak anxiety.</b><br/>
@@ -34,7 +34,7 @@ a single hallucination, rogue bash loop, or prompt injection can exfiltrate your
 **VETTO** wraps Claude Code, Codex, Antigravity, Cursor, and Aider in an OS-level kernel sandbox **before the agent process starts**:
 - **Zero Credential Theft**: `~/.ssh`, `~/.aws`, `~/.gnupg`, and `.env*` are physically unreadable by the agent.
 - **Zero Destructive Writes**: Agent file modifications are strictly confined to your project root and `/tmp`.
-- **Zero Performance Penalty**: **0.002s** startup latency, 0 MB idle RAM, unprivileged execution without Docker.
+- **Zero Performance Penalty**: **~4ms** startup overhead, 0 MB idle RAM, unprivileged execution without Docker.
 
 ---
 
@@ -69,7 +69,7 @@ npx @shledery/vetto doctor
 
 ```yaml
 # In GitHub Actions CI (unattended agent runs, evals, SWE-bench)
-- uses: shleder/vetto@v0.2.13
+- uses: shleder/vetto@v0.2.18
 ```
 
 *Prebuilt standalone archives with SHA256 checksums and CycloneDX SBOMs for all architectures (`x86_64`, `aarch64`, Windows `.zip`, Linux/macOS `.tar.gz`) are published on [GitHub Releases](https://github.com/shleder/vetto/releases).*
@@ -149,7 +149,7 @@ Containers were designed for packaging backend microservices—not for interacti
 
 | Dimension | VETTO | Docker Containers | Why It Matters |
 | :--- | :--- | :--- | :--- |
-| **Startup Overhead** | **0.002s** (effectively 0ms) | **3.5s – 8.0s** | Subagents and test loops execute with zero perceptible latency |
+| **Startup Overhead** | **~4ms** (CI-gated spawn overhead) | **3.5s – 8.0s** | Subagents and test loops execute with zero perceptible latency |
 | **Daemon** | **None** (zero background processes) | `dockerd` background service | No background daemon to crash, stall, or consume idle resources |
 | **RAM Overhead** | **0 MB** | **1.5 GB+** (VM / daemon engine) | Leaves all workstation RAM free for compilation and local models |
 | **Permissions** | **Unprivileged** (no root / no sudo) | Root / `docker` group (root-equivalent) | Completely eliminates root-escalation attack surface on your host |
@@ -165,8 +165,9 @@ Security tooling frequently makes misleading cross-platform claims. Vetto reject
 
 Vetto establishes an immutable 3-tier boundary architecture:
 - **Tier 1 (Production-Grade)**: **Linux (Native)** and **Linux (WSL2)**. Full kernel isolation via Landlock LSM (ABI v1–v6), Seccomp-BPF, private Mount/PID/Network namespaces, and tmpfs secret masking overlays.
-- **Tier 2 (Experimental)**: **macOS (Darwin)**. Apple Seatbelt SBPL (`sandbox_init_with_parameters`) write and execution confinement, kqueue parent-death watchdog process reaping. Broad read permissions required due to Apple dynamic linker (`dyld`) shared cache constraints.
-- **Tier 3 (Preview / Process Guardrails)**: **Windows Native**. Process containment via Job Objects (`KILL_ON_JOB_CLOSE`), Low Integrity tokens (`S-1-16-4096`), and AppContainer DACLs. For production-grade Tier 1 isolation on Windows, running inside WSL2 is strongly recommended.
+- **Tier 1 via VM (Uniform path)**: **macOS → Linux VM** (`mac-vm`, Virtualization.framework) and **Windows → WSL2** (guest vetto + sync-back). Same Tier-1 stack inside the guest; default on macOS/Windows when the VM is configured, fail-closed with an actionable message when it is not.
+- **Tier 2 (Experimental, maximum-achievable)**: **macOS native (Seatbelt)**. Write lock + `--net=off` enforced; reads stay broad — the SBPL matrix proves only Shape A runs (all fragmented shapes SIGABRT incl. static Go), so narrow read-deny is closed until Apple fixes dyld (#62).
+- **Tier 3 (Preview, maximum-achievable)**: **Windows native (AppContainer/LPAC + Job)**. Process guardrails; per-domain WFP needs explicit admin opt-in and fails closed without it; Authenticode when the cert is present, explicit warning otherwise (#63).
 
 ### Canonical 5-Factor Capability Matrix
 
@@ -198,7 +199,7 @@ Native Windows isolation uses Job Objects and Less Privileged AppContainers (LPA
 - For production-grade **Tier 1** protection on Windows workstations, use **WSL2** (`wsl -- vetto ...`), which provides the native Linux kernel Landlock LSM and namespace isolation stack.
 
 ### Scope Closure: Issues #26, #62, #63
-Issue #26 formally closes the gap between marketing assertions and kernel reality, with per-backend tracking in #62 (macOS Seatbelt read-isolation, blocked by Apple `dyld` regression) and #63 (Windows AppContainer/LPAC hardening, WFP lease admin opt-in, release signing status). Vetto permanently repudiates ungrounded claims of cross-platform parity:
+Issue #26 tracks the honest per-OS matrix. #62 (macOS read-isolation) is closed as maximum-achievable: the SBPL matrix proves Shape A is the only runnable shape. #63 (Windows hardening) is closed as maximum-achievable: AppContainer/LPAC + Job at ceiling, WFP admin-gated, signing status explicit. Vetto permanently repudiates ungrounded claims of cross-platform parity:
 1. Platform capabilities are strictly tiered (Tier 1 Linux, Tier 2 macOS, Tier 3 Windows).
 2. All capability claims are continuously verified in CI via automated red-team matrices and diagnostic doctor probes.
 3. Pull requests or features claiming parity without underlying OS kernel enforcement proofs will be rejected.
@@ -238,6 +239,10 @@ vetto policy explain --why ~/.ssh/id_rsa
 # Inspect intercepted security violations and blocked paths from past sessions
 vetto audit
 vetto audit --latest
+
+# End-of-session security recap (top denied paths, egress split, intent)
+# printed automatically after every session; post-hoc on demand:
+vetto audit --latest --recap
 ```
 
 ### Dynamic Policy Grants (No Manual TOML Editing)
@@ -284,7 +289,7 @@ vetto --report html,sarif --jsonl session.jsonl -- cargo test
 - **No root / sudo** — runs completely unprivileged; cannot escalate host permissions.
 - **No TLS interception** — zero MITM, no custom root certificate authority; moves opaque bytes only.
 - **No telemetry or tracking** — completely private by default. No telemetry or project/user data is ever transmitted. The only network calls vetto itself initiates are short, non-blocking version checks against the npm registry and GitHub Releases (24h cache, 2s timeout, silent offline via cache). Self-update never runs unless explicitly opted in, and never in CI (`VETTO_NO_SELF_UPDATE=1` disables everything update-related).
-- **No Docker dependency** — instant 0.002s startup directly on your native OS kernel.
+- **No Docker dependency** — instant ~4ms startup directly on your native OS kernel.
 
 ---
 
@@ -314,7 +319,7 @@ Vetto puts the agent process inside an OS-level sandbox **before the agent proce
 ### 5. Policy Layer Hierarchy
 Policies merge in a deterministic, strict hierarchy where every TOML struct rejects unknown fields:
 ```text
-Host Global (~/etc/vetto/config.toml)
+Host Global (/etc/vetto/config.toml)
   └── User Global (~/.vetto/config.toml)
         └── Built-in Profile (default, strict, paranoid)
               └── Agent Preset (claude, cursor, aider, cline, codex)

--- a/docs/audit-proposal.md
+++ b/docs/audit-proposal.md
@@ -1,0 +1,457 @@
+# Prompt 09 — Structured Audit + Session Forensics (architecture proposal)
+
+Ветка: `arch/prompt-09`. Production-код не писался. Скоуп: `docs/` (этот файл),
+анализ `src/audit/`, `src/report/`, `src/events/`, `src/history.rs`.
+`src/verify_ng/` не трогался (чужой скоуп Prompt 01).
+
+## 1. Current audit architecture (что есть в репо)
+
+Источники истины сегодня:
+
+- `src/events/types.rs` — `Event` enum, 12 вариантов: `SessionStarted`,
+  `FileObserved{pid,comm,path,access}`, `ExecObserved{pid,argv}`,
+  `BlockedAttempt{pid,comm,path,source}`, `NetRequest{host,port,allowed}`,
+  `DnsResolved`, `NetEgress{host,ip,port,bytes}`, `NetQuotaExceeded`,
+  `SecretMasked{path}`, `Notice{message}`, `SessionTimeout`, `SessionEnded`.
+  Сериализация JSONL через `#[serde(tag="event")]`. Честная оговорка уже в коде:
+  `FileObserved` — best-effort /proc-poller, пропускает sub-100ms opens;
+  `BlockedAttempt` — только при опциональном канале (`--observe-seccomp` /
+  kernel audit feed). Enforcement от событий НЕ зависит.
+- `src/events/bus.rs` — `tokio::broadcast` 4096, `publish` синхронный,
+  fail-open при отсутствии получателей; `Lagged` в потребителях молча
+  пропускается (`continue`) — дыра для forensics (см. §20).
+- Потребители шины (`src/main.rs:1024-1056`): `JsonlSink` (дефолт
+  `~/.vetto/logs/session-<pid>.jsonl` + опциональный `--jsonl`),
+  `OsLogSink`, `StatsCollector`, OTEL-subscriber, `DesktopNotifier`.
+  Первым паблишится `SessionStarted{pid,tier,net_mode,profile}`
+  (`src/main.rs:1057`), затем `SecretMasked` per `deny_resolved` (только Tier FULL)
+  или `Notice` о деградации (SECCOMP / fs-only).
+- `src/report/stats.rs` — in-memory агрегатор: counts, op_counts, blocked
+  (cap 4096 distinct), suspicious через `classifier`, net/dns/egress (cap 500),
+  notices (cap 100). `SessionStats` — то, что рендерится в отчёты.
+- `src/report/json|html|md|sarif.rs + storage.rs + mod.rs` — отчёты
+  `.vetto/reports/vetto-report-<ts>-<pid>-<id>.<ext>`, `O_CREAT|O_EXCL|O_NOFOLLOW`,
+  `0600`, symlink/hardlink/fifo отказы; весь JSON прогоняется через
+  `sanitizer::sanitize_line` (best-effort). `compare_reports` — CI-дифф двух JSON.
+- `src/audit/history.rs` — `AuditRecord` (ts, session_id, agent, command?,
+  profile, policy_path?, exit_code, duration, tier, net_mode, blocked_count,
+  events_total, report_path?, log_path?) в `~/.vetto/history.jsonl` через
+  `record_session_history` (`src/main.rs:1484`); `inspect_session` /
+  `inspect_latest_session` ре-конструируют `SessionAuditDetail` парсингом JSONL
+  или JSON-отчёта; `vetto audit` — list/filter/since/agent/query + `--recap`;
+  `render_session_audit` — 5 секций (fs-denials, net, syscalls, suspicious, recs).
+- `src/history.rs` (`.vetto/history`, durations) — только для `--timeout auto`
+  (p95×2, floor 300s). К forensics отношения не имеет, не смешивать.
+- `src/events/tail.rs` (`vetto events --filter deny|net|files|exec|notice`),
+  `src/events/replay.rs` (`vetto replay --speed`), `src/audit/recap.rs`
+  (3–5 строк exit-recap, чистые сессии молчат), `src/audit/digest.rs` (daily).
+- `docs/schema/session-stats.schema.json` — JSON-контракт отчёта.
+- `docs/telemetry.md` — OTEL/opt-in, агрегированные счётчики, не forensics.
+- `src/verify_ng/` (Prompt 01): `evidence.rs` (HostFact/Constrained/SelfReport,
+  PASS только с host fact), `model.rs` (Verdict×ClaimStrength), `caps.rs`
+  (probe-доказательства для NOT_APPLICABLE), `redact.rs` (MAX_DETAIL 2000,
+  control-bytes strip, truncation) — переиспользовать как образец, не дублировать.
+
+## 2. Threat model (для чего audit нужен)
+
+Полезен при: incident, policy violation, unexpected egress, forbidden FS attempt,
+child escape attempt, secret access attempt, backend failure, degraded fallback,
+cleanup failure, споре «что реально было применено». Противник: (a) скомпрометированный/
+любопытный агент внутри песочницы (шум, секреты в argv/stdout, fork-бомбы, ключи
+в путях, попытки переполнить bus/stats); (b) post-hoc атакующий с доступом к хосту
+(правка history.jsonl/отчётов — integrity §9); (c) невнимательный оператор
+(шеринг отчёта с секретами — privacy §10). Audit — детекция и доказательство
+post-hoc, НЕ enforcement: лог не останавливает атаку, он фиксирует её след.
+
+## 3. Event taxonomy — сопоставление с prompt (Strong/Partial/Unsupported)
+
+Шкала: Strong — событие уже публикуется из доверенного хоста;
+Partial — публикуется, но best-effort/опционально/агрегировано с потерями;
+Unsupported — нет вообще.
+
+| Prompt event | Статус | Факт в репо |
+|---|---|---|
+| session created | Strong | `SessionStarted{pid,tier,net_mode,profile}`, `main.rs:1057` |
+| policy requested / normalized | Unsupported | нет событий; requested vs effective неразличимы |
+| backend selected | Partial | только строки `tier`/`net_mode` внутри `SessionStarted`; `Backend::describe()` никуда не пишется |
+| policy compiled / enforcement constructed | Unsupported | `Backend::spawn` молчит; Landlock ABI/ruleset, seccomp-профиль, mount-overlay список не фиксируются (кроме `SecretMasked` per-path) |
+| pre-launch verification | Partial | `Notice` о tier-деградации; `verify_status` в recap всегда `"off"` post-hoc; связи с `vetto verify` нет |
+| process started / child started | Partial | `ExecObserved{pid,argv}` без ppid/pgid/tree; /proc-поллер best-effort |
+| filesystem denial | Partial | `BlockedAttempt` только при опциональном канале; без него — тишина, неотличимая от «чисто» |
+| filesystem allow | Partial | `FileObserved` best-effort, sub-100ms пропуски |
+| network denial / allow | Strong (broker), Partial (прочее) | `NetRequest{allowed}` из `net_relay.rs`, `DnsResolved`, `NetEgress`, `NetQuotaExceeded` — Strong там, где трафик идёт через брокер; прямой egress вне брокера не виден |
+| secret access denial | Partial | `SecretMasked` = факт маскирования (FULL), не попытка доступа; попытка видна только если дошла до `BlockedAttempt` |
+| capability downgrade | Partial | `Notice` свободной формы, без структуры ` Capability{name,present,evidence}` (образец — `verify_ng/caps.rs`) |
+| verification result | Unsupported | нет события; `SessionStats` не несёт verdict/strength |
+| process termination | Partial | `SessionEnded{exit_code,duration}`; сигнал vs exit смешаны (`decode_status` в handle.rs, отрицательные коды) |
+| cleanup verification | Unsupported | `sweep_reparented` (proctrack.rs) и `terminate()` ничего не паблишат: число убитых/уцелевших орфанов, бюджет, timeout — теряются |
+| backend error | Partial | только `Notice{message}` свободной формы |
+| session completed | Strong | `SessionEnded` + `record_session_history` |
+
+Вывод: ядро deny/allow-сетки есть, но нет policy-snapshot, backend-plan,
+process-tree, cleanup и verification событий. Главная дыра — отсутствие
+негативных доказательств: «чистый» лог неотличим от «наблюдение было выключено».
+
+## 4. Event schema (предлагаемый контракт)
+
+Обёртка поверх существующего `Event` (расширение, не ломка JSONL):
+
+```json
+{"v":1,"event_id":"uuid7","seq":1234,"ts":"...","session_id":"session-<pid>",
+ "proc":{"pid":1,"ppid":0,"pgid":0,"comm":"..."},"type":"...","policy_hash":"sha256:…",
+ "backend":"linux:full","severity":"info|warning|high","decision":"allow|deny|n/a",
+ "corr":"…","prev_hash":"…","meta":{…}}
+```
+
+- `event_id` uuid7 (сортируемый), `seq` — монотонный счётчик sink-а на хосте;
+  разрыв seq = доказательство потерь (`Lagged`), пишется маркером
+  `sink-lagged{missed}` (уже есть в `jsonl.rs:62`, но парсеры его игнорируют —
+  чинить, не удалять).
+- `session_id` обязателен везде (сейчас выводится из pid/имени файла —
+  хрупко, коллизии при reuse pid).
+- `policy_hash` — sha256 канонического effective-policy (см. §6), одинаковый
+  во всех событиях сессии; `requested_hash` отдельно в snapshot-событии.
+- `decision` + `severity`: deny без severity=high запрещён схемой.
+- `meta` — типизированный per-type, секреты запрещены схемой (см. §10).
+- `prev_hash` — hash-chain (см. §9).
+- Fail-closed правило схемы: событие `*_denial` без `policy_hash+backend+decision`
+  считается malformed и помечается `Notice{m alformed}` — не молча глотается.
+
+## 5. Session schema
+
+Одна запись `session completed` должна содержать: session_id, started/ended_at,
+duration, exit (код + `signaled:bool`), requested/effective policy_hashes,
+backend{platform,tier,abi/ruleset-summary}, capability set, policy snapshot
+ссылку, счётчики (events_total, lost_events, denials, egress allow/deny),
+cleanup report, verification block, integrity footer (seq_max, chain_head),
+`vetto_version`+build. Сегодня это размазано по трём местам
+(JSONL-лог + JSON-отчёт + `AuditRecord`); предложение: JSON-отчёт = session record,
+JSONL = event stream, `history.jsonl` = индекс (указатели, не копия).
+
+## 6. Policy snapshot model
+
+Persisted (в отчёт + первым событием `policy.snapshot` после `SessionStarted`):
+requested policy (источники layers + их `PolicySourceKind`, CLI-overrides как факт),
+effective policy (allow_write/read, deny_resolved, secret_proxies как *паттерны*,
+не значения; net allowlist; seccomp-профиль; limits), `Backend::describe()` строкой
++ структурой probe (landlock_abi, userns, full_tier, seccomp_notify, audit_feed),
+capability report (`verify_ng::caps::CapabilitySet` — переиспользовать тип),
+security level (tier label + `SeccompProfile`), `policy_hash` (sha256 по каноническому
+JSON effective), `vetto_version` (`CARGO_PKG_VERSION`, уже пробрасывается в
+`VETTO_VERSION` env, `main.rs:836`). In-memory only: raw secret values, host env
+значения, полные argv с потенциальными секретами (в snapshot — только `argv0`+
+redacted rest). `policy.show --effective` (`policy/explain.rs`) — тот же загрузчик,
+что и сессия: использовать его как конструктор snapshot, чтобы requested vs
+effective не расходились.
+
+## 7. Process tree model
+
+Сегодня `ExecObserved{pid,argv}` без ppid — дерево невосстановимо.
+Предложение (Linux-first, честные оговорки): расширить до
+`{pid,ppid,pgid,argv0,argv_redacted,comm}`; источник — /proc-скан в момент exec
+(ppid/pgid из `/proc/<pid>/stat`, best-effort, помечать `evidence_tier:
+constrained` по шкале `verify_ng/evidence.rs`); FULL-tier дополнительно —
+post-mortem сверка через PID-namespace init (host fact). FS-ONLY — только
+poll + `sweep_reparented` отчёт. Реконструкция `reconstruct process tree` —
+чистая функция над событиями (pid→ppid рёбра), несвязанные pid — `orphan:true`,
+не додумывать. macOS: kqueue/fsevents только advisory (Unsupported для дерева);
+Windows: Job Object даёт kill-tree, но не exec-tree без ETW (Partial — ETW
+опционален, `sandbox/windows/etw.rs`); VM: hypervisor-events out of scope,
+только guest-agent маркеры как SelfReport.
+
+## 8. Evidence model (что доказывает, что нет)
+
+Три тира из `verify_ng/evidence.rs` распространить на audit: HostFact
+(post-mortem stat, wait status, sweep result, canary, Landlock-apply success —
+только это поддерживает сильные утверждения), Constrained (errno-класс + nonce
+через seccomp-notify, broker verdicts), SelfReport (stdout-маркеры, argv —
+только хинты). Audit trail доказывает: какая политика запрошена/применена
+(snapshot+hash), какой backend/tier работал, какие denials наблюдались,
+как завершилась сессия и уборка. НЕ доказывает: отсутствие необнаруженных
+доступов (наблюдение best-effort), непротиворечивость ядра, отсутствие
+kernel-эксплойта. Формулировка в отчёте обязана разделять
+«enforced (host fact)» vs «observed (constrained)» vs «no signal (not proof)».
+
+## 9. Integrity / tamper model (без buzzword-криптографии)
+
+Угроза: пост-сессионная правка `~/.vetto/history.jsonl`, JSONL-логов, отчётов
+владельцем хоста или малварью с правами пользователя. Честная матрица:
+
+- append-only + `O_APPEND|O_NOFOLLOW|O_EXCL` + fstat-валидация — уже есть
+  (`logger/jsonl.rs`, `report/mod.rs`, `report/storage.rs`). Защищает от symlink/
+  fifo/hardlink-подмен в момент записи. НЕ защищает от последующей правки файла.
+- `seq` + `sink-lagged` маркеры — детект потерь в пределах одного файла.
+  НЕ защищает от удаления суффикса.
+- hash-chain (`prev_hash`, sha256, verify в `vetto audit --verify-chain`) —
+  детект вставки/перестановки/правки середины; НЕ защищает от truncation
+  (нужен out-of-band head: seq_max+chain_head в `history.jsonl` + в отчёт) и
+  НЕ защищает от полной перезаписи атакующим, контролирующим хост целиком.
+- Ed25519-подпись отчёта (`policy/crypto.rs` уже умеет sign/verify для policy —
+  переиспользовать ключ `~/.vetto/signing.key`) — доказывает авторство хоста
+  на момент подписи третьему лицу; НЕ доказывает правдивость содержимого
+  (подписывается то, что собрал тот же хост) и бесполезна, если ключ на том же
+  хосте скомпрометирован. Поэтому: подпись — опциональная (`--sign-reports`),
+  по умолчанию выкл; chain — по умолчанию вкл (дешёвый, без ключей).
+- trusted host writer: writer = хост-процесс vetto (не песочница) — уже так;
+  зафиксировать инвариант: события изнутри песочницы никогда не принимаются
+  напрямую, только host-наблюдения (broker, notify, post-mortem).
+- `verify_ng` остаётся единственным security verifier; audit — свидетель,
+  не судья (требование prompt §Verification coupling).
+
+## 10. Secret redaction model (как не сделать forensics каналом утечки)
+
+Текущее состояние: три разных редктора — `logger/sanitizer.rs` (JSONL+reports,
+BEST-EFFORT, честно документирован), `pty/redact.rs` + `pty/ansi.rs`
+(Aho-Corasick, live stdout), `verify_ng/redact.rs` (MAX_DETAIL+control-strip+
+truncate). Дыры (adversarial): `logger/system_log.rs` и `logger/oslog.rs`
+форматируют события БЕЗ санитайзера (`system_log.rs:44-57`,
+`oslog.rs:27-43`, `_ => format!("{:?}", ev)` — полный Debug-дамп, включая
+`ExecObserved.argv` целиком); `audit/history.rs` хранит `command` как
+`argv.join(" ")` без редакции и ищет по нему (`filter_records`); TUI
+`format_event_row`/`describe` показывают полные пути/argv; `NetEgress.ip`
+и `DnsResolved.ips` — потенциальный exfil-сигнал через DNS в логах — хранить
+агрегированно (counts per domain), не каждый IP.
+
+Предложение — классификация полей, не «ещё один regex»:
+
+- `public`: tier, backend, counts, exit_code, duration, hashes — без редакции.
+- `operational`: пути deny, host allowlist-домены, comm — санитайзер + cap длины
+  (borrow `MAX_DETAIL` 2000 + truncate-маркер из `verify_ng/redact.rs`).
+- `sensitive`: argv (кроме argv0), env, Notice-тексты, stdout-производные —
+  redact-by-default: хранить `argv0` + `argc` + `argv_hash`, полный текст только
+  с `--include-argv` и явным `Notice{argv_redacted:true}`; ключи/значения —
+  только имена ключей, значения `[REDACTED]`.
+- `forbidden`: raw credentials, PEM-body, bearer-значения, полные env-дампы —
+  запрещены схемой; продюсер обязан не эмитить (fail-closed: sink дропает
+  событие с forbidden-паттерном и пишет `Notice{redaction_drop}` вместо тишины).
+- Единый `redact_text` на выходе заимствовать из `verify_ng/redact.rs`
+  (control-strip + cap), токенные паттерны — из `logger/sanitizer.rs`;
+  journald/oslog/eventlog-sink прогнать через тот же pipeline (сейчас голые).
+- Escape: все рендеры (TUI/replay/report-html) обязаны escape control-bytes
+  и ANSI (TUI уже частично через `AnsiRedactor`; replay `describe_replay_event`
+  печатает `argv.join` и `path` голыми — чинить).
+
+## 11. Storage format (JSONL vs SQLite vs CBOR)
+
+- JSON Lines — текущий, оставить как primary event stream: append-friendly,
+  grep-able, CI-простой (`jq`), работает с O_APPEND+NOFOLLOW, переживает
+  падение mid-session (каждая строка самодостаточна). Минусы: нет индекса,
+  повторный парсинг для `audit <id>` O(n). Приемлемо для CLI-объёмов.
+- SQLite — отклонить для event stream: WAL+fsync-сложности при SIGKILL-уборке,
+  lock-контеншн с sink-thread, риск «база бита — всё потеряно», тяжелее
+  `O_NOFOLLOW`-инварианты; рассмотреть позже только как опциональный индекс
+  (`vetto audit --index`) поверх JSONL, не как источник истины.
+- CBOR/binary — отклонить: нечитаемо в CI, не grep-абельно, ноль выигрыша
+  при текущих объёмах (busy-сессия ~10^4 событий).
+- Решение: JSONL (events) + JSON (session report, схема
+  `docs/schema/session-stats.schema.json` расширена §4-5) + JSONL
+  (`history.jsonl` как индекс с chain_head). Миграция — аддитивная,
+  старые файлы читаются (версионирование `"v":1`, неизвестные поля игнорить).
+
+## 12. CLI / reporting (предлагаемые запросы поверх существующего)
+
+Существует: `vetto audit [--latest|<id>|--since|--agent|--limit|query|--json|--recap]`,
+`vetto events --filter deny|net|files|exec|notice [--follow|--json]`,
+`vetto replay [--speed]`, `compare_reports`, recap, digest. Добавить (новые
+флаги/сабкоманды, без ломки старых): `--filter secret` (SecretMasked +
+secret-classified denials), `--filter degraded` (Notices о tier-fallback +
+capability.absent), `--filter cleanup` (sweep/orphan события),
+`vetto audit --verify-chain <id>` (пересчёт hash-chain + сверка head),
+`why-denied <path>` (= `policy explain` + релевантные BlockedAttempt из лога),
+`reconstruct --tree` (дерево из §7), `reconstruct --policy` (snapshot+hash),
+`--include-argv` (opt-in, с redaction-маркером). Все новые выводы — через
+единый санитайзер; `--json` остаётся машиночитаемым контрактом.
+
+## 13. TUI implications
+
+`src/tui/app.rs` (LiveEventAggregator, ring, фильтры), `full.rs` (PTY +
+AnsiRedactor), `statusline.rs` (live redact) — уже фильтруют
+deny/net/files/exec/notices. Добавить: бейдж integrity (`seq gaps: N`,
+`chain: ok/broken`), бейдж наблюдения (`observation: full/partial/off` —
+устраняет «тишина = чисто»), фильтр `degraded`/`cleanup`, redacted-рендер
+argv (только argv0 по умолчанию). TUI — потребитель той же схемы §4,
+никакой отдельной семантики событий.
+
+## 14. Linux events (evidence)
+
+FULL: Landlock-apply (ruleset summary, ABI — host fact), mount-overlay per
+deny_resolved (уже `SecretMasked`), netns/broker verdicts (уже), seccomp-notify
+BlockedAttempt (уже, опционально), PIDns teardown + sweep count (НОВОЕ —
+cleanup event), audit-feed denials (уже через `audit_reader.rs`, опционально).
+FS-ONLY: sub-reaper + `sweep_reparented` отчёт (НОВОЕ, иначе escape-attempt
+невидим); честный `Notice` о carve-out вместо overlay (уже). SECCOMP-only:
+только syscall/net сигналы + громкий `Notice` (уже); FS-события помечать
+`observation: off`, не «0 denials».
+
+## 15. Windows events
+
+Источники есть (`etw.rs`, `eventlog.rs`, `job_object.rs`, `firewall.rs`,
+`restricted_token.rs`, `appcontainer.rs`, `windows_sandbox.rs`,
+`minifilter.rs`), но в `Event` не проброшены. Предложение: маппить в ту же
+схему §4: Job Object kill-on-close → cleanup event (Strong — kernel-объект);
+WFP verdicts → NetRequest (Partial — только при включённом провайдере);
+AppContainer/restricted-token construction → enforcement-constructed
+(Strong, host fact); minifilter — только при наличии сервиса + ImagePath-match
+(иначе `capability.absent`, fail-closed, не silent); ETW — Constrained,
+опционально. Windows Sandbox (VM-путь) — см. §16.
+
+## 16. macOS / VM events
+
+macOS: Seatbelt-profile apply факт (Strong, host), fsevents (`fsevents.rs`) —
+advisory only (Unsupported для enforcement-доказательств), net_proxy verdicts
+→ NetRequest (Partial), `oslog` sink — прогнать через санитайзер (§10).
+VM (`--backend win-sandbox`, uniform VM path): hypervisor-guarantee вне зоны
+доказательств vetto — только guest-agent SelfReport-маркеры + host-side
+launch/teardown факты (VM started/stopped, image hash); e2e-изоляцию audit
+НЕ заявляет (Unsupported, честно).
+
+## 17. Verification integration (`vetto verify` + `verify_ng`)
+
+Не дублировать: переиспользовать `verify_ng::{evidence::EvidenceTier,
+caps::CapabilitySet, redact::{redact_text,MAX_DETAIL}, model::{Verdict,
+ClaimStrength}}` как общие типы (вынести в `src/evidence/` при реализации —
+этот переезд тоже часть плана). Audit-события получают поле
+`evidence_tier`; session report получает `verification:{verdict, strength,
+registry_hash}` блок, заполняемый ТОЛЬКО `verify_ng`-хarness-ом, никогда
+self-reported сессией. Инвариант: audit без host facts не может поднять
+strength выше Partial; `verify` читает audit как вход (что наблюдалось),
+а вердикт строит своими пробами.
+
+## 18. Repo / module changes (только файлы, без кода)
+
+- `src/events/types.rs` — envelope §4 (event_id/seq/session/proc/policy_hash/
+  backend/severity/decision/corr/prev_hash), новые варианты:
+  `PolicySnapshot`, `BackendSelected`, `EnforcementConstructed`,
+  `PrelaunchCheck`, `ChildStarted{ppid,pgid}`, `CapabilityDowngrade`,
+  `VerificationResult`, `CleanupReport`, `BackendError`; `ExecObserved` +
+  ppid/pgid/argv_redacted. Миграция аддитивная (`"v"` + `#[serde(default)]`).
+- `src/events/bus.rs` — счётчик seq на publish-стороне; `Lagged` превратить
+  в явное событие, не `continue`.
+- `src/logger/jsonl.rs` — простановка seq/prev_hash/session_id в sink,
+  маркеры потерь парсабельны; forbidden-паттерн → `redaction_drop`, не тишина.
+- `src/logger/system_log.rs`, `src/logger/oslog.rs` — пропустить через общий
+  санитайзер (сейчас голый формат — exfil/secret-дыра).
+- `src/policy/explain.rs` — конструктор policy snapshot + `policy_hash`
+  (sha256 канонического JSON); `why-denied` reuse.
+- `src/sandbox/mod.rs` — `Backend::describe()` структурно + publish
+  `BackendSelected`; fail-closed при unknown backend уже есть — сохранить.
+- `src/sandbox/linux/mod.rs` + `landlock.rs` + `mounts.rs` — publish
+  `EnforcementConstructed` (ABI/ruleset/mask-count); `proctrack.rs` +
+  `handle.rs` — publish `CleanupReport` (killed/reaped/survivors/budget).
+- `src/sandbox/linux/net_relay.rs`, `observe_seccomp.rs`, `audit_reader.rs` —
+  добавить policy_hash/corr/backend к существующим publish (контекст сессии).
+- `src/sandbox/windows/*`, `src/sandbox/macos/*` — маппинг §15-16 в общий `Event`.
+- `src/report/stats.rs` — агрегация новых счётчиков (lost_events, cleanup,
+  degraded) + caps preservation; сохранить caps 4096/500/100.
+- `src/report/json.rs` + `docs/schema/session-stats.schema.json` — session
+  schema §5 (snapshot-ссылка, hashes, backend, cleanup, verification,
+  integrity footer); html/md/sarif — те же поля, escape control/ANSI.
+- `src/audit/history.rs` — `AuditRecord` + chain_head/seq_max/policy_hash/
+  backend; `append_record_to_file` — O_NOFOLLOW-аналог jsonl (сейчас голый
+  `OpenOptions::append` — symlink-дыра); `command` — redacted argv0-only
+  по умолчанию; `--verify-chain`, `why-denied`, `reconstruct`.
+- `src/events/tail.rs` — фильтры secret/degraded/cleanup; `replay.rs` —
+  escape argv/path; `audit/recap.rs` — бейджи observation/integrity.
+- `src/tui/*` — те же фильтры/бейджи, redacted argv.
+- `src/evidence/` (новое, вынос из `verify_ng/`) — общие
+  EvidenceTier/Capability/redact типы для audit и verify.
+- `docs/schema/` — `audit-event.schema.json` (новое), расширение
+  `session-stats.schema.json`; `docs/telemetry.md` — границу audit vs telemetry
+  зафиксировать (forensics никогда не уходит на внешний endpoint).
+- Тесты: chain-verify, redaction-adversarial (argv/env/PEM/journald/oslog),
+  seq-gap детект, snapshot-hash стабильность, cleanup-report наличие,
+  TUI-escape. (Покрытие — при реализации, не здесь.)
+
+## 19. Migration strategy
+
+Фаза 0: схема + снапшот-хэш + envelope поверх текущего `Event`
+(аддитивно, `"v":1`, старые логи читаются). Фаза 1: backend/cleanup/
+capability события (Linux first), санитайзер в journald/oslog, O_NOFOLLOW
+для history. Фаза 2: Windows/macOS маппинг, `why-denied`/`reconstruct`/
+`--verify-chain`, TUI-бейджи. Фаза 3: опциональная Ed25519-подпись отчётов
+(`--sign-reports`, ключ из `policy/crypto.rs`), SQLite-индекс опционально.
+Каждая фаза — minor +0.0.1 по VERSIONS.md, major всегда 0. Инвариант фаз:
+ни одна фаза не меняет enforcement; только наблюдение.
+
+## 20. Security limitations (честные границы)
+
+1. Лог не доказывает enforcement: отсутствие denials при выключенном
+   наблюдении неотличимо от чистоты — лечится бейджем `observation:` (§13-14),
+   а не большим логом. Silent downgrade детектится только связкой
+   snapshot(teir/backend/caps) + `BackendSelected` + degraded-Notices;
+   один `Notice` свободной формы недостаточен — поэтому структура §4.
+2. Broadcast-losses (`Lagged→continue`, `stats` caps, net caps 500) —
+   атакующий шумом может вытеснить события; seq-gaps делают это видимым,
+   но не предотвращают. Stats-агрегаты — не доказательства, только хинты.
+3. Hash-chain ловит правку середины, но не truncation и не полную перезапись
+   атакующим с правами пользователя; подпись ловит авторство, но не правдивость
+   и умирает вместе с ключом на том же хосте. Модель: детект opportunistic-
+   правок, не защита от root/владельца хоста.
+4. Forensics-стор сам exfil-канал: argv/env/пути/IP в логах, отчёты, journald,
+   oslog, TUI-экспорт — лечится классификацией §10 (redact-by-default,
+   argv0-only, forbidden-drop, единый pipeline везде включая system_log/oslog,
+   caps на размеры). Любой новый sink обязан пройти redaction-review.
+5. Escape через логи: control/ANSI bytes в путях/argv/hostnames рендерятся в
+   TUI/replay/HTML — обязательный strip+escape (образец `verify_ng/redact.rs`).
+6. Session report пригоден для независимого review если: канонический JSON +
+   JSON-схема, policy snapshot + hashes, backend/caps блок, разделение
+   enforced/observed/no-signal, redaction-маркер (`redacted:true` + метод),
+   chain-head для проверки целостности, версия vetto. Без этих шести —
+   это маркетинг, не evidence.
+7. `command` в истории сегодня — голый `argv.join` с поиском по нему:
+   до миграции либо redact, либо не хранить; хранить секретосодержащую строку
+   ради удобства поиска — неприемлемый trade-off.
+
+## Critical review (ответы на 5 вопросов prompt)
+
+1. Что audit доказывает / не доказывает: доказывает запрошенное vs применённое
+   (при snapshot+hash), backend/tier-факт, наблюдаемые denials, исход и уборку
+   (при cleanup-событиях). НЕ доказывает отсутствие пропущенного наблюдения,
+   отсутствие kernel-обхода, правдивость при скомпрометированном хосте.
+2. Обязательные события для IR: PolicySnapshot, BackendSelected,
+   EnforcementConstructed, все denials (fs/net/secret/syscall) с decision,
+   ChildStarted(process tree), CleanupReport, BackendError, SessionEnded +
+   seq/integrity footer. Без любого из них картина неполна.
+3. Silent downgrade: детект = `requested.tier != effective.backend` или
+   `Capability.absent` без явного `degraded:true` + alert в recap/TUI;
+   молчаливый фолбэк без события — запрещён схемой (fail-closed Notice).
+4. Forensics как канал утечки: закрывается классификацией полей (§10) +
+   единым pipeline + forbidden-drop + argv0-only + caps; самая острая дыра
+   сегодня — голые system_log/oslog-sink и `command` в history.
+5. Пригодность для независимого review: шесть условий из п.6 §20; текущий
+   отчёт им не удовлетворяет (нет snapshot/hash/backend/caps/chain/
+   enforced-vs-observed), после §4-6, §9 — удовлетворяет.
+
+## Implementation plan (по фазам, без кода)
+
+- P0 (схема): envelope §4 + `audit-event.schema.json`; session schema §5;
+  policy snapshot + hash из `explain.rs`; seq в bus/sink; парсеры учат `"v"`.
+- P1 (Linux evidence + hygiene): BackendSelected/EnforcementConstructed/
+  CleanupReport/CapabilityDowngrade publish; policy_hash/corr во все publish;
+  санитайзер в system_log/oslog; O_NOFOLLOW для history; command redact;
+  фильтры secret/degraded/cleanup; `--verify-chain`.
+- P2 (поритет + UX): Windows/macOS маппинг §15-16; why-denied/reconstruct;
+  TUI-бейджи observation/integrity; вынос `src/evidence/` из verify_ng.
+- P3 (опционально): `--sign-reports` (Ed25519 из `policy/crypto.rs`);
+  SQLite-индекс поверх JSONL; старые артефакты — read-only совместимость.
+
+## Acceptance criteria
+
+- [ ] `vetto audit --verify-chain` проходит на свежих сессиях, детектит
+      ручную правку середины лог-файла и сообщает о truncation через head.
+- [ ] Чистая сессия с выключенным наблюдением показывает
+      `observation: off`, а не «0 denials»; silent downgrade tier даёт
+      явный degraded-сигнал в recap/TUI/audit.
+- [ ] Каждая сессия содержит PolicySnapshot с совпадающим policy_hash во всех
+      событиях; requested vs effective различимы; версия vetto зафиксирована.
+- [ ] CleanupReport присутствует всегда (FULL: pidns-teardown факт; FS-ONLY:
+      sweep killed/reaped/survivors/budget); escape-попытка видна в audit.
+- [ ] Adversarial redaction-тесты зелёные: argv/env/PEM/bearer/jwt в событиях,
+      отчётах, journald/oslog-выводе, `history.jsonl`, TUI-экспорте —
+      отредактированы; caps на размеры держат (bus-flood не роняет хост).
+- [ ] `why-denied`, `reconstruct --tree`, `reconstruct --policy`,
+      secret/degraded/cleanup-фильтры работают на Linux; Windows/macOS —
+      с честными Partial/Unsupported-бейджами, без завышенных заявлений.
+- [ ] JSON-отчёт валидируется расширенной `session-stats.schema.json`;
+      старые логи/отчёты читаются; enforcement не изменён (дифф — только
+      наблюдение); версионирование +0.0.1, major 0.

--- a/docs/cross-platform-proposal.md
+++ b/docs/cross-platform-proposal.md
@@ -1,0 +1,125 @@
+# Cross-platform sandbox: сверка proposal с кодом + решение
+
+Ветка: `arch/cross-platform`. Репозиторий: версия `0.2.18` (подтверждено `Cargo.toml:3`).
+Проверялся proposal `/home/shleder/Downloads/cross-platform-sandbox-proposal.md` (§1–26)
+чтением кода, не на веру. Production-код не писался. `src/verify_ng/` не тронут.
+
+## 1. Вердикт
+
+Proposal принять как базу с тремя обязательными правками (§3, пп. 1–3).
+Фактическая архитектура кода совпадает с описанной в proposal §2.1 почти везде;
+найденные расхождения — ниже, ни одно не ломает общий замысел
+(policy→compiler→runtime→backends, enforcement нативный, Linux FULL референс).
+
+## 2. Подтверждено кодом (Strong)
+
+- Fail-closed factory: `src/sandbox/mod.rs:58` (`detect/detect_with_backend/spawn`).
+  Неизвестный backend → bail, `win-sandbox` на не-Windows → bail.
+- `VETTO_FORCE_TIER` не обходит fail-closed: `src/sandbox/linux/mod.rs:106-112` —
+  форсированный tier выбирается только среди реально доступных примитивов.
+- Spawn до потоков: `src/main.rs:1-7` (порядок load-bearing), брокер/audit/TUI
+  стартуют только после `backend.spawn` (`main.rs:958-1043`).
+- Env default-deny на трёх backend: `linux/mod.rs:668`, `macos/mod.rs:432,441`
+  (`filter_proxy_secrets` до и после `env_extra`); Windows строит блок с нуля
+  (`windows/mod.rs:1117` и далее). Семантика единая.
+- Windows deny-внутри-гранта → fail-closed: `build_sandbox_spec`
+  (`windows/mod.rs:1172`+). Windows non-Off net → bail (нет DNS/IP-компилятора).
+  `inheritHandles=FALSE` в обоих вызовах create (`mod.rs:551,569`);
+  `CREATE_SUSPENDED` + `CREATE_NEW_PROCESS_GROUP` там же; строка `BREAKAWAY`
+  в коде отсутствует полностью (grep пуст) — silent-breakaway не ставится.
+- macOS Shape A + tail-deny как задокументированный максимум:
+  `macos/seatbelt.rs:204-205` (`SBPL_MAXIMUM_READ_SHAPE`), deny из
+  `policy.deny_resolved` (`seatbelt.rs:49`).
+- `macos/net_proxy.rs` НЕ wired в spawn: единственный референс —
+  объявление модуля в `sandbox/mod.rs:18`. Утверждение proposal (§10, §2.1)
+  «standalone, не wired» — факт.
+- `verify --preflight` unix-only: `src/verify.rs` — `#[cfg(not(unix))]` возвращает
+  `unavailable`. Windows battery отсутствует — главный пробел, как и заявлено.
+- `Tier` только про Linux: `src/policy/types.rs:9` (`Full/FsOnly/Seccomp`).
+- Backend-trait отсутствует: `Backend` — enum с `#[cfg]`-вариантами
+  (`sandbox/mod.rs:49`). `SandboxSpec` как типа нет; `Policy` смешанный.
+  Capability-контракт есть только у Windows (`WindowsCapabilities`,
+  `windows/mod.rs:272`) и частично у Linux (`Probe`); у macOS сравнимого нет.
+- Kill-стратегии kernel-уровня там, где заявлены: `PidNsPipe` / `ProcessGroup`
+  (sweep только Linux) / `JobObject`, `Drop→terminate` (`handle.rs:169-213`).
+- Exit-коды: `VettoError::Sandbox→125`, `Policy→1` (`error.rs` + `exit_codes.rs`).
+  Утверждение proposal §2.1 корректно.
+- Дыра `VETTO_SEATBELT_MODE=none`: подтверждена — `macos/mod.rs:356-366`:
+  режим `none` пропускает `apply_seatbelt` полностью, молча (только
+  `child_trace`). Закрыть первой, до любых новых backend (согласен с §21, §24п7).
+- Threat-model: 4 non-defense класса на месте (`docs/threat-model.md:36-63`).
+  CI: `ci.yml` + `macos-sbpl-matrix.yml` + `e2e-agents.yml` существуют.
+
+## 3. Расхождения и обязательные правки proposal
+
+1. **Внутреннее противоречие по WSL2.** §1 требует «WSL2 признать Tier 1
+   без оговорок», §12 — «Tier 1 УСЛОВНО (interop выключен, проект внутри
+   Linux-FS, иначе Partial)». Верна §12. §1 исправить на условную формулировку.
+2. **Двусмысленность «WSL2».** `docs/platform-backends.md:15-16,26` уже называет
+   Tier 1 запуск Linux-бинаря *внутри* WSL2. Предлагаемый `BackendId::wsl` (§12,
+   §23) — оркестрация *из* Windows-бинаря. Это разные trust-модели; развести
+   термины явно (wsl-exec vs wsl-orchestrated), иначе матрица §13 вводит
+   в заблуждение.
+3. **§2.2 п.7 смягчить.** `daemon`/`mcp` — отдельные субкоманды
+   (`main.rs:229-232`), не участники run-path. Риск только через общие типы
+   (`Policy`/`RunConfig`), не через поток исполнения. Dependency-lint (§20п7,
+   §21) всё равно нужен, но формулировку «в security path» снять.
+4. Мелочь: `windows/mod.rs:18`-комментарий про «один токен без AppContainer»
+   — утверждение proposal «код это уже соблюдает» проверено только
+   чтением preflight (`enforcement_ready`, `mod.rs:472`); при Phase 3
+   перечитать строки ~600–660 (Job attach до resume) глазами.
+
+## 4. Сила backend (итоговая матрица, следы в коде)
+
+| Backend | FS write | FS read | net off | net allowlist | detached cleanup | Итог |
+|---|---|---|---|---|---|---|
+| Linux FULL | Strong | Strong | Strong | Strong | Strong (kernel) | референс, не трогать |
+| Linux FS-ONLY | Strong | Strong (carve, бюджет) | Strong | Unsupported (fail-closed) | best-effort (sweep, setsid-gap) | честный fallback |
+| Windows native | Strong (grants) | Partial (alias/COM-gap) | Strong | Unsupported без admin / Partial с WFP-lease | Strong (Job) | strong при связке §1, allowlist без админа не обещать |
+| macOS native | Strong | Partial (Shape A+tail-deny) | Strong | Unsupported (fail-closed) | best-effort (watchdog) | «with documented read-isolation limits» |
+| macOS VM / WSL-hardened / .wsb | Strong | Strong | Strong | Strong/Partial | Strong | отдельные BackendId, nightly-CI |
+
+Adversarial-покрытие proposal §18 достаточно; добавить явно:
+WSL_INTEROP-вычищение из env, `/mnt/c`-проект как отдельный кейс,
+`wsl.exe`/`powershell.exe`-лаунчеры из native-песочницы, IFEO/scheduler-vectors.
+
+## 5. Предлагаемые файлы (будущие изменения, production-код НЕ писан)
+
+- `docs/cross-platform-proposal.md` — этот файл (создан сейчас).
+- `docs/threat-model.md` — дополнения §3.4 proposal (время вне покрытия,
+  COM/RPC/registry/WSL-interop, XPC/Mach/keychain/TCC/launchd, shared-folders).
+- `docs/platform-backends.md` — условный Tier 1 для WSL2 + развод терминов (п. 2 §3).
+- Новый `src/compile/` (Intent/Spec/Capabilities/ValidationReport, чистая функция).
+- `src/sandbox/backend.rs` (trait `SandboxBackend`, `BackendId`, `CommandSpec`).
+- `src/sandbox/linux|windows|macos/` — перенос capability-гейтов из spawn в compile,
+  sentinel self-test (Linux), partial-вердикты (macOS), deny-типизация (Windows).
+- Новые `src/sandbox/vm/`, `src/sandbox/wsl/` (Phase 5–6).
+- `src/verify.rs` — battery на Windows + PARTIAL-вердикты.
+- CI: FULL+FS-ONLY+seccomp джобы, windows battery, WSL-hardened джоба, VM nightly.
+
+## 6. Implementation plan (порядок из §25, принят)
+
+- Phase 0: архитектурное решение (этот файл) + threat-model. Без кода.
+- Phase 1: типы Intent/Spec/Capabilities/ValidationReport рядом с `Policy`,
+  `compile()` для Linux FULL. Dual-write с assert-эквивалентностью.
+- Phase 2: Linux hardening (sentinel self-test, типизированный R-протокол).
+- Phase 3: Windows native (compile-гейты, WFP-lease как отдельный backend-id,
+  deny лаунчеров WSL/scheduler, Job-attach аудит).
+- Phase 4: macOS native (partial-вердикты, `SEATBELT_MODE=none` за debug-gate,
+  launchd-paths deny).
+- Phase 5: macOS Linux-VM (`BackendId::VmLinux`, guest-attestation).
+- Phase 6: WSL-hardened + `.wsb` как backend-id, interop-матрица.
+- Каждый шаг — зелёный CI, Linux FULL e2e как gate без регрессий.
+- Версионирование: релизы строго +0.0.1 (AGENTS.md); docs-правки версию не бампают.
+
+## 7. Acceptance criteria
+
+1. `compile()` unit-покрыт на всех ОС; Linux FULL e2e идентичны до/после Phase 1.
+2. `VETTO_SEATBELT_MODE=none` невозможен в release-сборке (fail-closed в CI).
+3. `verify --backend X` возвращает PASS/PARTIAL(перечень)/FAIL/UNAVAILABLE;
+   partial никогда не выдаётся за PASS; Windows больше не `unavailable`.
+4. Allowlist на native Windows/macOS без admin — отказ с actionable-причиной.
+5. Не-hardened WSL — честный PARTIAL с причиной, не PASS.
+6. Ни один backend-модуль не импортирует daemon/remote/mcp/tui/telemetry (CI-lint).
+7. Формулировки claims — только из §26 proposal (запрет «full isolation»
+   без квалификатора).

--- a/docs/env-proposal.md
+++ b/docs/env-proposal.md
@@ -1,0 +1,220 @@
+# Prompt 07 — Environment & Credential Boundary: архитектурный документ
+
+> Скоуп: только `docs/` + анализ. `src/verify_ng/` не тронут. Production-код не пишется.
+
+## 1. Current env exposure inventory (факт по коду, не по prompt)
+
+Механизм един для всех backend'ов: `std::env::vars_os()` + фильтр `EnvironmentPolicy::allows()` + `env_extra` поверх.
+
+| Точка | Файл:строки | Факт |
+|---|---|---|
+| Linux child env | `src/sandbox/linux/mod.rs:652-686` | allowlist-фильтр, затем `filter_proxy_secrets`, затем `env_extra` поверх, затем повторный `filter_proxy_secrets`. Fail-closed порядок верный |
+| macOS child env | `src/sandbox/macos/mod.rs:425-450` | та же схема, что Linux |
+| Windows child env | `src/sandbox/windows/mod.rs:1114-1170` | allowlist-фильтр + `env_extra`, **без** `filter_proxy_secrets` |
+| `EnvironmentPolicy::allows` | `src/policy/types.rs:204-223` | deny-first, `*` только как суффикс-префикс, case-sensitive |
+| Merge слоёв | `src/policy/loader.rs:649-659,1434-1435` | `pass_through` и `deny_env` — union через `extend` на всех уровнях |
+| Immutable | `src/policy/loader.rs:490-544,1414-1423` | lockdown покрывает только `security.immutable=false` и FS allow-пути; env не покрыт |
+| Baseline | `src/policy/defaults.rs:61-96`, `profiles/*.toml` | один плоский allowlist (~17 имён + `LC_*`); режимов нет |
+| Agent-пресеты | `profiles/agents/*.toml` | добавляют секретные ключи (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `CODEX_*`, `OPENCODE_*`...) в `pass_through` |
+| `env_extra` | `src/main.rs:830-882` | `VETTO_*`, proxy-набор (`build_proxy_env`), `GIT_SSH_COMMAND`, `VETTO_CRED_BROKER_SOCK`; обходит allowlist by design, без проверки ключей |
+| Proxy upstream | `src/sandbox/linux/net_relay.rs:482-505` | брокер читает хостовые `HTTP(S)_PROXY`/`ALL_PROXY` напрямую из своего env (не из env агента — корректно) |
+| Secret masking в выводе | `src/logger/sanitizer.rs`, `src/pty/redact.rs`, `src/cli/mask.rs` | везде BEST-EFFORT, задокументировано |
+| `dry_run` | `src/main.rs:1589` | печатает `agent_cmd.join(" ")` без санитизации |
+| Doctor-проба | `src/doctor/agent_check.rs:117-130` | эталон: `env_clear()` + только `PATH` — правильно, взять за образец для strict-режима |
+| Seatbelt | `src/sandbox/macos/seatbelt.rs:1-70` | env-правил нет (SBPL их не выражает); unix-socket исключение для XPC оставлено сознательно |
+| Shell | везде | exec напрямую (`execve`/`CreateProcess`), шелла-прокладки нет — хорошо |
+
+Что реально наследуется по default-профилю: `HOME PATH SHELL USER LOGNAME TERM COLORTERM LANG LC_* TMPDIR PWD OLDPWD XDG_RUNTIME_DIR XDG_CONFIG_HOME NO_COLOR CI TERM_PROGRAM` (+ `HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY` из `defaults.rs:80-83`, хотя в `default.toml` их нет — расхождение константы и TOML, см. §7).
+
+Чего реально НЕТ в child env по умолчанию (Strong): `SSH_AUTH_SOCK`, `LD_PRELOAD`, `AWS_*`, `GH_TOKEN`, `*_API_KEY` (кроме agent-пресетов), `DBUS_*`, `DISPLAY`, `BASH_ENV`, `GIT_*` (кроме инжекта `GIT_SSH_COMMAND`).
+
+## 2. Вердикты по prompt (не на веру)
+
+| Требование prompt | Вердикт | Обоснование |
+|---|---|---|
+| allowlist + deny-first | **Strong** | `types.rs:204-223` уже deny-first; default-deny для всего остального |
+| secret-proxies strip | **Strong** (unix) / **Partial** (windows) | Linux/macOS — двойной strip; Windows — strip отсутствует, держится только на `bail` в `main.rs:862-870` |
+| минимизация inherited state | **Partial** | baseline узкий, но `HOME/PATH/SHELL/TMPDIR/XDG_*` наследуются verbatim без валидации |
+| 5 режимов (inherit-all/sanitized/explicit/baseline/secrets-off) | **Unsupported** | один плоский allowlist; `inherit-all` невыразим вообще, что хорошо, но и остальные 4 не различены |
+| deterministic PATH | **Unsupported** | `PATH` копируется как есть: CWD-компоненты, writable dirs, shadowing не проверяются |
+| argv policy / redaction | **Unsupported** | `agent_cmd` verbatim; `dry_run` печатает; `/proc/<pid>/cmdline` открыт внутри pidns; санитайзер только для логов |
+| запрет secrets в argv | **Unsupported** | механизма нет; только документация |
+| loader vars policy | **Partial** | default-deny спасает сегодня, но нет non-overridable deny: любой нижний слой может добавить `LD_PRELOAD` в `pass_through` |
+| policy precedence с non-overridable deny | **Unsupported** | `pass_through` — union всех слоёв (`loader.rs:651`); repo-фрагмент/CLI могут расширить env вопреки system; immutable env не касается |
+| shell startup isolation | **Partial** | прямого шелла нет, но `HOME`+`SHELL` настоящие; на Tier FULL rc-файлы режутся FS-слоем, на Seccomp-only/macOS — нет |
+| proxy policy | **Partial** | uppercase passthrough + инжект relay-URL через `env_extra`; lowercase дропаются (ломают тулзы); `NO_PROXY=""` vs unset семантика не продумана |
+| Windows env block | **Partial** | сортировка, NUL/32MiB проверки есть; case-sensitivity бага (см. §7 finding W1); `SystemRoot/COMPSPEC` baseline не определён |
+| macOS launch/Keychain | **Unsupported** | env чистится, но XPC/unix-socket исключение оставляет Keychain и credential API доступными независимо от env |
+| Linux namespaces для env | **Strong** | private procfs + pidns прячут `/proc/<pid>/environ` соседей на Tier FULL; на FS-ONLY — нет |
+| audit env событий | **Unsupported** | в `events/` env не фиксируется вообще (только сам факт — правильно для значений, но нет события «какие имена пропущены») |
+
+## 3. Threat model (env как attack surface)
+
+Граница: всё, что агент читает без файлового доступа — `environ`, `cmdline`, унаследованные сокеты/fd, platform credential API.
+
+1. **Прямое чтение секретов** из унаследованных `*_TOKEN/*_KEY/AWS_*` — закрыто default-deny, открывается agent-пресетами (осознанно, но без режима secrets-off).
+2. **Credential discovery через имена**: даже без значений агент перечисляет `env` и узнаёт, какие провайдеры настроены у хоста (наличие `ANTHROPIC_*` vs `OPENAI_*` — информация для таргетинга).
+3. **PATH hijacking**: writable `~/bin`, `.` в `PATH`, project-local бинари, созданные самим агентом скрипты + последующий exec без абсолюта.
+4. **Loader hooks**: `LD_PRELOAD/LD_AUDIT/LD_LIBRARY_PATH` (Linux), `DYLD_INSERT_LIBRARIES` (macOS), `PYTHONPATH/NODE_OPTIONS/RUBYOPT/PERL5OPT` — выполнение кода в доверенных процессах (ssh-proxy helper, git).
+5. **Shell hooks**: `BASH_ENV/ENV/ZDOTDIR/XDG_CONFIG_HOME`-сдвиг — выполнение при каждом `sh -c` внутри агента.
+6. **Proxy перенаправление**: свой `HTTP_PROXY` у агента → весь egress через атакующего; creds в URL `http://user:pass@proxy`.
+7. **Git env**: `GIT_SSH_COMMAND/GIT_CONFIG_*` — подмена ssh; собственный `GIT_SSH_COMMAND` инжектится vetto, агентский должен давиться.
+8. **Сокеты через env**: `SSH_AUTH_SOCK` закрыт, но `XDG_RUNTIME_DIR` открыт → предсказуемые пути `…/ssh-agent.*`, `…/bus`, `VETTO_CRED_BROKER_SOCK` (доступ к брокеру = доступ ко всем proxied-секретам для allowlisted-доменов).
+9. **argv leak**: секреты в флагах (`--token`, `--api-key`) видны в `/proc/<pid>/cmdline`, `ps`, audit-логах, `dry_run`-выводе.
+10. **Coredump/ошибки**: env дампится в core-файлы и crash-репорты; `ResourceLimits` не управляет `RLIMIT_CORE`.
+11. **Windows**: `PSModulePath` (autoload модулей), `COMSPEC` (подмена шелла), `APPDATA`-хелперы (`gh`, `docker credStore`), DPAPI через user-контекст независимо от env.
+12. **macOS**: Keychain/XPC доступны при любом env; `__OS_LOG` может утащить секреты в unified log.
+
+## 4. Environment policy IR (предложение)
+
+```toml
+[environment]
+mode = "sanitized"          # inherit-all | sanitized | explicit | baseline | secrets-off
+pass_through = [...]        # только для explicit/baseline-дополнений
+deny = [...]                # union, non-overridable вниз (см. §6)
+# Новые секции:
+# [environment.path] / [environment.argv] / [environment.secrets] — §5, §9
+```
+
+Семантика режимов (дефолт `sanitized`, fail-closed: неизвестный `mode` = ошибка загрузки, не fallback):
+
+- `inherit-all` — запрещён всегда (fail-closed `bail` в лоадере; нужен только doctor-пробам внутри кода, не конфигам).
+- `sanitized` — текущий default-baseline (таблица §1) + обязательные санитайзеры PATH (§5).
+- `explicit` — только `pass_through` из project+CLI слоёв, без дефолтного baseline (для параноидальных репо).
+- `baseline` — per-agent минимум (сегодняшние `profiles/agents/*.toml`), без секретов.
+- `secrets-off` — `baseline` минус любые `*_KEY/*_TOKEN/*_SECRET` даже из agent-пресетов + обязательный `secret_proxies` strip + запрет `VETTO_CRED_BROKER_SOCK` инжекта.
+
+## 5. Sanitization rules + PATH security design
+
+Обязательные (non-overridable, применяются после merge, до exec):
+
+1. **Hard-deny список** (всегда, независимо от слоёв): `LD_PRELOAD LD_AUDIT LD_LIBRARY_PATH LD_CONFIG DYLD_* BASH_ENV ENV ZDOTDIR PYTHONPATH PYTHONSTARTUP NODE_OPTIONS NODE_PATH?` — см. нюанс ниже — `RUBYOPT RUBYLIB PERL5OPT PERLLIB GIT_SSH_COMMAND GIT_SSH GIT_CONFIG_* GIT_DIR GIT_WORK_TREE SSH_AUTH_SOCK SSH_AGENT_PID DBUS_SESSION_BUS_ADDRESS XAUTHORITY TERMCAP TERMPATH`.
+   Нюанс: `NODE_PATH/NVM_DIR/CARGO_HOME/RUSTUP_HOME` сегодня в passthrough (`defaults.rs`) ради тулчейнов. Решение: оставить, но пометить tier-зависимыми — на Tier FULL они указывают на read-only маунты и безопасны; в остальных тирах выводить warning в `warnings`. Разрывать тулчейны молча нельзя.
+2. **PATH construction** (детерминированная, новый код в одном месте на backend):
+   разбить по `:`, выкинуть `` (пусто = CWD), `.`, `..`-компоненты, несуществующие dirs; варнинг на group/world-writable dirs (fail-open с варнингом, не fail-closed — иначе сломаем dev-машины; strict-профиль — fail-closed опция `path_strict = true`); результирующий PATH экспортировать; исходный хостовый PATH в audit-событие (только факт фильтрации, не значения — хотя PATH не секрет, значения нужны для диагностики; PATH логировать можно).
+3. `HOME` — наследовать, но agent-пресеты обязаны держать credential-dotfiles закрытыми через FS-deny (уже есть); альтернатива (chroot-HOME) — отвергнута: ломает тулчейны, выигрыш дублирует FS-слой.
+4. `TMPDIR/TEMP` — сверять с `tmpfs_tmp`: если изолированный tmpfs включён, `TMPDIR` переписывать на него через `env_extra`; рассинхрон env-vs-mount сегодня — баг.
+5. `PWD/OLDPWD` — не наследовать, выставлять из `opts.cwd` детерминированно через `env_extra`.
+6. `SHELL/COMPSPEC` — фиксировать из системного дефолта, не из env пользователя.
+7. `LANG/LC_*` — как сегодня (passthrough + возможность deny), плюс `TZ`/`TZDIR` в hard-deny (exfil географии + подмена tzdata-файлов).
+8. Proxy: канонизировать обе регистра (`HTTP_PROXY`+`http_proxy` и т.д.) из одного источника; в relay-режиме обе обязаны указывать на relay (сегодня так через `env_extra`, но хостовый passthrough дублирует — убрать proxy из default passthrough, оставить только инжект); `NO_PROXY` — явный список вместо пустой строки.
+9. `VETTO_*` — только через `env_extra`; любой `VETTO_*` из parent env давить (сегодня parent `VETTO_*` не проходит allowlist — Strong, зафиксировать тестом).
+
+## 6. Policy precedence
+
+Предложение: `system -> user -> Vetto -> project -> agent -> command` для `pass_through` (union, как сегодня), но:
+
+- `deny` (включая новый hard-deny из §5) — **только расширяемый вниз**: нижний слой может добавить deny, убрать — никогда. Сегодня union уже даёт это для deny фактически (убрать нельзя — нет операции вычитания), требуется зафиксировать инвариант + покрыть тестом на immutable.
+- `pass_through`-расширение при `is_immutable` — запретить CLI/repo-расширения секретообразных имён (`*_KEY/*_TOKEN/*_SECRET/*_PASSWORD`, регистронезависимо) — fail-closed `PolicyLockdownViolation`, аналогично существующему запрету FS-путей (`loader.rs:1415`).
+- `env_extra` — ввести allowlist ключей (`VETTO_*`, proxy-набор, `GIT_SSH_COMMAND`, `PWD`): любой другой ключ из кода = `bail` в debug / игнорирование с warn в release. Сегодня проверки нет.
+
+## 7. Конкретные findings (файлы/модули)
+
+- **W1 (Windows deny-обход регистром)**: `src/sandbox/windows/mod.rs:1120-1128` + `types.rs:205` case-sensitive. Родительский `aws_secret_access_key` обойдёт `deny = ["AWS_SECRET*"]`. Фикс: нормализовать к upper при матчинге на Windows (матчинг, не хранение).
+- **W2 (Windows без broker-strip)**: `windows/mod.rs:1114-1170` нет `filter_proxy_secrets`; держится на `bail` в `main.rs:862-870`. Фикс: добавить тот же двойной strip (defense in depth, 3 строки).
+- **M1 (macOS пустая env-строка)**: `macos/mod.rs:448` `CString::new(entry).unwrap_or_default()` — при `=`/NUL в имени/значении в env тихонько попадает пустая строка вместо дропа (Linux такой entry дропает, Windows дропает). Фикс: `filter_map` как в Linux.
+- **D1 (расхождение baseline)**: `defaults.rs:80-83` содержит proxy-переменные, `profiles/default.toml:30-37` — нет. Какой baseline истинен, зависит от пути загрузки (`loader.rs:1031`). Фикс: один источник (TOML), константу удалить.
+- **A1 (argv в dry_run)**: `main.rs:1589` печатает сырой `agent_cmd`. Фикс: пропускать через существующий `logger::sanitizer::sanitize_line`.
+- **S1 (предсказуемый сокет брокера)**: `main.rs:874` `vetto-cred-<pid>.sock` в shared `/tmp` + allow_write `/tmp`. Дизайн ок (брокер проверяет домен), но отметить: любой процесс пользователя может соединиться; mitigations — `0600` + случайный суффикс, сокет прятать при `tmpfs_tmp`.
+- **C1 (RLIMIT_CORE)**: `ResourceLimits` (`types.rs:162-172`) не управляет core-дампами → env с секретами (agent-пресеты!) может осесть в core. Фикс: `RLIMIT_CORE=0` перед exec на Unix.
+
+## 8. argv design
+
+- Spawn-контракт (`src/sandbox/handle.rs:37-42`): добавить инвариант «сырые секреты в `agent_cmd` запрещены»; vetto свои секреты так не передаёт (Strong уже).
+- Санитизация логов: `dry_run`, `watch.rs:62`, JSONL — через `sanitize_line` (BEST-EFFORT, честно пометить).
+- Trusted helper alternative: уже есть прецедент — `ssh-proxy` helper (`net_relay.rs:1271-1281`) и cred-broker сокет вместо env. Новые секреты — только этим путём, не флагами.
+- Верификация: тест «argv со `--api-key=sk-...`» обязан показать: значение видно в child `cmdline` (документируем как inherent, не фиксим), но обязано быть зацензурено в `dry_run`/JSONL.
+
+## 9. Per-platform mapping
+
+- **Linux**: env-фильтр (`linux/mod.rs:652`) + private procfs/pidns (прячет `environ` соседей) + Landlock (режет socket-файлы `XDG_RUNTIME_DIR`, rc-файлы) + seccomp. Дотыкать: PATH-санитайзер, `RLIMIT_CORE=0`, `TMPDIR`-синхрон, hard-deny.
+- **Windows** (`windows/mod.rs`): env-блок + W1/W2 фиксы; `SystemRoot`/`COMSPEC`/`PATHEXT`/`PSModulePath` — явный минимальный набор в baseline (сегодня ни разрешены, ни запрещены — child может не стартовать без `SystemRoot`); PowerShell-профили режутся FS-deny (`$HOME\Documents\PowerShell` добавить в deny-паттерны); Credential Manager недоступен для чистки из env — честно в limitations.
+- **macOS** (`macos/mod.rs` + `seatbelt.rs`): env-фильтр + M1 фикс; Keychain/XPC — вне досягаемости env-границы, фиксируется как limitation; `DYLD_*` в hard-deny избыточен (SIP), но дёшев — оставить.
+- **VM** (`windows_sandbox.rs`): env не прокидывается внятно по коду (grep по `env` пуст) — специфицировать: в VM уходит только `explicit`-минимум + `VETTO_*`; секреты — никогда (в VM нет брокера).
+
+## 10. Verification tests (проект, не код)
+
+1. `inspect env`: child печатает `env -0`; assert — только allowlist-имена, секретов хоста нет, `VETTO_*` из parent отсутствуют.
+2. `inspect PATH`: `PATH` без ``/`.`/`..`, порядок сохранён, writable-dirs залогированы.
+3. `/proc/<pid>/environ` (Linux FULL): сосед по pidns не видит процесс вообще; хост видит отфильтрованное.
+4. Shell startup leakage: `BASH_ENV=/tmp/evil` + `ZDOTDIR=/tmp/evil` в parent → маркер-файл не создан.
+5. Loader vars: `LD_PRELOAD=/tmp/evil.so`, `PYTHONPATH`, `NODE_OPTIONS=--require /tmp/evil` в parent → не унаследованы даже при `pass_through` в repo-слое (non-overridable deny).
+6. Secret propagation: `AWS_SECRET_ACCESS_KEY`, `GH_TOKEN` в parent → отсутствуют в child при любом профиле.
+7. Agent-пресет: `ANTHROPIC_API_KEY` виден с `--agent claude`, отсутствует в `secrets-off`.
+8. Lockdown: repo-слой с `pass_through = ["AWS_SECRET_ACCESS_KEY"]` при immutable → `PolicyLockdownViolation`.
+9. Windows: lowercase `path`/`aws_secret_access_key` в parent → корректный match обеих веток.
+10. argv: `dry_run` с `--api-key=sk-test` → `[REDACTED]` в выводе.
+11. Malicious PATH: dir с `ls`-подменой первым в `PATH` + writable → отфильтрован/залогирован, подмена не исполняется.
+12. Broker sock: `VETTO_CRED_BROKER_SOCK` указывает на `0600`-сокет со случайным именем.
+
+## 11. Audit semantics
+
+- Новое событие `EnvBoundary { mode, allowed_names: Vec<String>, dropped_names: Vec<String>, path_rewritten: bool }` — **только имена**, значений нет (PATH — исключение: значение не секрет, нужно для диагностики; секретообразные значения никогда).
+- Значения env — никогда в JSONL/report/verify (расширить `sanitize_line` правилом `redact_env_assignments` — уже есть, `sanitizer.rs:245`).
+- Doctor-проба: `env_clear()`+`PATH` образец из `agent_check.rs` — переиспользовать.
+
+## 12. Предлагаемые файлы/модули (изменений кода НЕТ — только план)
+
+| # | Файл/модуль | Действие |
+|---|---|---|
+| 1 | `docs/env-proposal.md` (этот файл) | создать — единственный артефакт хода |
+| 2 | `src/policy/types.rs` (`EnvironmentPolicy`) | добавить `mode`, `path_strict`; `allows()` — Windows-CI-нормализация, hard-deny константа |
+| 3 | `src/policy/defaults.rs` | удалить `DEFAULT_ENV_PASSTHROUGH` как второй источник; оставить TOML |
+| 4 | `src/policy/loader.rs` | `inherit-all` → bail; immutable для секретообразных env; deny-union инвариант + тест |
+| 5 | `src/sandbox/envfilter.rs` (новый) | общий PATH-санитайзер + hard-deny + `PWD/TMPDIR/SHELL`-канонизация для Linux/macOS/Windows |
+| 6 | `src/sandbox/linux/mod.rs` (`child_exec`) | вызывать `envfilter`, `RLIMIT_CORE=0` |
+| 7 | `src/sandbox/macos/mod.rs` (`build_envp`) | вызывать `envfilter`, M1 фикс |
+| 8 | `src/sandbox/windows/mod.rs` (`environment_block`) | вызывать `envfilter`, W1+W2 фиксы, `SystemRoot/COMPSPEC` baseline |
+| 9 | `src/sandbox/handle.rs` (`SpawnOptions`) | allowlist ключей `env_extra` + argv-инвариант в доке |
+| 10 | `src/main.rs` | `dry_run`-санитизация, сокет `0600`+рандом, `TMPDIR`-синхрон |
+| 11 | `src/sandbox/windows/windows_sandbox.rs` | специфицировать VM-env-минимум |
+| 12 | `src/events/types.rs` + `src/logger/sanitizer.rs` | `EnvBoundary`-событие (имена only) |
+| 13 | `profiles/*.toml`, `profiles/agents/*.toml` | `mode`, secrets-off вариант, `PSModulePath`-deny для Windows |
+| 14 | `tests/` (интеграционные) | 12 тестов из §10 |
+
+## 13. Migration plan
+
+1. Docs-only (этот ход): `docs/env-proposal.md` → коммит в `arch/prompt-07`, стоп.
+2. `envfilter.rs` + W1/W2/M1/A1/C1/D1 фиксы — маленькие, независимые, первыми.
+3. `mode` в IR + лоадер (`inherit-all`→bail, immutable-env) — за ним TOML-правки профилей.
+4. PATH-санитайзер (warn-режим) → сбор телеметрии ложных срабатываний → `path_strict` для strict.
+5. `EnvBoundary`-аудит + 12 тестов.
+6. VM-env-спецификация.
+
+## 14. Security limitations (честно)
+
+- Keychain (macOS), DPAPI/Credential Manager (Windows), XPC-брокер — вне env-границы; закрываются FS/слоями или не закрываются вовсе.
+- `secrets-off` не лишает агента способности **попросить** секрет у пользователя/файла — только не подсовывает его сам.
+- Санитизация логов BEST-EFFORT (высокая энтропия, нестандартные форматы).
+- `cmdline` внутри pidns виден соседям по песочнице — mutual distrust между процессами одного агента не моделируется.
+- Core-дампы хоста (systemd-coredump) вне `RLIMIT_CORE` vetto, если агент форкает до установки лимита — окно минимально, но ненулевое.
+- Predictable `VETTO_SESSION_ID` в env — идентификатор сессии виден агенту (нужен для relay); скоп ударов — корреляция, не secret.
+
+## 15. Critical review: 10+ часто забываемых escape/leak путей
+
+1. `BASH_ENV/ENV` — код при каждом неинтерактивном `sh -c`.
+2. `ZDOTDIR` — сдвиг всего zsh-конфига.
+3. `LD_AUDIT` — забывают чаще, чем `LD_PRELOAD`; тот же эффект.
+4. `XDG_CONFIG_HOME` — сдвиг конфигов git/ssh (`$XDG_CONFIG_HOME/git/config`).
+5. `GIT_CONFIG_COUNT/GIT_CONFIG_KEY_*` — конфиг через env, обходит FS-deny на `.gitconfig`.
+6. `PYTHONSTARTUP` (интерактивный python) и `NODE_OPTIONS=--require` — в отличие от `PYTHONPATH` их редко чистят.
+7. `PERL5OPT/RUBYOPT` — аналогично для perl/ruby хелперов.
+8. `TMPDIR` вне tmpfs-изоляции — предсказуемые race-файлы, сокеты.
+9. `TZDIR` — подмена tzdata-файлов парсером libc.
+10. `GCONV_PATH/LOCPATH` — подмена glibc-модулей конверсии/локалей (классика, почти никто не чистит).
+11. `HOSTALIASES` — подмена резолвинга без трогания DNS.
+12. Creds в proxy-URL (`HTTP_PROXY=http://user:pass@…`) — пасмурная копия секрета внутри «несекретной» переменной.
+13. `VETTO_CRED_BROKER_SOCK` — сам путь в env даёт доступ к выдаче секретов (по дизайну, но забывают, что это bearer-capability).
+
+## 16. Implementation plan + acceptance criteria
+
+План: §13 пп. 2–6, оценка — 4–6 инкрементов, каждый с тестами из §10. Порядок fail-closed-first: лоадер-bail и deny-фиксы раньше PATH-варнингов.
+
+Acceptance criteria:
+
+- [ ] AC1: `inherit-all` в любом TOML → ошибка загрузки, сессии нет.
+- [ ] AC2: все 12 тестов §10 зелёные на Linux; Windows/macOS — подмножество 1,2,6,9,10.
+- [ ] AC3: repo-слой не может протащить `LD_PRELOAD`/`AWS_*` ни в `pass_through`, ни мимо deny (тесты 5, 8).
+- [ ] AC4: `dry_run`/JSONL с секретом в argv — только `[REDACTED]`.
+- [ ] AC5: `docs/env-proposal.md` и код не расходятся (повторный аудит `grep`-матрицы §7 — пусто).
+- [ ] AC6: `src/verify_ng/` untouched (проверяется `git diff --stat`).

--- a/docs/fail-closed-proposal.md
+++ b/docs/fail-closed-proposal.md
@@ -1,0 +1,269 @@
+# Fail-Closed + Runtime Verification — архитектурное предложение (Prompt 03)
+
+> Скоуп: `docs/`, `src/sandbox/mod.rs`, `src/sandbox/handle.rs`, `src/error.rs`, `src/exit_codes.rs`.
+> `src/verify_ng/` не тронут (Prompt 01, чужой скоуп). Production-код не пишется — только архитектура.
+> Оценка соответствия каждого требования prompt: **Strong** (уже есть и достаточно),
+> **Partial** (есть частично / можно обойти), **Unsupported** (нет и нужно проектировать).
+
+## 1. Current fail-open / fail-closed inventory
+
+База fail-closed в репозитории реально сильная — это главный вывод аудита prompt на веру не принимается, проверено по коду.
+
+| # | Место | Файл | Вердикт | Комментарий |
+|---|-------|------|---------|-------------|
+| 1 | Отказ от unsandboxed fallback | `src/sandbox/mod.rs:60-139` | **Strong** | `detect_with_backend` возвращает `Err` вместо слабого backend; неизвестный backend — `bail`. Silent downgrade отсутствует на этом уровне |
+| 2 | Linux tier selection | `src/sandbox/linux/mod.rs:108-136` | **Partial** | `pick_tier` fail-closed, но выбор зависит от runtime `VETTO_FORCE_TIER` — downgrade-override через env, не через явный CLI opt-in |
+| 3 | FS-ONLY / Seccomp как tier, а не fallback | `src/sandbox/linux/mod.rs:149-168` | **Partial** | Это честная смена tier с другим набором гарантий, но UX называет tier одинаково «sandboxed»; пользователь не всегда понимает, что full→fs-only — weaker |
+| 4 | Relay требует FULL | `src/sandbox/linux/mod.rs:150-156`, `src/main.rs:781-789` | **Strong** | Двойная проверка (backend + supervise), fail-closed с actionable сообщением |
+| 5 | macOS relay reject | `src/sandbox/macos/mod.rs:60-80` | **Strong** | allowlist/strict/ask явно отклоняются, а не деградируют в `--net=off` |
+| 6 | Windows enforcement gate | `src/sandbox/windows/mod.rs:432-466,468-481` | **Strong** | `enforcement_ready()` + `--net=off`-only + Inherit-stdio-only; неполные capabilities — `Err` |
+| 7 | Windows deny-inside-grant | `src/sandbox/windows/mod.rs:1184-1202` | **Strong** | Secret внутри granted root — fail-closed `bail`, а не молчаливое игнорирование |
+| 8 | Child setup handshake `R/E` | `src/sandbox/linux/mod.rs:1197-1214`, `src/sandbox/macos/mod.rs:116-132` | **Strong** | Готовность сообщает только полностью сконфигурированный child (`child_b` пишет `R` после Landlock+stdio+seccomp); `E`/EOF/timeout — `VettoError::Sandbox` → exit 125 |
+| 9 | Preflight `--verify` | `src/main.rs:801-820`, `src/verify.rs:154-295` | **Partial** | Opt-in (`--verify`), не обязателен; `shadow` продолжает запуск при leaks; `probe` всегда `NetMode::Off` — relay-конфигурация не верифицируется |
+| 10 | `doctor --probe` | `src/main.rs:1916-1986` | **Partial** | Диагностика по запросу, не gate; Windows явно `unavailable`; exit 1 только при leaks |
+| 11 | `VettoError` → exit code | `src/error.rs:38-50`, `src/exit_codes.rs:96-118` | **Partial** | Typed-путь детерминирован (Sandbox→125), но legacy substring-fallback жив и расширяем человеческой ошибкой (`anyhow!` с «не тем» текстом → неверный код) |
+| 12 | `Pty` → fail-closed | `src/error.rs:46` | **Partial** | `Pty(_) → EXIT_AGENT_ERROR (1)`, а не 125: сбой stdio-конфигурации выглядит как «ошибка агента», хотя сессия не стартовала в запрошенном виде |
+| 13 | Cred-broker spawn failure | `src/main.rs:1086-1095` | **Partial** | `failed to spawn credential broker` — только `eprintln warning`, сессия продолжается; при `secret_proxies` это fail-open для секретов (агент без брокера может искать обход) |
+| 14 | macOS rlimits best-effort | `src/sandbox/macos/mod.rs:325-339` | **Partial** | Отклонённые `setrlimit` только печатаются; запуск продолжается с меньшими limits без отражения в security level |
+| 15 | macOS pdeath watchdog | `src/sandbox/macos/pdeath_watch.rs:21-23,41-46` | **Partial** | Fork/kqueue failure — продолжение без watchdog + stderr; орфан после SIGKILL vetto остаётся (документировано, но не gate) |
+| 16 | Linux subreaper failure | `src/sandbox/linux/mod.rs:1394-1399,1577-1582` | **Partial** | Только `tracing::warn`; setsid-эскейперы переживают teardown — известное окно FS-ONLY |
+| 17 | cgroup setup failure | `src/sandbox/linux/mod.rs:1225-1232,1431-1438` | **Partial** | `_ => None`: отсутствие limits silently игнорируется; child уже сообщил `R`, handle создан |
+| 18 | `VETTO_SEATBELT_MODE=none/allow-all` | `src/sandbox/macos/mod.rs:356-384` | **Partial** | Диагностический kill-switch полностью снимает enforcement внутри child; защита только «CI-only» комментарием, без compile-gate или требования explicit CLI-флага |
+| 19 | `VETTO_NO_MAC_LIMITS`, `VETTO_CHILD_TRACE`, `VETTO_NO_PDEATH_WATCH` | `src/sandbox/macos/mod.rs:332`, `src/sandbox/macos/pdeath_watch.rs:33` | **Partial** | Env-отравление ослабляет sandbox без ведома оператора; verify-ng уже фиксирует это как отравление (FM-08), но production-spawn это не проверяет |
+| 20 | Policy mutation после detect | `src/main.rs:734-765` | **Partial** | `pol.allow_read.push(parent)` (бинарник агента) и `deny_write.push(bin)` мутируют policy после load; verify/preflight уже отработал на другой policy — hash-continuity отсутствует |
+| 21 | Env allowlist + `env_extra` | `src/sandbox/linux/mod.rs:664-677`, `src/sandbox/macos/mod.rs:425-450` | **Strong** | Default-deny + двойной `filter_proxy_secrets`; `env_extra` — только внутренние `VETTO_*`, повторная зачистка есть |
+| 22 | Windows env non-UTF16 drop | `src/sandbox/windows/mod.rs:1114-1170` | **Partial** | Некорректные entries silently `continue`/drop вместо fail-closed; поведение зависит от мусора в parent env |
+| 23 | `dry_run` с несуществующим backend | `src/main.rs:643-650,767-769` | **Partial** | При `--dry-run` отсутствие backend подменяется `Tier::Full`-заглушкой — вывод «tier: full» вводит в заблуждение, это не измерение |
+| 24 | TUI/timeout игнор | `src/main.rs:1216-1223` | **Partial** | `--timeout` в TUI-режимах молча игнорируется (только notice); оператор думает, что deadline есть |
+| 25 | Signal forwarder install | `src/main.rs:1712-1719` | **Partial** | Ошибка установки SIGINT/SIGTERM — `eprintln warning`, сессия идёт без forwarder |
+| 26 | Staged update / auto-update | `src/main.rs:92-97,1727-1750` | **Partial** | `warning: staged update not applied / background staging failed` — не gate, но влияет на целостность бинарника между verify и spawn (TOCTOU на обновление) |
+
+Вывод: ядро spawn-цепочки — **Strong fail-closed**. Периметр (env-override, broker, limits, watchdog, policy-mutation, dry-run, CLI-warnings) — **Partial** и именно там живут все «security error → warning → continue» переходы.
+
+## 2. Threat model (дополнение к docs/threat-model.md, не замена)
+
+Активы и out-of-scope наследуются из `docs/threat-model.md` (§Assets, §What Vetto Does NOT Protect).
+
+Новый противник Prompt 03: **ложное чувство enforcement**. Атакующие позиции:
+
+1. **Adversarial agent внутри**: escape через setsid (FS-ONLY/macOS), дескрипторы, `execve` вне policy, UDS/IPC-exfil, чтение entry-names в FS-ONLY, перехват `env_extra`/broker-socket пути.
+2. **Drift/TOCTOU снаружи**: подмена policy-файла между load и spawn; замена бинарника агента между `resolve_in_path` и `execve`; symlink-parent swap; late-created secret-shaped файлы в `$PROJECT`; изменение `HOME`/cwd.
+3. **Оператор-ошибка**: `--dry-run`-вывод принят за гарантию; `--timeout` в TUI принят за deadline; `shadow` принят за enforcement; `doctor` без `--probe` принят за proof.
+4. **Env-отравление**: `VETTO_FORCE_TIER`, `VETTO_SEATBELT_MODE`, `VETTO_NO_MAC_LIMITS`, `VETTO_NO_PDEATH_WATCH`, `VETTO_CHILD_TRACE` в наследованном окружении CI/обёрток.
+5. **Supply-chain бинарника**: staged-update между preflight и spawn; подмена `processmodel.dll` резолва вне System32 (уже закрыто `LOAD_LIBRARY_SEARCH_SYSTEM32` — Strong).
+
+Границы доверия: доверенный — host-верификатор vetto до `fork` + ядро; недоверенный — всё внутри sandbox, весь stdout/self-report child, все observation-фиды (подтверждено `docs/threat-model.md:65-70`).
+
+## 3. Security invariants (должны стать кодом, сейчас — только текст)
+
+1. `I1 no-launch-without-enforcement`: ни один `execve`/CreateProcess до `Verified` (pre-launch checks зелёные).
+2. `I2 no-silent-downgrade`: любой переход на weaker tier/backend требует explicit opt-in (`--tier`/`--backend` + `--allow-degraded`) либо fail-closed.
+3. `I3 enforcement-object-not-config`: проверяется живой объект (Landlock ruleset fd / mount ns / netns / Job handle / seatbelt-профиль-хэш), а не in-memory `Policy`.
+4. `I4 observation-never-enforces`: verify/oracle не меняют enforcement; FAIL oracle убивает сессию, а не «чинит» политику.
+5. `I5 policy-continuity`: хэш policy, ушедшей в spawn, равен хэшу policy, прошедшей pre-launch (frozen spec, как FM-03 в verify-ng).
+6. `I6 trusted-verifier-only`: PASS выставляет только host после wait/host-fact; self-report child — максимум hint (уровень evidence из `docs/verify-ng.md:17-24` переиспользовать).
+7. `I7 cleanup-is-guarantee`: потеря контроллера (crash/SIGKILL/power-loss) оставляет либо kernel-held teardown (pidns/Job), либо честный `degraded-cleanup` статус, но никогда «terminated».
+8. `I8 warnings-never-gate-bypass`: любой `warning:` на пути Requested→Running обязан либо иметь error-код, либо быть вне security-пути (логи/telemetry/UI).
+
+## 4. Sandbox state machine
+
+```text
+Requested -> Validated -> Compiled -> Constructed -> Verified -> Launchable -> Running -> VerifiedRuntime -> Terminating -> Terminated
+```
+
+Допустимые переходы: каждый шаг только вперёд; `Verified -> Launchable` только при зелёных pre-launch; `Launchable -> Running` только через fork/spawn, владеющий frozen spec; `Running -> VerifiedRuntime` только через host-post-launch probes; `* -> Terminating` из любого состояния после `Constructed` (обязательный cleanup-контракт); `Terminating -> Terminated` только после подтверждённого teardown.
+
+Невозможные: `Requested -> Running`, `Validated -> Launchable` (мимо compile/construct), `Running -> Launchable`, `Terminated -> *`, `VerifiedRuntime -> Running` без повторной верификации.
+
+Rollback: до `Launchable` — освободить ресурсы и вернуться в `Requested` с ошибкой; после `Running` rollback нет, только `Terminating` с kill-стратегией tier.
+
+Fatal states (уничтожают возможность launch в этой сессии): `BackendUnavailable`, `PolicyCompilationFailed`, `PreLaunchFailed`, `SpecMismatch`, `SpawnFailed`, `PostLaunchFailed` (убивает уже стартовавший child и запрещает retry без нового `Requested`), `DriftDetected`.
+
+Карта на текущий код: `Requested` = CLI parse (`src/main.rs:99-128`, `src/config.rs:186-381`); `Validated` = `RunConfig` + policy load (`src/main.rs:686-693`); `Compiled` = tier/backend resolve (`src/sandbox/mod.rs:65-139`, `pick_tier`); `Constructed` = fork-цепочка до байта `R` (`src/sandbox/linux/mod.rs:1110-1244`, `src/sandbox/macos/mod.rs:50-150`); `Verified` — отсутствует как состояние (есть только opt-in preflight); `Launchable/Running` слиты в `backend.spawn` → `handle`; `VerifiedRuntime` отсутствует; `Terminating/Terminated` — `SandboxHandle::terminate/drop` (`src/sandbox/handle.rs:169-213`).
+
+## 5. Pre-launch checks (обязательные, до fork; каждый — fail-closed)
+
+Проверяется **объект enforcement**, не структура config:
+
+1. `backend-selected`: tier/backend разрешён security level (strict/standard/degraded, §8) + explicit opt-in на degraded зафиксирован.
+2. `effective-policy-frozen`: канонический хэш frozen spec (policy + net + tier + backend-describe + argv/env/cwd + nonce) посчитан и защёлкнут; любая мутация после (типа `allow_read.push` в `src/main.rs:756-765`) — только до freeze, после — `SpecMismatch`.
+3. `capability-probe`: живые примитивы (Landlock ABI, userns/full-stack, seccomp, seatbelt-availability, Windows `enforcement_ready`) — не кэш `doctor`, а свежий probe этого запуска.
+4. `containment-object`: предсозданные объекты — netns/mountns handle (FULL), Job Object (Windows), seatbelt-профиль-хэш (macOS); spawn владеет ими, а не «надеется создать в child».
+5. `filesystem-policy`: Landlock prepared-ruleset собран и его хэш совпадает с frozen; deny-inside-grant проверен (Windows-аналог уже есть — распространить на все tier).
+6. `network-policy`: relay-топология соответствует NetMode; FS-ONLY+relay и macOS/Windows+relay уже отклоняются — вынести в единый gate, а не три копии.
+7. `credential-boundary`: broker-socket создан до fork либо `secret_proxies` пусты; spawn-failure брокера — fatal, не warning (§1.13).
+8. `environment-filtering`: allowlist применён к снимку env + скан diagnostic-env (`VETTO_*`) с FAIL при отравлении (переиспользовать FM-08).
+9. `resource-policy`: cgroup/rlimit/Job-limits применены или честно задекларированы как `limits-degraded` с влиянием на security level; silent `None` запрещён (§1.17).
+10. `binary-identity`: `resolve_in_path` + device/inode snapshot бинарника; child сверяет перед `execve` (закрывает TOCTOU resolve→exec).
+11. `expected-security-level`: итоговая тройка (tier, net, limits/cleanup) маппится на strict/standard/degraded и печатается как одна строка до запуска.
+
+Сейчас: **Strong** только 3 (частично), 6 (размазан по трём файлам), 8 (фильтр, но без скана env-override). Остальное — проектировать.
+
+## 6. Post-launch checks + 7. Runtime verification protocol
+
+Слои (все — host-верификатор, не self-report):
+
+- `P1 liveness+identity`: `waitpid`/Job-handle + сверка root_pid/pgid/Job membership; смерть контроллера до `R` — `SpawnFailed`.
+- `P2 containment-membership`: Linux — `/proc/<pid>/ns/{mnt,net,pid}` inode сравнить с pre-launch снимком; Windows — `IsProcessInJob` + integrity-level readback; macOS — профиль-хэш + `sandbox_check`-readback где доступно.
+- `P3 canary-probes` (безопасные, одноразовые, nonce-bound): deny-path open должен дать `EACCES`; loopback-connect должен отказать; write-outside должен отказать; env-canary (`VETTO_CANARY_NONCE`) не должен утечь в `/proc/<pid>/environ` вне allowlist. Положительный контроль: разрешённый read/write внутри `$PROJECT` обязан succeed (ловит over-confinement и oracle-deceit, ср. FM-02).
+- `P4 child-inheritance`: fork bomb-grandchild наследует Landlock/seccomp (проверка через constrained errno-сигнал grandchild + host-fact); setsid-эскейпер детектируется через subreaper/sweep-отчёт.
+- `P5 network-reality`: relay-broker counters (allowed/denied) + host loopback-listener canary (как в `src/verify.rs:234-249`, но для живой сессии, не throwaway).
+- `P6 secrets-inaccessibility`: host-fact stat/canary-сравнение masked paths (masked должен быть empty/null-bound на FULL; carved-out на FS-ONLY — честный PARTIAL).
+- `P7 limits-reality`: cgroup `memory.current`/`pids.current` readback; rlimit readback через `/proc/<pid>/limits`; Job-memory readback.
+
+Протокол: `Running → (P1+P2+P3-negative) → VerifiedRuntime`; `P4–P7` — периодический re-verify тиком (Linux 5–30с адаптивно, mac/Win реже) + по событию (fork-storm, net-deny spike, drift-signal). Любой FAIL — `Terminating` + kill-стратегия tier + exit 125, retry только через новый `Requested`. Evidence-уровни и nonce-связка — из `docs/verify-ng.md:17-31` (HOST_FACT единственный для PASS).
+
+Что только до запуска: создание ns/Job/seatbelt-профиля, Landlock restrict_self, mount-оверлеи, uid/gid-map handshake, env-freeze, binary-identity snapshot.
+
+Что повторять после: membership ns/Job, canary deny/net/write, broker counters, limits readback, sweep-отчёт.
+
+Что невозможно изнутри sandboxed process (требует trusted host verifier): собственный ns-membership (может врать `/proc`), полнота Landlock-coverage, Job-membership, чтение чужого environ без ptrace-блока, broker-side DNS-ответы, cgroup-лимиты хоста, факт убийства эскейперов.
+
+## 8. Fallback matrix (без silent downgrade)
+
+| Fallback | security-equivalent? | weaker? | observable? | auto? | opt-in? | must-fail? |
+|---|---|---|---|---|---|---|
+| Linux full → fs-only | нет | да (нет ns/overlay/netns) | сейчас только tier-label в env/логе | **да (auto через pick_tier)** — главная дыра | должен требовать `--allow-degraded` | в strict — да |
+| Linux full/fs-only → seccomp-only | нет | сильно да (нет FS-изоляции) | tier-label | да (auto) | opt-in | в strict/standard — да |
+| macOS native → best effort (read-tail-deny, limits-warn, watchdog-miss) | нет | да | частично (stderr) | да | opt-in на degraded | в strict — да (только Linux VM) |
+| Windows experimental → weaker (job-only/token-only) | нет | да | `enforcement_ready` gate | нет — уже fail-closed (**Strong**, держать) | n/a | да |
+| native → VM (win-sandbox/OrbStack/WSL2) | да/сильнее | нет | явный `--backend win-sandbox` | нет (explicit) | да, explicit backend | нет |
+| relay → off при недоступности FULL | нет | зависит от threat (exfil vs offline) | да (bail-текст) | нет — уже fail-closed (**Strong**, держать) | explicit `--net=off` retry | да (не деградировать молча) |
+| verify FAIL → shadow-continue | нет | да | да (stderr) | нет (требует `--shadow`) | да, но `--shadow` обязан быть несовместим со strict | в strict — запретить флаг |
+
+Security levels: `strict` — только FULL/seatbelt-strict/experimental-Windows + pre+post verify зелёные, ноль degraded, `shadow` запрещён; `standard` — FULL/FS-ONLY + seatbelt + Windows-exp, degraded только с `--allow-degraded`, post-verify обязателен; `degraded` — seccomp-only/FS-ONLY-без-sweep/macOS-best-effort допустимы, но каждая сессия печатает `degraded: <причины>` и audit-маркер; VM-бэкенды удовлетворяют strict.
+
+## 9. Drift model
+
+| Drift-событие | Детект | Как |
+|---|---|---|
+| policy-файл изменён после freeze | **да** | frozen-spec hash + `verify_spec_continuity`; mtime/inotify — только hint |
+| files/symlinks поменялись (swap parent, late secret) | частично | pre-exec `openat2(RESOLVE_BENEATH)` + re-resolve deny перед Landlock; late-created secrets — только следующим freeze (документированный residual) |
+| child запущен другим способом (exec вне spawn) | **да** | только spawn владеет containment-объектом; чужой pid не проходит P2-membership |
+| дополнительный handle/fd передан внутрь | частично | `close_range` в child уже есть; SCM_RIGHTS через broker — allowlist fds; UDS-передача от third-party — residual (ср. verify-ng §Потолки) |
+| sandbox object закрыт (alive-pipe/Job handle) | **да** | FULL: EOF alive-pipe → init kills ns; Windows: kill-on-close — kernel; FS-ONLY/macOS: watchdog/poll — best-effort, честный degraded |
+| external process изменил env/context | **да** до exec | env-freeze snapshot; после exec — environ readback host-фактом |
+| backend enforcement частично отказал (Landlock ok, seccomp miss) | частично | P3-canary ловит функциональный отказ; silent BPF-reject без canary-сигнала — residual, закрывается positive-control |
+
+Недетектируемо в принципе: TLS-payload к allowed-API, записи внутри `$PROJECT`, side-channels, kernel-0day, полнота логов — наследуются из `docs/verify-ng.md:97-102` и threat-model §What Vetto Does NOT Protect.
+
+## 10. Crash / partial failure semantics
+
+| Сбой | Поведение | Уже запущенные процессы |
+|---|---|---|
+| backend init crash (probe/pick_tier) | fail-closed до fork, exit 125 | нет процессов — нечего убивать |
+| policy compilation failure | fatal `Validated`, exit 125 (не 1) | нет |
+| verification timeout (pre/post) | timeout = FAIL, не retry-in-place; exit 125 | pre: не стартовали; post: `Terminating` через kill-стратегию |
+| child spawn failure (fork/exec) | `E`/EOF/timeout → `VettoError::Sandbox` → 125 | частично созданные — убить через уже захваченные handles (Windows-путь с TerminateProcess до `return Err` — образец) |
+| launcher (vetto) crash после создания sandbox, до launch | pre-`R`: child умирает на handshake-timeout/PDEATHSIG; post-`R`: см. ниже | FULL: alive-pipe EOF → init kills ns (**Strong**); Windows: Job kill-on-close (**Strong**); FS-ONLY/macOS: subreaper-sweep/watchdog best-effort (**Partial** — честно маркировать `degraded-cleanup`) |
+| child crash | exit-код честно наружу; sweep эскейперов; `VerifiedRuntime` не выставляется задним числом | эскейперы — через tier kill-стратегию |
+| host power loss | после ребута — ничего живого; при старте — stale-registry cleanup (`status`/`kill --hung` уже есть) | n/a, но audit обязан различать `terminated` vs `unknown-after-reboot` |
+
+## 11. Error taxonomy (к `src/error.rs` / `src/exit_codes.rs`)
+
+Сейчас: `VettoError::{Landlock,Namespace,Mount,Seccomp,Sandbox,UnsupportedPlatform}→125`, `Pty→1`, `Policy→1`, `PolicyLockdownViolation→126` + legacy substring-fallback. Предложение (только таксономия, без кода):
+
+- Новые варианты: `PreLaunchCheck{check}`, `PostLaunchCheck{check}`, `SpecMismatch{expected,got}`, `DriftDetected{signal}`, `DegradedRefused{reason}`, `TeardownIncomplete{detail}` — все → **125**.
+- `Pty` разделить: `PtySetup` (до launch) → 125; `PtyIo` (после VerifiedRuntime) → 1.
+- Cred-broker failure с непустыми `secret_proxies` → `Sandbox` (125), не warning.
+- Cgroup/rlimit/subreaper/watchdog failure: в strict → 125; в standard/degraded → запуск с `limits-degraded` маркером + audit, но никогда silent.
+- Убить substring-fallback поэтапно: заморозить список (не расширять — уже написано), добавить `#[deny]`-линт на новые `anyhow!` без typed-конструктора на security-пути, мигрировать существующие call sites.
+- Exit 103 из threat-model (`docs/threat-model.md:110`) расходится с кодом (125): унифицировать доки на **125** (код — источник правды).
+
+## 12. Policy hash / identity model
+
+Frozen spec (канонический JSON, сортировка ключей, `NetMode::label`, tier, backend-describe, argv/env/cwd snapshot, binary device+inode, nonce сессии, хэш реестра verify-ng): `sha256(canonical)`. Считается один раз из той же `&Policy`-ссылки, что уходит в spawn (паттерн FM-03); `detect→freeze→spawn` под серийным мьютексом spawn-контракта (паттерн FM-09). Re-freeze перед fork обязан совпасть, иначе `SpecMismatch` → fatal. Хэш пишется в JSONL-audit, CI-summary и отчёт; привязка «хэш ↔ живой процесс» — только непрерывность владения до fork (честно, как в verify-ng §Что всё ещё нельзя доказать).
+
+## 13–16. Platform plans
+
+**Linux (13):** единый pre-launch gate перед `spawn_full/fs_only/seccomp_only`; env-скан diagnostic-override; binary-identity snapshot; cgroup-результат в security level; P2-membership через ns-inode; P3-canary через отдельную throwaway-сессию + живой broker-counters; sweep-отчёт как host-fact (число убитых/оставшихся, не «предположительно чисто»).
+**Windows (16→14):** сохранить fail-closed ядро; добавить post-launch readback (Job-membership, integrity, spec-хэш); HANDLE-capture для evidence — отдельным backend-ревью (как требует verify-ng §Потолки); per-domain egress без admin остаётся UNPROVABLE — не чинить, честно маркировать; `win-sandbox` (VM) — единственный strict-путь с сетью.
+**macOS (15):** seatbelt-профиль-хэш в frozen spec; диагностические `VETTO_SEATBELT_MODE` — только за compile-gate (`cfg(debug_assertions)`/feature) либо explicit CLI-флаг, никогда silent env; read-secrecy потолок PARTIAL честно в security level (ср. FM-11); watchdog-failure в strict — fatal.
+**VM implications (16):** VM-бэкенды — explicit opt-in tier с собственной spec-схемой (`.wsb`/VM-образ хэш); fallback native→VM никогда не auto (разные trust-границы, время старта, стоимость); drift внутри VM — вне host-верификатора, требуется in-guest agent отчёт как CONSTRAINED-сигнал максимум.
+
+## 17. CLI/UX semantics
+
+- `--verify` из opt-in в default-on для supervised run; `--no-verify` — explicit с degraded-маркером (standard) / запрещён (strict).
+- `--shadow` несовместим со strict; в выводе всегда `shadow: policy-layer only, kernel NOT shadowed` (уже есть в `--help`/dry-run — поднять до gate).
+- `--dry-run` обязан печатать `NOT ENFORCED` баннер + никогда не подменять tier-заглушку (`Tier::Full` fake в `src/main.rs:644-646` — убрать, печатать `tier: unknown (dry-run)`).
+- `--allow-degraded` (новый): единственный opt-in на weaker tier; без него любой degraded — 125.
+- `--security-level strict|standard|degraded` (новый, default standard): определяет таблицу §8.
+- Стартовая строка сессии: `sandbox: <backend> tier=<t> net=<m> level=<l> spec=<short-hash> [degraded: <reasons>]`.
+- `doctor` без `--probe` — диагностика, не proof: подписать вывод; `verify`/`doctor --probe` — единственные proof-команды pre-launch.
+
+## 18. Tests and adversarial cases
+
+Переиспользовать harness verify-ng (не дублировать): новые блокеры как сценарии registry с ClaimStrength-капами FM-11:
+
+1. `FC-PRE-001` downgrade без opt-in обязан дать 125 (full→fs-only через `VETTO_FORCE_TIER`, full→seccomp).
+2. `FC-PRE-002` env-отравление (`VETTO_SEATBELT_MODE=none`, `VETTO_NO_MAC_LIMITS`, `VETTO_NO_PDEATH_WATCH`) — FAIL/INCONCLUSIVE по FM-08, в strict — отказ запуска.
+3. `FC-PRE-003` policy-mutation после freeze (push allow_read) — `SpecMismatch`, 125.
+4. `FC-PRE-004` бинарник подменён между resolve и exec — отказ.
+5. `FC-PRE-005` broker spawn failure при `secret_proxies` — 125, не warning.
+6. `FC-POST-001` setsid-эскейпер: FULL — убит ядром (Strong); FS-ONLY/macOS — детектирован sweep-отчётом, статус `degraded-cleanup`, destructive — только disposable VM (FM-05).
+7. `FC-POST-002` ns/Job-membership mismatch после старта — `Terminating`, 125.
+8. `FC-POST-003` canary deny/net/write readable — FAIL, 125 (negative + positive control, FM-02 nonce).
+9. `FC-POST-004` controller SIGKILL mid-session: FULL/Windows — дерево мертво (host-fact); FS-ONLY/macOS — честный residual-отчёт.
+10. `FC-POST-005` oracle-deceit: self-report «всё запрещено» при реально открытом контроле — ловится positive-control + HOST_FACT.
+11. `FC-ERR-001…010` десять warning-path регрессий (§19): каждый `warning:` на security-пути покрыт тестом «ошибка → 125 либо маркер degraded, но не silent continue».
+12. Фаззинг exit-code mapping (расширить существующие proptest в `src/exit_codes.rs:246-320`): typed-errors всегда побеждают substring; `PtySetup`→125.
+
+## 19. Exact repo / module changes (без кода, только карта)
+
+| # | Файлы/модули | Изменение |
+|---|---|---|
+| M1 | `docs/fail-closed-proposal.md` (новый, этот файл) | Архитектура Prompt 03 |
+| M2 | `src/sandbox/mod.rs` | `Backend::detect_with_backend` принимает `SecurityLevel` + `allow_degraded`; downgrade — explicit; `describe()` отдаёт machine-readable spec для frozen-hash |
+| M3 | `src/sandbox/handle.rs` | `SandboxHandle` несёт `spec_hash`, `security_level`, `teardown_receipt` (sweep-kill counts); `terminate()` возвращает receipt вместо `()` |
+| M4 | `src/error.rs` | Новые варианты `PreLaunchCheck/PostLaunchCheck/SpecMismatch/DriftDetected/DegradedRefused/TeardownIncomplete`; split `Pty` на setup/io |
+| M5 | `src/exit_codes.rs` | Заморозка substring-fallback; `PtySetup`→125; доку-комментарий про 125-vs-103 |
+| M6 | `src/main.rs` supervise (потребитель, вне скоупа правок тут) | Порядок detect→load→freeze→pre-launch→spawn→post-launch; `--security-level`, `--allow-degraded`, default-on `--verify` |
+| M7 | `src/sandbox/linux/*` (потребитель) | Pre-launch gate, binary-identity, env-скан, cgroup-в-security-level, ns-membership P2, sweep-receipt |
+| M8 | `src/sandbox/macos/*` (потребитель) | Профиль-хэш, diagnostic-env gate, watchdog-failure fatal-в-strict |
+| M9 | `src/sandbox/windows/*` (потребитель) | Post-launch readback Job/integrity, HANDLE-capture ревью отдельно |
+| M10 | `docs/threat-model.md`, `docs/exit-codes.md`, `SECURITY.md`, `ARCHITECTURE.md` | Синк: 125 (не 103), levels, degraded-маркировка, dry-run/shadow-дисклеймеры |
+| M11 | `src/verify_ng/registry/*` (чужой скоуп, только предложение) | FC-* сценарии как потребители, без правок в этом prompt |
+
+Правки production-кода в этом prompt не делаются; M2–M5 — только интерфейсные декларации на фазе имплементации.
+
+## 20. Migration strategy
+
+Фаза A (docs-only, этот prompt): настоящий документ + синк кодов в доке. Фаза B (interfaces): M4+M5 таксономия + M3 receipt-структуры, всё backward-compatible (новые варианты/поля, старые пути живы). Фаза C (gates): default-on pre-launch + `--allow-degraded`/`--security-level`, `shadow`-strict запрет, dry-run честность. Фаза D (runtime): P2-membership + canary post-launch + teardown receipts. Каждая фаза — минорный релиз +0.0.1 по политике версионирования, с `docs/verify-ng.md`-гейтом (ноль INCONCLUSIVE в блокерах) как release-gate.
+
+## Critical review: 10+ мест «security error → warning → continue»
+
+1. `src/main.rs:1093` cred-broker failure → `warning`, запуск идёт (§1.13).
+2. `src/sandbox/linux/mod.rs:1431-1438,1613-1620` cgroup `Err → None` (§1.17).
+3. `src/sandbox/macos/mod.rs:335-338` rlimits refused → `eprintln`, continue (§1.14).
+4. `src/sandbox/macos/pdeath_watch.rs:41-46` watchdog fork fail → `warning`, continue (§1.15).
+5. `src/sandbox/linux/mod.rs:1394-1399` subreaper fail → `tracing::warn` (§1.16).
+6. `src/main.rs:1712-1719` SIGINT/SIGTERM forwarder fail → `warning` (§1.25).
+7. `src/main.rs:95,1749` staged-update failure → `warning` (TOCTOU-окно бинарника, §1.26).
+8. `src/main.rs:805-807,1353-1357` shadow продолжает при leaks/threshold (§1.9).
+9. `src/main.rs:1216-1223` timeout в TUI молча игнор (§1.24).
+10. `src/sandbox/windows/mod.rs:1146-1151` malformed env entries — silent drop (§1.22).
+11. `src/main.rs:727-732` snapshot failure → `tracing::debug` (rollback-гарантия испаряется тихо).
+12. `src/main.rs:95-97` + `src/sandbox/linux/mod.rs:109-114` diagnostic-env вообще не сканируется на security-пути (§1.2/1.18/1.19).
+
+Ответы на обязательные вопросы: только до запуска — создание ns/Job/seatbelt/Landlock-restrict/mount-оверлеи/handshake/env-freeze/binary-snapshot; повторять после — membership, canary deny/net/write, broker-счётчики, limits-readback, sweep-отчёт; только trusted host verifier — собственная ns/Job-принадлежность, полнота coverage, Job/integrity readback, broker-DNS, cgroup хоста, факт смерти эскейперов (self-report изнутри — максимум CONSTRAINED-hint, PASS только HOST_FACT).
+
+---
+
+## Implementation plan (остановиться после, ждать ревью)
+
+1. Принять настоящий документ в `arch/prompt-03` (этот файл) — docs-only коммит.
+2. Синкнуть доки кодов/уровней (M10): 125 как канон, dry-run/shadow дисклеймеры.
+3. Спроектировать интерфейсы M3–M5 (error-варианты, receipt, freeze-spec схема) — ревью без кода.
+4. Включить gates фазы C за feature-флагом: default-on verify, `--allow-degraded`, `--security-level`, strict-запрет shadow.
+5. Реализовать post-launch P1–P3 + teardown receipts (фаза D), FC-сценарии в harness как блокеры.
+6. Прогнать verify-ng gate (ноль INCONCLUSIVE в I1–I6, canary PASS) + adversarial-сьют §18; релиз +0.0.1.
+
+## Acceptance criteria
+
+- [ ] Ни один weaker-tier переход без explicit opt-in; каждый — в audit с `degraded: <reason>` либо 125.
+- [ ] Pre-launch gate обязателен: 11 проверок §5 зелёные до fork; любое нарушение — 125, запуск невозможен.
+- [ ] Frozen-spec continuity: мутация policy/env/binary между freeze и spawn — `SpecMismatch`, 125.
+- [ ] Post-launch: P1–P3 зелёные до `VerifiedRuntime`; FAIL — kill + 125; PASS только HOST_FACT.
+- [ ] Все 12 warning-path §Critical review либо стали 125, либо несут degraded-маркер + audit; silent continue — ноль.
+- [ ] `VETTO_*` diagnostic-env сканируется до fork; в strict любое отравление — отказ.
+- [ ] Доки синкнуты на 125; dry-run/shadow/doctor честны (не proof); `src/verify_ng/` untouched в diff.

--- a/docs/network-proposal.md
+++ b/docs/network-proposal.md
@@ -1,0 +1,124 @@
+# Network Policy + Egress Control — архитектурное предложение (Prompt 06)
+
+Статус: предложение, production-код не писан. `src/verify_ng/` не затронут.
+Базовый факт: реальный enforcement сегодня существует только на Linux; macOS/Windows — fail-closed отказы relay-режимов.
+
+## 1. Текущая сетевая архитектура (по коду, не по заявлениям)
+
+| Компонент | Файл | Что реально делает |
+|---|---|---|
+| `NetMode::{Off, Allowlist, Strict, Ask}` | `src/config.rs:18-28` | Парсинг `--net`; IP-литералы отвергаются (`validate_domain`, `src/config.rs:440-474`) |
+| FULL/off: interface-less netns | `src/sandbox/linux/mod.rs:1027` (`CLONE_NEWNET`) | Маршрута наружу нет вообще; lo поднимается только ради relay |
+| FULL/relay: loopback CONNECT/SOCKS relay R + host-брокер | `src/sandbox/linux/net_relay.rs`, fork-цепочка `src/sandbox/linux/mod.rs:1031-1050` | Агент ходит только в `127.0.0.1:47129`; брокер резолвит, валидирует, коннектит pinned `SocketAddr`, отдаёт fd через `SCM_RIGHTS` |
+| FS-ONLY/off: seccomp `UnixOnly` | `src/sandbox/linux/seccomp_netblock.rs` | `socket/socketpair` не-`AF_UNIX` → `EAFNOSUPPORT`; relay-режимы запрещены до запуска (`src/sandbox/linux/mod.rs:150-156`) |
+| `blackhole_resolv_conf` | `src/sandbox/linux/mounts.rs:361` | В relay-режиме `/etc/resolv.conf` → `/dev/null`: агент сам не резолвит |
+| Env: allowlist + `build_proxy_env` | `src/sandbox/linux/mod.rs:664` (`child_exec`), `src/sandbox/linux/net_relay.rs:1252` | Агент получает только loopback `*_PROXY` + пустой `NO_PROXY`; апстрим-прокси читается брокером из host-env |
+| Landlock net ports (ABI 4+) | `src/sandbox/linux/landlock.rs:475-498`, `src/policy/loader.rs:702-721` | `allow_tcp_connect/bind` — второй рубеж портов |
+| DebugPortGuard | `src/sandbox/linux/debug_guard.rs` | Токен-гейт loopback debug-портов (9222/9229/5678…) |
+| DoH/DoT deny-листы | `src/sandbox/linux/net_relay.rs:210-278` | Блок известных резолверов по домену/IP + любой порт 853 |
+| macOS / Windows | `src/sandbox/macos/seatbelt.rs:62-63`, `src/sandbox/macos/mod.rs:58-76`, `src/sandbox/windows/mod.rs:460-462` | Только `net=off`; relay-режимы — отказ до запуска. `src/sandbox/macos/net_proxy.rs` — мёртвый helper, в spawn не вшит |
+| Аудит | `src/events/types.rs:43-65`, `src/sandbox/linux/net_relay.rs:298-366,610,859` | `NetRequest{allowed}`, `DnsResolved{ips}`, `NetEgress{bytes_tx/rx}`, `NetQuotaExceeded` |
+
+Отделение enforcement от conventions: kernel-граница — netns, seccomp family-фильтр, Landlock-порты, Seatbelt `deny network*`, AppContainer без net-capability. Всё остальное (`*_PROXY` env, отсутствие curl в PATH, shell-обёртки) — не граница. `net=off` этим тестам удовлетворяет: удаление `HTTP_PROXY` нигде не используется как механизм запрета.
+
+## 2. Threat model
+
+Ненадёжен агент и все потомки: произвольный код, raw syscalls, собственные бинарники, демоны, `setsid`-побеги. Доверенные: оператор, бинарь vetto, ядро, политика до запуска. Вне скоупа (как в `SECURITY.md`): hostile kernel/root, side-channels, prompt-injection внутри разрешённого API.
+
+## 3. Модель политики и exact semantics (Strong/Partial/Unsupported)
+
+| Режим | Семантика | Вердикт |
+|---|---|---|
+| `off` | FULL: netns без интерфейсов + seccomp `UnixOnly`. FS-ONLY: seccomp `UnixOnly`. Ни один `AF_INET/INET6` сокет не создаётся (FS-ONLY) или не имеет маршрута (FULL) | **Strong** (Linux). macOS Seatbelt-deny — Strong для IP, с оговоркой mach/IPC. Windows AppContainer-no-capability — Partial (нет loopback-изоляции внутри контейнера) |
+| `localhost` | Отдельного `NetMode` нет. Частично покрыт DebugPortGuard (токен на debug-порты) внутри relay-режимов | **Partial** → ввести `NetMode::Localhost` (см. §10) |
+| allowlist доменов | CONNECT-уровень: имя→проверка→один резолв в брокере→весь answer-set валидируется→коннект к pinned IP. TLS opaque, без SNI-фильтрации | **Strong** (дестинация), **Unsupported** (контент — осознанно) |
+| IP/CIDR | Вторичный люк `allow_cidr` (`BrokerConfig.allow_cidr`): IP-литерал, совпавший с CIDR, пропускается; резолв-ответы из CIDR не считаются forbidden. Не first-class `NetMode` | **Partial** → ввести `NetMode::Cidr` или явный `strict-ip:` |
+| port/protocol | `strict:host:port` (имя+порт, `strict_allowed`, `net_relay.rs:413`), плюс Landlock connect/bind-порты. Протоколов кроме TCP/SSH-helper нет; UDP вне relay недостижим (нет маршрута), но seccomp тип сокета не различает — держится на netns | **Partial** → держать инвариант «порт-ограничение = брокер + Landlock», UDP/QUIC — явный deny (§5) |
+| proxy-only | Как режима нет; апстрим-прокси — транспортная деталь брокера (`get_upstream_proxy`) | **Unsupported** → ввести `NetMode::ProxyOnly{url}` с запретом прямого коннекта в брокере |
+| unrestricted | Отсутствует осознанно | **Unsupported** by design; не вводить без явного флага оператора |
+
+## 4. Exfiltration attack matrix (вердикты против текущей архитектуры, Linux FULL/relay)
+
+- curl/wget/Python/Node/Go/Rust-TCP через прокси-env → CONNECT к relay → policy. **Закрыто** (property-тест: любой TCP-клиент без relay-доступа не имеет маршрута).
+- Сырой IP-литерал в CONNECT → `domain_allowed` false (IP не матчится; CIDR-люк — только при явном `allow_cidr`). **Закрыто по умолчанию**.
+- DNS-эксфильтрация при заблокированном TCP/HTTP: агентский резолвер чёрная дыра (`resolv.conf` → /dev/null) + маршрута нет; DoH/DoT-домены, IP и порт 853 режутся в брокере дважды (`request_allowed` и `resolve_and_connect`). **Закрыто**; остаток — DNS-имена внутри разрешённых CONNECT (имя легитимного домена как канал — это DLP, не граница, см. §7).
+- IPv4/IPv6/UDP/QUIC напрямую: маршрута нет; seccomp в off вообще не даёт создать семью. В relay-режиме `AF_INET` создать можно (нужен loopback), но за пределы lo пакетам идти некуда; QUIC/UDP наружу невозможен топологически. **Закрыто топологией**, не фильтром (честно фиксируем).
+- Raw/privileged сокеты: `AF_PACKET/VSOCK/NETLINK` режутся seccomp в обоих режимах; `CAP_NET_RAW` сняты (`drop_agent_capabilities`, `mod.rs:294`); `bpf/perf` в hardening-списке. **Закрыто**.
+- Unix-сокеты: `AF_UNIX` разрешён всегда (IPC). Файловые — через FS-политику; **abstract-сокеты изолированы netns в FULL** (ядро скоупит их по netns), в FS-ONLY — **дыра**: общий abstract-неймспейс с хостом. Фиксируем как известное ограничение FS-ONLY.
+- Proxy-env: агент видит только loopback-прокси; `NO_PROXY` пуст и перезаписывается (`build_proxy_env`); брокер читает апстрим из host-env, агент его подменить не может (env allowlist в `child_exec`). **Закрыто**.
+- Альтернативный netns/интерфейс: `unshare/setns` требуют `CAP_SYS_ADMIN`, bounding set сброшен + securebits locked; mount-API в hardening-списке. **Закрыто**.
+- Inherited/pre-opened сокеты: `close_all_except(&[0,1,2])` перед exec в C (`mod.rs:861`); управляющий сокет брокера есть только у R и родителя, агент его никогда не наследует (`child_b` его не держит). Агент обязан прийти «голым». **Закрыто**; property-тест обязателен.
+- Потомок с host-networking: наследование netns+seccomp необратимо; покрыто `tests/integration/linux_subagents.rs`. **Закрыто**.
+- WSL-интероп/Windows: Windows-бэкенд только `net=off`; WSL2 идёт Linux-путём (Tier 1). Windows loopback внутри AppContainer без capability — считать Partial, не Strong.
+- VM networking: `--backend win-sandbox` — отдельная граница `.wsb`; доменный relay туда не транслируется — только off.
+
+## 5. Domain allowlist: DNS/IP-семантика (ядро предложения)
+
+1. **TOCTOU устранён конструкцией**: резолв один, в брокере, коннект к pinned `SocketAddr`, имя второй раз не резолвится (`resolve_and_connect`, `net_relay.rs:553-622`). Смена DNS между соединениями → новое соединение проходит все 4 шага заново (уже задокументировано в `docs/network.md`).
+2. **Answer-set правило «один грязный — все грязные»**: `any_forbidden → Err` (`net_relay.rs:594-607`). Сохранить как инвариант; покрыть тестом со смешанным ответом (публичный + `169.254.169.254`).
+3. **CDN**: разрешён любой публичный IP разрешённого имени. Это destination-control, не свидетельство «доверенности» IP.
+4. **Wildcard**: `*.d` = только поддомены, не база (текущее поведение `domain_allowed` + тест `wildcard_domain_allowlist_*`). Сохранить; `*` в `Strict` — запретить (сейчас `pat == "*"` разрешает всё — **найти и закрыть**: `strict_allowed`, `net_relay.rs:424-426`).
+5. **SNI vs IP**: SNI не инспектируется (нет MITM — принцип). Зафиксировать в security-claims: «имя проверяется в CONNECT, не в TLS».
+6. **HTTPS-шифрование/редиректы**: редирект на неразрешённый домен = новый CONNECT = deny для proxy-aware клиентов. Не-proxy-aware клиенты вне relay не имеют маршрута (fail-closed). Утверждение «allowlist предотвращает exfiltration» при разрешённой сети — **запретить** в документации (уже частично есть в `SECURITY.md:117-120`).
+7. **Разделение**: destination control (брокер) / content inspection (нет, не будет) / DLP (квоты+аудит, см. §7).
+
+## 6. Апстрим-прокси: найденная слабина (Partial → чинить)
+
+`resolve_and_connect` при установленном host-прокси уходит в `connect_via_proxy` и **возвращает dummy `0.0.0.0:port` без проверки answer-set и без `NetEgress`-валидного IP** (`net_relay.rs:573-578`). Имя при этом проверено в `request_allowed`, но пиннинг и IP-валидация обойдены. Решение: в proxy-ветке резолвить имя в брокере, валидировать answer-set тем же `forbidden_destination`, CONNECT к апстриму слать на pinned IP апстрима, целевой `host:port` — строкой (как сейчас), в `NetEgress` писать реальный IP апстрима + флаг `via_proxy`. Без этого `allow_cidr`/metadata-защита при корпоративном прокси — декларация.
+
+## 7. Advanced egress / DLP: что оправдано
+
+Оправдано (уже есть / дёшево): host-брокер как **trusted egress broker** (единственная точка выхода), per-domain `net_quota` + `NetQuotaExceeded`, `NetEgress` с байтами, `DnsResolved` с IP, fail-closed `ask` без TTY. Transparent proxy (перехват без cooperation клиента) — не нужен: netns уже вынуждает cooperation топологией. **Не оправдано** (превращает в DLP-платформу): TLS interception/CA, контент-инспекция, taint-tracking, secret-aware policy на сетевом уровне. Граница Vetto заканчивается на «куда и сколько байт»; «что внутри TLS» — вне скоупа, фиксируется в claims. DNS-имя-как-канал при разрешённой сети — residual risk, лечится квотой, а не инспекцией.
+
+## 8. Кросс-платформа
+
+- **Linux**: netns + seccomp-family + Landlock-порты + capability-drop. eBPF-направление (`RelayMode::Ebpf`, cgroup_sock_addr) держать экспериментальным; базовым остаётся netns (аудитируемость > прозрачность).
+- **Windows**: AppContainer без net-capability = off (текущее). WFP-модуль (`src/sandbox/windows/firewall.rs`) — только opt-in lease с image-scope, PID-scope недоступен (зафиксировано в коде); домены в WFP не отдавать никогда — нужен DNS→IP-компилятор в брокере (нет) либо loopback-брокер как на Linux. WSL2 — Tier 1 путь.
+- **macOS**: Seatbelt `deny network*` = off. `net_proxy.rs` — готовый pinned-коннектор; не хватает вшивки в spawn (loopback-брокер + proxy-env + fail-closed отказ при невозможности bind). `sandbox-exec` deprecation — явный риск (уже зафиксирован).
+- **VM**: `.wsb`-бэкенд — только off; relay в VM не проектировать.
+
+## 9. Adversarial verify-suite (property, не бинарник)
+
+Каждый тест — свойство: `tests/verify_ng/scenarios/NET-*.toml` + раннер вне `verify_ng` harness-кода (только новые scenario-файлы + общий executor, который уже есть в Prompt 01 скоупе — координироваться, не дублировать). Свойства:
+`NET-OFF-IPV4/IPV6/UDP-001` (нет маршрута любым сокетом), `NET-OFF-DNS-002` (резолвер-дыра + DoH IP напрямую), `NET-RELAY-PIN-003` (смена DNS между коннектами не уносит старый IP), `NET-RELAY-MIXED-ANSWER-004` (смешанный answer-set → deny), `NET-RELAY-IP-LITERAL-005`, `NET-RELAY-REDIRECT-006` (редирект наружу → deny), `NET-RELAY-UDP-QUIC-007` (UDP наружу невозможен), `NET-INHERIT-008` (pre-opened fd не переживает exec), `NET-LOOPBACK-009` (debug-порт без токена → deny), `NET-PROXY-UPSTREAM-010` (exfil через апстрим при deny-имени → deny; metadata через прокси → deny), `NET-ABSTRACT-011` (abstract-сокет хоста недоступен из FULL; FS-ONLY — задокументированный провал), `NET-WILDCARD-012` (`notgithub.com` vs `github.com`, база vs `*.`).
+
+## 10. Изменения по репозиторию (без кода в этом ходе)
+
+| # | Файлы/модули | Изменение |
+|---|---|---|
+| 1 | `src/config.rs` (`NetMode`, `parse_net_mode`) | Добавить `Localhost`, `ProxyOnly{url}`, `Cidr(Vec<IpCidr>)`; точные semantics в `--help`/docs |
+| 2 | `src/sandbox/linux/net_relay.rs` | Закрыть `*` в `strict_allowed`; proxy-ветка с валидацией answer-set + честный `NetEgress`; `IpCidr` переиспользовать для `Cidr`-режима |
+| 3 | `src/sandbox/linux/seccomp_netblock.rs` | Документировать инвариант «тип сокета не фильтруется, держит netns»; опционально `SOCK_DGRAM`-deny в off (совместимость проверить) |
+| 4 | `src/sandbox/linux/mod.rs` | `Localhost`-режим: netns + relay только на 127.0.0.1-цели; проброс управляющего сокета без изменений |
+| 5 | `src/sandbox/macos/*` (`mod.rs`, новый `broker_loopback.rs` на базе `net_proxy.rs`) | Вшить loopback-брокер в spawn для allowlist/strict; иначе сохранить fail-closed отказ |
+| 6 | `src/sandbox/windows/*` | Loopback-брокер + WFP image-scope lease как opt-in; по умолчанию только off |
+| 7 | `src/policy/loader.rs`, `src/policy/types.rs` | `[network]` gains: `mode`, `localhost_allow_ports`, `proxy_only_url`; `allow_cidr` → явный режим вместо люка |
+| 8 | `src/events/*`, `src/report/*` | `via_proxy`, `pinned_ip`, `answer_set` в `NetEgress/DnsResolved`; отображения в JSONL/OTEL/TUI |
+| 9 | `tests/verify_ng/scenarios/NET-*.toml` (+ доки раннера) | 12 property-сценариев из §9 |
+| 10 | `docs/network.md`, `SECURITY.md`, `docs/threat-model.md`, `ARCHITECTURE.md` | Claims из §11; запрет заявления «allowlist = no exfiltration» |
+
+## 11. Security claims и limitations (честные формулировки)
+
+Заявляем: off = нет маршрута/семьи сокетов (по тирам); relay = CONNECT-дестинация + per-connection пиннинг + answer-set deny + opaque TLS; наследование границы потомками; fail-closed везде, где примитив недоступен. Не заявляем: контент-контроль при разрешённой сети; SNI-фильтрацию; abstract-изоляцию в FS-ONLY; Windows loopback-изоляцию; WFP PID-scope. Граница Vetto → DLP проходит по `NetEgress`: байты/куда — наши; семантика внутри TLS — чужая.
+
+## 12. Critical questions (ответы)
+
+- **Exfil при FS-sandbox + включённой сети?** Да, по определению: разрешённая дестинация = легальный канал. Лечится сужением allowlist + квотой, не сетевым запретом.
+- **Exfil через DNS при блокированном TCP/HTTP?** В FULL/relay — нет (дыра резолвера + нет маршрута + DoH-блок). В FS-ONLY host-резолвер доступен Cody? Нет: FS-ONLY допускает только `net=off`, relay запрещён — DNS уходит вместе со всем IP. Ответ: при relay denial DNS-канала нет; при разрешённой сети DNS-имя — DLP-риск.
+- **Inherited sockets?** Закрываются `close_all_except` до exec; управляющий fd брокера агенту недоступен конструктивно. Property-тест `NET-INHERIT-008`.
+- **Что нужно для truly `network=off`?** Отсутствие маршрута (netns без интерфейсов / Seatbelt-deny / AppContainer-no-capability) + невозможность создать семью (seccomp) + невозможность вернуть маршрут (no CAP_SYS_ADMIN, mount-API deny) + дыра резолвера не нужна, т.к. резолвить некуда. Env-чистка — гигиена, не граница.
+- **Где кончается sandbox и начинается DLP?** На записи `NetEgress`: дестинация/объём — sandbox; содержимое — DLP/другой продукт.
+
+## 13. Migration plan
+
+Фаза A (docs+policy, без поведения): этот документ → `docs/network.md` claims → `verify_ng` NET-сценарии как failing-spec. Фаза B (Linux): strict-`*`, proxy-ветка, `Localhost`/`Cidr`/`ProxyOnly` режимы. Фаза C (macOS/Windows loopback-брокеры, opt-in). Каждая фаза: fail-closed по умолчанию, `vetto doctor` показывает новый режим, `CHANGELOG.md` +0.0.1.
+
+## 14. Acceptance criteria
+
+1. `off` любым транспортом (TCP/UDP/IPv6/DoH-IP/raw-family) наружу не выходит на FULL и FS-ONLY — property-тесты зелёные.
+2. Relay: смена DNS между коннектами, смешанный answer-set, IP-литерал, редирект, апстрим-прокси — все deny/пиннинг-свойства зелёные.
+3. `strict:*:port` невозможен (парсер отвергает `*`).
+4. Pre-opened fd и abstract-сокет хоста недоступны из FULL; FS-ONLY abstract — задокументированный красный тест, не молчание.
+5. Неподдерживаемый режим на тире = отказ до запуска с action-подсказкой, никогда тихий fallback.
+6. JSONL содержит `NetRequest/DnsResolved/NetEgress` с pinned IP для каждого relay-соединения; proxy-ветка пишет реальный IP апстрима.
+7. Документация не содержит утверждения «allowlist предотвращает exfiltration» без оговорки про разрешённую сеть.

--- a/docs/platform-backends.md
+++ b/docs/platform-backends.md
@@ -60,6 +60,7 @@ The Linux backend represents Vetto's reference production architecture, leveragi
 ### Seatbelt (SBPL) & Regression Tracking
 - Vetto dynamically loads Apple's private Seatbelt API (`libsandbox.1.dylib!sandbox_init_with_parameters`), avoiding brittle reliance on the deprecated `/usr/bin/sandbox-exec` CLI wrapper.
 - **Root Cause of dyld SIGABRT Crashes**: On modern macOS releases (macOS 13 Ventura, macOS 14 Sonoma, macOS 15 Sequoia), Apple's dynamic linker (`dyld`) maps system dynamic libraries directly from shared caches (`/System/Library/dyld/dyld_shared_cache_*`). When SBPL policies employ fragmented file-read allowlists (multiple discrete `(allow file-read* (subpath "..."))` clauses), dyld's internal validation routines and memory mappings abort with `SIGABRT` upon first library resolution.
+- **Maximum read shape (issue #62, CLOSED as maximum-achievable)**: the SBPL matrix (`.github/workflows/macos-sbpl-matrix.yml`, `scripts/sbpl-matrix-test.sh`, macos 14/15/15-intel, green) proves ONLY Shape A — single broad `(allow file-read* (subpath "/"))` + trailing secret denies — runs. Every fragmented shape (B naive, C clauses, D require-any, E regex, F allowlist) SIGABRTs ALL binaries including static Go. There is NO per-runtime narrow shape on current macOS: static Go and dynamic Swift/Rust behave identically. Narrow read-deny reopens only if Apple fixes dyld; until then Shape A + tail-deny (`deny_resolved`) is the enforced maximum, constant `SBPL_MAXIMUM_READ_SHAPE` in `src/sandbox/macos/seatbelt.rs`.
 - **Compensating Policy Architecture**: To guarantee process stability while preventing data destruction, Vetto applies broad read access `(allow file-read* (subpath "/"))` alongside tail denials `(deny file-read* (subpath (param "DENY_PATH_...")))`. Write access is strictly constrained to the workspace root and `/tmp`.
 - **Read-Isolation Limitations**: Because Darwin kernels do not expose unprivileged mount namespaces or VFS inode masking, unprivileged read denial on macOS cannot guarantee absolute secrecy against all native binaries. Vetto transparently exposes this platform behavior in `vetto doctor` under the `sbpl-read-fragment` probe.
 - **Network Boundaries**: Darwin kernels lack unprivileged network namespaces (`CLONE_NEWNET`). Egress restriction is limited to `--net=off` via SBPL `(deny network*)` (with a local UNIX domain socket exemption for libSystem/XPC IPC). Per-domain allowlisting is unsupported and fails closed.
@@ -84,6 +85,17 @@ The Windows native backend is designated **Tier 3 (Preview)**. It provides proce
 - The default Windows process sandbox runs under an AppContainer token combined with low integrity (`S-1-16-4096`).
 - When `--lpac` or `lpac = true` is configured, Vetto validates the Less Privileged AppContainer SID (`S-1-15-2-2`, `ALL RESTRICTED APPLICATION PACKAGES`), stripping implicit package capabilities and isolating local IPC/RPC endpoints.
 - `sandbox::windows::probe()` inspects `lpac_api` and reports status in `vetto doctor`.
+- **Hardening review (issue #63)**: maximum-achievable surface — AppContainer default-deny DACL on the workspace, LPAC SID opt-in stripping package capabilities, low-integrity token blocking medium-integrity writes, Job Object kill-on-close for the full tree. No silent elevation anywhere: every path that needs admin fails closed with an actionable message.
+
+### WFP lease: explicit admin opt-in, fail-closed without it
+- Fine-grained per-domain egress via Windows Filtering Platform (`src/sandbox/windows/firewall.rs`: dynamic WFP session, private sub-layer, process-image + pinned TCP/IP conditions, filters removed on lease drop) REQUIRES administrator privileges — WFP engine open + filter install fail without elevation by Windows design.
+- Vetto refuses to demand elevation: `firewall::probe()` reports WFP/token state without requesting it; any lease attempt without admin fails closed (`--net` allowlist on native Windows degrades to AppContainer capability deny, never to silent allow).
+- Maximum-achievable: `--net=off` enforced via AppContainer capabilities unprivileged; per-domain allowlist needs explicit admin opt-in OR WSL2 (where the Linux broker does it unprivileged).
+
+### Authenticode Digital Signing
+- `packaging/windows/sign.ps1` signs `vetto.exe` using `signtool.exe` or `osslsigncode` with SHA-256 and RFC 3161 timestamps (`http://timestamp.digicert.com`).
+- Configured in CI release workflows via `SIGNING_CERT_PFX` and `SIGNING_CERT_PASSWORD`.
+- **Release signing status (issue #63)**: release archives are minisign-signed in `release-train.yml` (threshold-signed key, SLSA-verified); Authenticode `vetto.exe` signing runs when `SIGNING_CERT_PFX` is present, otherwise CI emits an explicit warning and ships the binary unsigned — never silently claimed as signed. `vetto doctor` reports the effective state.
 
 ### Job Object Lifecycle & IO Rate Control
 - Windows Job Objects enforce `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` to ensure 100% of descendant processes are terminated when Vetto exits.

--- a/docs/policy-ir-proposal.md
+++ b/docs/policy-ir-proposal.md
@@ -1,0 +1,203 @@
+# Policy Engine + Sandbox IR — Architecture Proposal (Prompt 02)
+
+Статус: proposal, production-код не писать. Скоуп: `docs/` + контракты. `src/verify_ng/` не трогать.
+
+## 1. Current architecture (факт по репозиторию)
+
+Конвейер сегодня: `CLI (src/cli.rs, src/config.rs RunConfig)` → 7-tier `LayeredPolicyLoader` (`src/policy/loader.rs`: SystemGlobal → UserGlobal → BuiltinProfile/Preset → AgentPreset → Repository(+fragments) → LocalOverride → CliExplicit/CliOverride) → glob/var-резолв в конкретные пути (`glob_resolve.rs`: `$PROJECT/$HOME/$AGENT`, `~`, 50k cap, несуществующие glob = пустое множество) → `Policy` (`src/policy/types.rs`) → тир-зависимый `build_policy()` (FS-ONLY вырезает secret-shaped reads из allowlist, бюджет 20k) → `Backend::detect/spawn` (`src/sandbox/mod.rs`: Linux FULL/FS-ONLY/Seccomp, macOS Seatbelt, Windows process-sandbox) → lifecycle через `SandboxHandle` (`src/sandbox/handle.rs`). Параллельно: `checker.rs` (warnings), `lint.rs` (R1–R5), `explain.rs` (`--why`, JSON), `crypto.rs` (Ed25519-подпись слоёв), `conditions.rs` (bounded `branch/file_exists/project_contains`).
+
+Ключевые факты, влияющие на IR:
+
+- FS/Network разделены по владельцам: FS-корни живут в `Policy` (TOML-слои), а net-режим — в `RunConfig::net` (CLI/global/agent-default), не в policy-слоях. `deny_network: bool` в `Policy` — только intent слоя, enforcement зависит от CLI. Это расщепление — главный источник silent-downgrade риска.
+- Landlock — чистый allowlist без subtract (`ARCHITECTURE.md`): deny внутри allowed-дерева на FULL маскируется mount-overlay (`mask_restricted_devices`, `mask_path`, `isolate_tmp/shm`), на FS-ONLY — энумерацией дерева с вырезанием secret-shaped файлов (`is_secret_shaped`: `.env*`, `pem/key/p12/pfx/kdbx`, case-insensitive) + `strip_read_on_write` (READ_FILE снимается с write-корней; честная цена: созданное в корне нельзя прочитать обратно).
+- Сеть Linux FULL: netns без интерфейсов + loopback CONNECT/SOCKS-релей → host-брокер (проверка имени → один DNS-lookup → reject unsafe answer set → connect к pinned IP:port, TLS opaque, без SNI-инспекции и CA). Off на FULL = пустой netns; на FS-ONLY = seccomp-гейт семейств сокетов. Relay требует FULL, иначе fail-closed (`LinuxSandbox::spawn`). `--git-ssh` — только Linux, через ProxyCommand по тому же CONNECT-пути.
+- macOS: нативный Seatbelt через `sandbox_init_with_parameters` in-memory (без `sandbox-exec`), профиль `(deny default)` + `file-write*` на allow_write + broad `(allow file-read* (subpath "/"))` + trailing deny на `deny_resolved` (last-match-wins). Только `--net=off` (`deny network*` + исключение `network-outbound remote unix-socket` для XPC); allowlist/strict/ask — fail-closed до запуска. Эмпирический максимум Shape A (`SBPL_MAXIMUM_READ_SHAPE`): фрагментированные read-allowlist SIGABRT'ят dyld на macOS 13–15 — узкий read недостижим не по вине vetto. Read-deny без mount ns — best-effort против нативных бинарников; `doctor` показывает `sbpl-read-fragment` probe.
+- Windows: experimental `processmodel.dll!Experimental_CreateProcessInSandbox` (runtime-resolve, System32-only) + AppContainer + restricted low-integrity token (когда есть as-user export) + Job Object kill-on-close. Только `--net=off`; доменные режимы — fail-closed (нет DNS→IP-компилятора). Spec — FlatBuffers `SandboxSpec`: write/read гранты + пустой NetworkPolicy (default-deny контракт API). Deny внутри гранта — fail-closed bail (`path_inside_root`, case-insensitive, lexical; symlink-алиасы и 8.3 short names не моделируются — честно задокументировано). Stdio только inherit. Нет WIN-BASIC fallback. WFP/firewall/minifilter/Windows Sandbox — отдельные capability-gated opt-in, не вызываются launcher-путём, elevation не запрашивается.
+- Окружение — default-deny везде: фильтр `EnvironmentPolicy::allows` (exact + префикс `*` только в конце; `normalize_env_patterns` молча дропает `*`, `=`-содержащие, не-`[A-Za-z0-9_]`) + `cred_broker::filter_proxy_secrets` (двойная strip: до и после `env_extra`). `env_extra` — только внутренние `VETTO_*`. Windows дополнительно: case-insensitive dedup, сортировка блока, 32 MiB лимит, дроп `=`/`NUL`-имён.
+- Лимиты: `ResourceLimits` strictest-wins на всех уровнях слияния (слои → `--limits` → cgroup). Парсинг `--limits` fail-closed на неизвестных ключах/суффиксах, overflow-checked. Маппинги: Linux rlimit+cgroup перед exec; macOS rlimit best-effort (отказы — в stderr, не скрыты); Windows Job memory/active-process + best-effort IO-rate (без fail всего job на старых Windows — см. ниже как несоответствие инварианту).
+- Immutability: `security.immutable=true` на Tier 1 запрещает снимать lockdown и добавлять allow-пути через CLI (`PolicyLockdownViolation`). Но: запрет покрывает только `allow_write/allow_read`, не `pass_through`/net/limits — дыра (см. §3).
+- Наблюдение никогда не кормит enforcement (threat-model.md §"Why observation never feeds enforcement"): Landlock/Seatbelt применяются до exec, ивенты — advisory.
+- `VETTO_FORCE_TIER`, `VETTO_SEATBELT_MODE=none/allow-all/...`, `VETTO_NO_MAC_LIMITS`, `VETTO_CHILD_TRACE` — env-киллсвитчи, способные ослабить границу вне policy. Сегодня не хешируются и не попадают в отчёты.
+- Policy hash сегодня отсутствует: нет канонической сериализации, нет `policy hash → effective config` связи; `verify`/`doctor --probe` проверяют границу throwaway-песочницей, но не сверяют `effective == requested` через хеш.
+
+## 2. Prompt 02: разбор (не принимать на веру)
+
+Технически неверное / небезопасное в prompt:
+
+1. `allowlist destinations` + `CIDR/IP rules` как единый net-блок IR — небезопасное смешение. Репозиторий намеренно запрещает IP-литералы в доменных режимах (`validate_domain` в `config.rs`) и валидирует DNS-ответы через брокер (reject private/loopback/link-local/multicast/reserved, NAT64, metadata `169.254.169.254`). Отдельное поле `allow_cidr` существует в `Policy`, но семантика его enforcement на FULL-релее не определена тем же строгим путём. IR обязан разделить `egress.domains` (брокер, DNS-пиннинг) и `egress.cidr` (сырой IP-уровень, только где есть IP-enforcement: Landlock ABI4 connect/bind-порты, WFP-lease) и запретить CIDR как способ обойти доменный пиннинг.
+2. `proxy mode` как нейтральное поле — опасно без явного запрета TLS-инспекции. Архитектура репозитория: брокер opaque byte pump, без CA/SNI-парсинга. IR фиксирует: `proxy.opaque_tls_passthrough=true`, `tls_interception=unsupported` на всех бэкендах (расширение только через отдельное explicit-поле, default off, требующее host-компонента).
+3. `DNS behavior` в песочнице — в FULL DNS внутри песочницы нет вообще (`blackhole_resolv_conf`), резолвит хост-брокер один раз с валидацией всего answer set. IR не должен обещать "настраиваемый DNS внутри" — только `dns: { broker_resolved_once_pinned }`.
+4. `interpreter policy` / `allowed executables` как общее поле — нереализуемо единообразно: Landlock даёт EXECUTE-право на inode, Seatbelt — `process-exec` blanket, Windows — AppContainer без per-binary allow в текущем spec. Общее поле допустимо только как `process.exec_scope: { allow_roots }` с capability `partial` везде, либо platform-extension.
+5. `shell behavior`, `service/daemon creation` как IR-семантика — в репозитории это следствие PID-namespace/Job lifecycle, а не отдельные примитивы. Отдельные булевы флаги создадут ложную точность. Правильно: `lifecycle.*` + `process.inheritance`, без `can_create_service: true/false`.
+6. `disk usage if enforceable` / `network bandwidth if enforceable` — "if enforceable" в prompt противоречит его же требованию "backend не может silently degrade". В IR нет условных полей: каждое поле имеет capability-статус, и `unsupported`/`requires_*` → fail-closed или явный opt-in, никогда "постараемся".
+7. `requires_vm` как capability-статус в одном ряду с `supported_*` — смешение категорий (место исполнения vs степень поддержки). Разделить: `support: exact|partial|unsupported` × `needs: none|host_component|vm|admin|entitlement`.
+8. Конвейер prompt (`... → Validation → Enforcement`) пропускает фазу резолва glob→concrete и фазу capability-check до fork. В репозитории glob-резолв load-time и fail-closed бюджеты (50k, 20k, condition-scan бюджеты) — load-bearing. Правильный конвейер: `User Policy → Normalize → Resolve (vars/globs→concrete, бюджеты) → Sandbox IR (frozen) → Backend Plan → Capability Check → Validation → Enforcement → Verify(applied plan)`.
+9. `policy hash uniquely identifies effective security config` — верно как цель, но хеш только policy недостаточен: effective config включает CLI `--net`, `env_extra`, тир/ABI, бэкенд-капабилити, kill-свитчи env. Хешировать надо frozen IR + backend plan + provenance (см. §8).
+
+## 3. Gap-анализ: чего не хватает сегодня для IR
+
+- Нет frozen IR-артефакта: `Policy` мутирует (`checker::check` retain'ит несуществующие write-корни с warning — это widen-by-drop? нет, это tighten, но молчаливое изменение requested без фиксации в хеше нарушает "verification sees actual applied plan").
+- Net-режим вне policy-слоёв: `RunConfig.net` не участвует в `MergedPolicy`, не подписывается `crypto.rs`, не входит в precedence-иерархию (§6 чинит).
+- Нет machine-readable capability-модели: `probe()`/`capabilities()` есть, но маппинг "поле→статус" живёт в головах и `bail!`-строках. Нужен `CapabilityReport` как данные.
+- Нет Backend Plan как данных: backend сразу `spawn`s; `--dry-run`/`explain` печатают, но не сериализуют детерминированный план для verify.
+- Нет детерминизма по построению: HashMap-итерация (`net_quota`), glob-порядок, `identity_nonce` — для хеша нужна каноническая сериализация (sorted keys, stable order).
+- Дыры immutability: покрыты только allow-пути; `pass_through`, net, limits, `secret_proxies`, env-override через CLI не блокируются. IR фиксирует полный never-overridable set.
+- Windows IO-rate best-effort (`SetInformationJobObject` failure игнорируется) противоречит инварианту "impossible never reported as enforced": либо fail-closed, либо capability `partial` + warning в plan, с явным статусом в отчёте.
+- macOS `VETTO_SEATBELT_MODE=none` — диагностический обход enforcement через env вне policy. В IR-модели любой такой свитч обязан входить в provenance-хеш и помечать plan `tainted: true` → verify fail.
+
+## 4. Sandbox IR — концептуальная схема (versioned, frozen)
+
+`ir_version: "0.1.0"`. Все пути — concrete absolute canonical (резолв уже произошёл; glob-паттерны в IR запрещены). Все списки — отсортированы, дедуплицированы. Неизвестные поля на любом уровне — hard error (fail-closed), никогда ignore.
+
+```toml
+[meta]
+ir_version = "0.1.0"
+schema_hash = "<blake2/sha256 канона схемы>"
+source_layers = ["system-global", ..., "cli-override"]  # provenance, ordered
+canonical_bytes_hash = "<hash frozen IR>"               # §8
+
+[fs]
+write_roots = [...]        # concrete dirs/files, allow
+read_roots  = [...]        # concrete, allow (без write-прав)
+deny_subtractions = [...]  # concrete существующие; вне грантов = warn useless_deny
+read_only = true           # read_roots никогда не дают write (инвариант)
+symlink_policy = "resolve_parent_then_prefix"  # как сегодня normalize_scope_path
+mount_semantics = "no_host_mounts"             # агент не получает новых маунтов
+host_mounted_paths = []    # пусто по умолчанию; любой элемент → needs host_component
+
+[egress]
+mode = "off"               # off | domain_allowlist | domain_strict | ask
+domains = [...]            # lowercased DNS-имена, без IP-литералов
+strict_ports = {...}       # domain -> [ports], только при mode=domain_strict
+dns = "broker_resolved_once_pinned"
+tls = "opaque_passthrough_no_interception"
+cidr = [...]               # РАЗДЕЛЬНО от domains; только IP-enforcement backend'ы
+bind_ports = [...]         # Landlock ABI4+; иначе capability
+connect_ports = [...]
+unix_ipc = "always_allowed"          # AF_UNIX разрешён во всех режимах
+unix_socket_files = [...]  # требуют fs-грантов на файл сокета (как сегодня)
+quotas = {...}             # per-domain bytes; enforcement best-effort → capability partial
+
+[process]
+exec_scope = "allow_roots" # exec только из read/write-корней (Landlock EXECUTE); Seatbelt/Win = partial
+inheritance = "same_policy" # потомки наследуют (Landlock irreversible, Seatbelt inherit, Job containment)
+detach_policy = "contained_or_fail" # FULL: kernel-kill; FS-ONLY/macOS: group-kill+sweep/watchdog (докум. гэп)
+privilege_drop = true      # capabilities stripped / low-integrity / least-privilege
+no_new_privs = true        # Linux; где нет аналога → capability
+
+[secrets]
+default = "deny"
+brokered_env = [...]       # secret_proxies: strip из env, только через host-брокер
+masked_paths = [...]       # deny_resolved concrete
+mask_mechanism = "overlay|carve|sbpl_tail_deny"  # выбирает backend, фиксируется в plan
+inherited_credentials = "deny"  # SSH/agent-сокеты, облачные credential-файлы — только явным грантом (который lint помечает high)
+
+[env]
+mode = "allowlist"         # inherit-all ЗАПРЕЩЁН на уровне схемы (нет такого значения)
+pass_through = [...]       # exact + trailing-*; нормализация как сегодня, дропнутое — в warnings IR
+deny = [...]               # deny бьёт allow (инвариант)
+home_synthetic = "..."     # значение HOME внутри (default: реальный HOME; изменение — explicit)
+tmp_isolated = true        # /tmp tmpfs (FULL) / policy tmpfs_tmp
+
+[resources]
+cpu_seconds, address_space_bytes, processes, open_files, file_size_bytes
+io_iops, io_bandwidth_bytes
+merge = "strictest_wins"   # инвариант слияния
+
+[lifecycle]
+session_identity = "<stable id>"   # НЕ nonce без фиксации: nonce входит в plan, не в IR-хеш
+timeout_secs, cleanup = "kill_tree", reap = "kernel|group+sweep|job_close"
+orphan_policy = "kill"     # где kernel не может → задокументированный гэп + capability partial
+crash_handling = "fail_closed_report"
+
+[extensions]               # intentionally platform-specific, префикс по ОС
+linux.seccomp_profile / linux.cgroup / linux.dev_allow
+macos.oslog
+windows.lpac / windows.io_rate / windows.appcontainer_identity
+# Правило: consumer обязан отвергнуть неизвестный extensions.* (deny_unknown_fields на каждом уровне).
+```
+
+Семантика capability на поле (machine-readable, в Backend Plan, не в user policy):
+
+`support: supported_exactly | supported_partially | unsupported` × `needs: none | host_component | vm | admin | entitlement`. `best_effort` как статус ЗАПРЕЩЁН: либо `supported_partially` с явным описанием потери (`loss: "reads of newly-created secret-shaped files in FULL tmpfs_tmp gap"`), либо `unsupported`. "Partial" без описания потери — inval
+id plan.
+
+## 5. Нормализация: `User Policy → Normalized → IR`
+
+1. Parse (deny_unknown_fields на каждом слое, как сегодня) → 2. Precedence-merge (§6) → 3. Vars/globs→concrete resolve с бюджетами (50k glob, 20k FS-ONLY-enum, condition-scan budgets; превышение = fail-closed, не truncation) → 4. Subtractive apply (deny бьёт allow; deny вне грантов → `useless_deny` warn, не error) → 5. Tier-independent IR freeze (каноническая сериализация: sort, dedup, lowercase domains, normalize env-patterns; дропнутое — в `ir.warnings`, warnings входят в хеш) → 6. Hash IR → 7. Backend Plan compile → 8. Capability check → 9. Validation (invariants §7) → 10. Enforcement → 11. Verify видит applied plan (§8).
+
+Детерминизм: канон = UTF-8, LF, sorted keys/arrays, integers decimal, paths canonical-lexical. `net_quota` HashMap сериализуется sorted. Nonce/identity — только в plan.
+
+## 6. Precedence (фиксирует расщепление net)
+
+Порядок (возрастание силы): `system-global < user-global < builtin-profile < preset < agent-preset < repository < repository-fragment(sorted) < local-override < cli-explicit-file < cli-flags < generated-security-profile(computed, не слой) < platform-backend-constraints (только tighten)`.
+
+Правила: merge `allow_*` — union; `deny_*` — union (deny монотонно, снять deny верхним слоем нельзя — только сузить соответствующий allow); `limits` — strictest-wins; `env.pass_through` — union минус `deny`; net-режим: единый источник — `cli-flags > agent-default > global-config > off`, policy-слои могут только требовать `off` (tighten), никогда включать relay. Never-overridable (даже CLI): `immutable` снятие, `deny` снятие, `env.mode=allowlist`→`inherit-all` (такого значения нет в схеме), `tls.opaque` выключение, снятие `no_new_privs`/`privilege_drop`, добавление allow-путей при lockdown. Backend constraints только сужают (fail-closed при конфликте), никогда не расширяют.
+
+## 7. Backend contract (trait, без привязки к Win32/Landlock/SBPL в сигнатурах)
+
+```
+parse(user_layers) -> NormalizedPolicy
+resolve(normalized, ctx{project,home,agent,tier_probe}) -> ResolvedConcrete
+compile(ir: FrozenIR) -> BackendPlan { steps: [...opaque backend ops...], capability: per-field Support×Needs, loss_descriptions, deterministic_bytes }
+check(plan) -> ok | fail_closed(reason, action)
+construct/apply/launch/cleanup  (жизненный цикл, как сегодня spawn→handle→terminate)
+report_capabilities() -> CapabilityReport  (данные, не строки)
+verify_applied(plan_hash) -> Attestation { ir_hash, plan_hash, backend_id, abi/enforcement ids, taint_flags }
+```
+
+Инварианты (formal-ish): (i) `unsupported` никогда не репортится как enforced; (ii) backend не расширяет запрошенное (plan ⊆ IR по каждому полю); (iii) defaults explicit (пустое ≠ дефолт: `tmp_isolated`, `no_new_privs` всегда присутствуют); (iv) deny бьёт inherit на всех уровнях; (v) unknown field = hard error; (vi) хеш frozen IR + plan однозначно идентифицирует effective config (включая net-источник, tier/ABI, taint); (vii) plan детерминирован при тех же входах (nonce вне хешируемой части); (viii) verify читает applied plan (attestation из enforcement-контекста), не requested policy.
+
+Fail-closed матрица: relay на не-FULL → abort; allowlist/strict/ask на macOS/Windows → abort; deny-внутри-гранта на Windows → abort; CIDR при отсутствии IP-enforcement → abort; `useless` deny → warn; бюджет резолва превышен → abort; taint (kill-switch env) → plan помечен, verify fail, запуск только с explicit `--allow-tainted` (которого по умолчанию нет; поле reserve).
+
+## 8. Хеш и доказательство `effective == requested`
+
+- `ir_hash = H(canonical(FrozenIR))`; `plan_hash = H(canonical(BackendPlan без nonce/identity/pid))`; session attestation = `{ir_hash, plan_hash, backend_id, abi, capability_vector, taint, source_layers}` — пишется в JSONL/отчёты (`report/`, `audit/`) и показывается в `policy explain --json`.
+- Доказательство равенства: verify перекомпилирует plan из frozen IR детерминированно и сравнивает `plan_hash`; затем enforcement-контекст (до exec, в setup-цепочке) подтверждает применение (`R`-байт readiness уже существует — расширить его attestation-payload) вместо доверия requested. Расхождение любого байта → fail-closed exit 103.
+- Хеш живёт в трёх местах: frozen IR-артефакт сессии (рядом с отчётом), session JSONL, `doctor --probe` вывод. Отдельного "policy registry" не нужно.
+
+## 9. Маппинги (Strong / Partial / Unsupported)
+
+Легенда: Strong = kernel-guaranteed deny; Partial = enforced с описанной потерей; Unsupported = fail-closed при запросе.
+
+Linux FULL: fs.write Strong (Landlock allowlist + NO_NEW_PRIVS irreversible); fs.read Strong вне дерева, внутри дерева — Strong через mount-overlay; deny_subtraction Strong (overlay); symlink Strong (VFS inode-decision); host_mounted_paths Strong (private ns); egress.off Strong (пустой netns); domain_allowlist/strict Strong при proxy-shaped TCP (потеря: non-proxy-aware протоколы не работают — это fail-closed by design, не downgrade); CIDR Partial (только через ABI4 port-правила + брокер-пиннинг; чистый IP-allow без DNS — Partial с loss); unix_ipc Strong; exec_scope Strong (EXECUTE-право); inheritance Strong (irreversible наследование); detach Strong (PIDNS kernel-kill); privilege_drop/no_new_privs Strong; secrets.brokered Strong (двойная strip); env allowlist Strong; resources Strong (rlimit+cgroup; io — через cgroup, см. extensions); lifecycle Strong.
+Linux FS-ONLY: fs.read Partial (carve + strip_read_on_write, loss: созданное-в-корне нечитаемо; late-created secret-shaped файлы в writable-корне — известный гэп → Partial с loss); detach Partial (group-kill + subreaper-sweep, setsid-gap документирован); egress relay Unsupported (fail-closed); mounts Unsupported.
+Linux Seccomp-tier: fs.* Unsupported (только syscall-hardening + netblock); запрошенный fs-IR → fail-closed.
+macOS Seatbelt: fs.write Strong (SBPL write* на корни); fs.read Partial (Shape A broad + tail-deny; loss: read-изоляция незамаскированного — best-effort против нативных бинарников, честно в doctor); deny_subtraction Partial (только для deny_resolved, last-match-wins); symlink Partial (SBPL subpath-семантика ≠ inode; TOCTOU-стойкость слабее Landlock); egress.off Strong (`deny network*` + unix-socket исключение для XPC — исключение задокументировано, не скрыто); domain_*/ask/cidr/bind/connect Unsupported (fail-closed); exec_scope Partial (`process-exec` blanket); inheritance Partial (наследование SBPL без PIDNS); detach Partial (kqueue watchdog, без kernel-kill); privilege Strong-нет-аналога → Partial (rlimit best-effort, отказы в stderr); secrets.brokered Strong (env-strip общий); lifecycle Partial.
+Windows process-sandbox: fs.write/read Strong внутри AppContainer-границы при доступных API (default-deny вне грантов); deny_subtraction Unsupported внутри гранта (fail-closed bail — это честный Partial→abort, не silent); symlink Partial (лексическая проверка + loader-resolved deny, 8.3/symlink-алиасы не моделируются); egress.off Strong (AppContainer caps, default-deny); domain_*/cidr/ports Unsupported без WFP-lease (fail-closed; WFP = needs admin, explicit opt-in, не часть launcher-плана); unix_ipc N/A (нет AF_UNIX-семантики релея; локальный IPC — через LPAC-изоляцию, Partial); exec_scope Partial; inheritance Strong через Job containment; detach Strong (kill-on-close); privilege_drop Strong (restricted+low-integrity/AppContainer least-privilege); env Strong; resources Strong для cpu/mem/processes, io_rate Partial (best-effort на старых Windows → plan обязан ставить partial+loss, а не молчать); lifecycle Strong.
+macOS Linux-VM mapping (OrbStack/Docker/VM): вне host-сущностей — это Linux FULL внутри гостя; IR тот же, `needs: vm`, host-secrets не мапятся в гостя по умолчанию (`mapped_folders` — explicit allow, каждый — fs-grant с provenance `vm-mapping`); сеть гостя — через его netns-стек; attestation дополнительно фиксирует `vm_boundary: true`. Windows Sandbox `.wsb`: аналогично `needs: vm`, mapped folders explicit, vSwitch off при `egress.off`.
+
+## 10. Critical questions (явные ответы)
+
+- Что нельзя выразить общим IR: точные mount/topology-операции (overlay vs carve vs tail-deny — это plan, не intent); dyld-совместимые read-формы macOS; Windows integrity-level/AppContainer-SID детали; symlink-раскрытие на не-inode системах; per-syscall seccomp-профили вне Linux; поведение XPC/mach-lookup; 8.3/short-name алиасы; точная семантика `setsid`-побега (это loss-описание, не флаг).
+- Intentionally platform-specific: `linux.seccomp_profile/cgroup/dev_allow/io_priority`, `macos.oslog`, `windows.lpac/io_rate`, `net_ports` (ABI4) как extension с fallback Unsupported, `dev/shm/tmp` изоляция детали, `snapshot/ephemeral/git_guard` (это product-фичи, не sandbox-примитивы — в IR не входят, живут рядом).
+- Против LCD: IR выражает строжайший intent (deny-by-default, deny-beats-inherit, no inherit-all), а backend честно ставит Unsupported вместо усреднения; общий знаменатель запрещён правилом "сужение только через fail-closed, не через silent".
+- Против silent downgrade: capability-check до fork + deterministic plan-hash + verify(applied) + taint-флаги + запрет `best_effort` без loss-описания + `unknown=error`.
+- Где живёт policy hash: в frozen IR-артефакте сессии + JSONL + отчёты + `explain --json` (три места, §8), не в отдельном registry.
+- Доказательство effective==requested: детерминированная перекомпиляция + сравнение plan_hash + attestation из enforcement-контекста (readiness-payload), не из requested policy.
+
+## 11. Security pitfalls / anti-patterns
+
+Exfiltration: allowlist без DNS-пиннинга (rebinding) — запретить схемой (только broker-pinned); IP-литералы в domain-полях — reject; `*.domain` покрывает subdomains, не base — фиксировать в нормализации; proxy-creds в env песочницы — только через brokered_env; `net_quota` не считать enforcement (учёт, не граница). Escape: writes в `/`, `/usr`, `$HOME` (lint R1/R2 → в IR-validation как hard-fail при lockdown, warn иначе); `allow_read=/` (yolo) + secrets только через masked_paths — честно Partial на macOS; `ro_mounts` вне read — авто-грант только явный (как сегодня, но фиксировать в plan). Adversarial: prompt-инъекция внутри разрешённого API — out of scope IR (зафиксировано в threat-model), но IR не должен давать полей "content-filter" (ложная граница); malicious dependency с exec — покрывается exec_scope+inheritance, не blocklist'ами. Tautологии: `display_only_deny` имя вводит в заблуждение — в IR переименовать в `masked_paths` (enforcement-механизм фиксирует plan). Env `*` (full-wildcard) — reject схемой. `VETTO_SEATBELT_MODE`/`VETTO_FORCE_TIER` вне хеша — taint (см. §7).
+
+## 12. Предлагаемые файлы (только proposal, кода нет)
+
+- `docs/policy-ir-proposal.md` — этот документ (финал).
+- Будущие (план, не создавать сейчас без аппрува): `src/policy_ir/` (`meta.rs`, `schema.rs`, `canonical.rs`, `freeze.rs`, `precedence.rs`, `capability.rs`, `plan.rs`, `verify.rs`), `src/sandbox/backend_trait.rs` (Backend contract §7), `docs/schema/sandbox-ir-v0.1.schema.json`, `docs/policy-ir-mapping.md` (Strong/Partial/Unsupported матрицы), тесты `tests/policy_ir_*` (детерминизм, fail-closed матрица, хеш-стабильность, adversarial: rebinding/CIDR-bypass/taint).
+
+## 13. Implementation plan (по фазам, без production-кода сейчас)
+
+1. Freeze-контракт: каноническая сериализация + `ir_hash` + frozen-артефакт в отчётах; перенести net-режим в provenance IR. 2. Capability-модель как данные (`report_capabilities` на каждом backend'е) + Strong/Partial/Unsupported матрицы в docs. 3. Backend Plan как детерминированные данные + `check()` до fork + `--dry-run` выводит plan-hash. 4. Verify(applied): attestation-payload в readiness + сравнение хешей, exit 103 при расхождении. 5. Precedence-фикс: единый net-источник, полный never-overridable set, deny-монотонность. 6. Taint-модель для env-киллсвитчей + Windows io_rate partial-честность. 7. Миграция: dual-read (старые TOML → Normalized → IR), `policy explain` показывает IR-хеш, старые поля мапятся 1:1, `display_only_deny` алиас к `masked_paths` с deprecation-warn.
+
+## 14. Acceptance criteria
+
+- AC1: frozen IR + `ir_hash`/`plan_hash` в JSONL/отчёте/`explain --json`; перекомпиляция даёт тот же `plan_hash` (тест детерминизма).
+- AC2: каждый пункт fail-closed матрицы (§7) abort'ится до fork с actionable-сообщением (тест на каждый backend).
+- AC3: `unknown field` в любом слое/extension — hard error, не warning.
+- AC4: ни один backend не репортит `unsupported` как enforced (capability-вектор в attestation сверяется с матрицей).
+- AC5: CIDR нельзя использовать для обхода domain-пиннинга (adversarial-тест: CIDR 0.0.0.0/0 при domain-режиме → abort или explicit IP-enforcement path).
+- AC6: DNS-rebinding тест: смена ответа на private между соединениями → deny второго соединения.
+- AC7: taint-тест: установленный `VETTO_SEATBELT_MODE`/`VETTO_FORCE_TIER` → plan tainted, verify fail без explicit opt-in.
+- AC8: `effective == requested` e2e: attestation из enforcement-контекста совпадает с планом; мутация одного байта IR ломает verify.
+- AC9: `src/verify_ng/` untouched (git status чист по этому пути).
+- AC10: production-код не написан в этом ходе; только `docs/policy-ir-proposal.md`.

--- a/docs/proctree-proposal.md
+++ b/docs/proctree-proposal.md
@@ -1,0 +1,376 @@
+# Process-Tree Containment + Guaranteed Cleanup — Architecture Proposal (Prompt 05)
+
+Статус: proposal, НЕ production-код. Ничего из нижеописанного не реализовано.
+Скоуп: `src/sandbox/{handle.rs,linux/proctrack.rs,macOS/pdeath_watch.rs,windows/job_object.rs}`
++ связанные модули. `src/verify_ng/` — чужой скоуп, не трогаем.
+
+## 1. Current process lifecycle (как есть сейчас)
+
+### Linux FULL (`src/sandbox/linux/mod.rs`: `spawn_full`, `child_full`, `child_b`)
+
+```text
+vetto (host ns, держит alive_w)
+└─ S (USER+MOUNT+IPC+NET ns; alive_r; err pipe)
+   ├─ R (relay, только allowlist/strict; вне pidns, вне Landlock)
+   └─ B (PID 1 нового pidns; PDEATHSIG; приватный /proc; Landlock; seccomp)
+      └─ C (agent; PDEATHSIG+getppid-check; seccomp; execve; пишет 'R')
+```
+
+Teardown FULL: `KillStrategy::PidNsPipe` (`src/sandbox/handle.rs:45-49`) —
+drop `alive_w` → EOF на `alive_r` → B делает `kill(-1, SIGKILL)` внутри pidns,
+затем reaps всех. Crash-resilience ядра: смерть vetto = EOF = тот же путь.
+B также ловит смерть C (`waitpid(-1)`) и убивает ns. Зомби жнёт B как PID 1.
+Оценка: Strong.
+
+### Linux FS-ONLY / Seccomp (`spawn_fs_only`, `spawn_seccomp_only`)
+
+Один fork, child = agent. `setpgid(0,0)` (или `setsid` в PTY), Landlock,
+seccomp, PDEATHSIG + getppid-check. Teardown (`handle.rs:175-195`):
+`kill(-pgid)` + `kill(pid)` + `proctrack::sweep_reparented` (только Linux,
+`sweep=true`). Перед fork — `set_subreaper` (`src/multi/isolation.rs:154`),
+после fork — `arm_exit_sweep` (atexit, т.к. `supervise` выходит через
+`std::process::exit`, `Drop` не бежит; `proctrack.rs:41-70`). Стрипы 360°:
+утечка сабреапера, выход из асьминхронного окна, выполнение вне peload-sweep.
+Оценка: Partial/best-effort, честно задокументировано в коде.
+
+### macOS (`src/sandbox/macos/mod.rs`, `pdeath_watch.rs`)
+
+Один fork, `setpgid(0,0)`, Seatbelt, execve. Teardown:
+`KillStrategy::ProcessGroup{pid,pgid,sweep:false}` — только `kill(-pgid)` +
+`kill(pid)`. `sweep=false` явно. Плюс `pdeath_watch::spawn` из родителя:
+kqueue NOTE_EXIT на vetto → SIGKILL агента (закрывает «vetto SIGKILLed»
+окно; grandchildren НЕ покрыты). Оценка: Partial.
+
+### Windows (`src/sandbox/windows/mod.rs`, `job_object.rs`)
+
+`Experimental_CreateProcessInSandbox` с `CREATE_SUSPENDED` →
+`create_kill_on_close_job` → `AssignProcessToJobObject` →
+`ResumeThread`. Teardown: drop job (kill-on-close) + drop process handle
+(`handle.rs:196-203`). `job_object.rs:104-106` — `KILL_ON_JOB_CLOSE |
+DIE_ON_UNHANDLED_EXCEPTION`, breakaway явно не разрешён (комментарий).
+`terminate()` вызывается из `Drop`, `wait_with_timeout` (`main.rs:1512`),
+TUI-quit, verify_ng killer. Оценка: Strong при условии, что assignment
+успел до ResumeThread (выполняется: suspended → assign → resume — правильно).
+
+### Timeout/supervision (`src/main.rs`)
+
+`wait_with_timeout` (`main.rs:1512-1536`): только `--tui=none`; TUI-режимы
+таймаут игнорируют (предупреждение `main.rs:1216-1223`). Немедленный
+`terminate()` по дедлайну, без graceful-фазы. `install_sigint_forwarder`
+(`main.rs:1704`): SIGINT/SIGTERM → forward (FS-ONLY: всей группе). Ctrl+C в
+TUI: `p` = pause, `q`+`y` = terminate. Daemon (`src/daemon/registry.rs:137`):
+`stop_session` = `child.kill()` + `wait()` на vetto-child (не на дерево
+напрямую; дерево чистит teardown самого vetto — ок для FULL/Job, best-effort
+иначе). `vetto kill` (`src/cli/kill.rs:33-89`): SIGTERM → 2с → SIGKILL,
+по группе с fallback на pid.
+
+## 2. Threat model
+
+Агент = произвольный код от uid пользователя внутри sandbox. Цели агента:
+пережить termination boundary (double-fork, `setsid`, daemonize,
+` KillStrategy::ProcessGroup`,
+nohup/`&`, at/cron/systemd --user, сокет/файл как якорь, respawn по таймеру,
+рождение ребёнка после смерти родителя, fork-bomb как DoS на sweep).
+Граница доверия: ядро/ОС — доверены; vetto-родитель — доверен, но убиваем
+(SIGKILL); всё внутри sandbox — враждебно. Non-goals (из threat-model.md):
+враждебное ядро, root, другой uid, prompt-injection внутри разрешённого,
+записи в разрешённый `$PROJECT`, side-channels.
+
+Приоритет gaps по exploitability × impact:
+1. FS-ONLY/macOS setsid-grandchild вне sweep-бюджета — детерминированный escape.
+2. Supervisor-crash + delayed/respawn child (cron/at/systemd --user вне pidns;
+   Job вне job; macOS вне группы).
+3. Creation race (assign после первого исполнения) — частично есть на Windows,
+   нет на Unix (нет раннего ownership вообще).
+4. False-positive cleanup checks (ниже §12).
+5. Resource-exhaustion как containment-атака (fork-bomb против sweep/observer).
+
+## 3. Security invariants
+
+- **I1 Termination closure.** Ни один процесс session не переживает
+  termination boundary в неконтролируемом состоянии. Strong tier: доказывается
+  ядром/Job; best-effort tier: утверждается только после успешной
+  post-cleanup assertion (§10), иначе — FAIL с явным residual.
+- **I2 Early ownership.** Владение потомком формируется до его первой
+  исполняемой инструкции (suspended-create+assign; pidns-fork; seccomp при
+  рождении невозможен — фиксировать как Unsupported и компенсировать).
+- **I3 Descendant closure.** Владение транзитивно: ребёнок владельца —
+  владелец. Механизм обязан покрывать внуков без их кооперации.
+- **I4 Crash resilience.** Смерть супервизора в любой точке обязана вести к
+  смерти дерева без кода супервизора (kernel/Job-alive-pipe/watchdog).
+- **I5 Cleanup authority.** Единственный владелец teardown — держатель
+  `SandboxHandle` (как уже в verify_ng/killer.rs: single-owner); `Drop` =
+  terminate; путь `std::process::exit` обязан иметь atexit-эквивалент.
+- **I6 No false-clean.** Cleanup успешен только при доказанном отсутствии
+  session-owned descendants (pidns-empty / job-empty / orphan-scan-empty +
+  cgroup-empty). Пустой `waitpid(root)` ≠ чистое дерево.
+- **I7 Fail-closed degradation.** Потеря примитива (subreaper prctl, kqueue,
+  cgroup mount) — громкий warn + понижение tier, никогда молча.
+
+## 4. Process ownership model
+
+Владелец = (session_id, механизм, граница). Граница Strong: pidns (Linux
+FULL), Job (Windows). Граница best-effort: pgid + subreaper-adoption
+(FS-ONLY), pgid + watchdog (macOS). Потомок принадлежит сессии, если создан
+внутри границы после её установки. FS-ONLY/macOS: принадлежность потомка,
+рождённого между fork и установкой фильтров, недоказуема — окно фиксируется
+как residual, а не игнорируется. Передача владения (daemon `stop_session`,
+`vetto kill`) — только через владельца handle, не через сырой pid (сегодня
+`kill.rs` шлёт сигналы по pid — gap, см. §12 п.6).
+
+## 5. Process creation protocol
+
+Требуемый порядок (target state):
+1. Создать границу ДО первой инструкции: pidns-fork / suspended+assign /
+   pgid+subreaper-arm.
+2. Запретить исполнение до готовности границы: Windows `CREATE_SUSPENDED` —
+   Strong (уже есть); Unix fork не даёт suspended — компенсировать
+   PDEATHSIG+getppid-check ДО unshare/mount (уже) + fail-closed setup pipe
+   с таймаутом (уже, 30с) + никогда не возвращать handle до байта 'R' (уже).
+3. Агент исполняется только после irreversible фильтров (seccomp/Landlock/
+   Seatbelt) — уже.
+4. Handle возвращается только после readiness; любой сбой — kill_and_reap,
+   не leak.
+
+## 6. Linux design
+
+**Strict (FULL) — Strong, уже есть, держать:**
+pidns + B(PID 1, reaper, alive-pipe) + PDEATHSIG + kill(-1) + cgroup.kill.
+Добавить (proposal): pidfd на B/S для точного ожидания без PID-reuse
+(`pidfd_open` + `poll`), `cgroup.kill` как второй kill-путь в
+`CgroupHandle::cleanup` уже частично есть — поднять до обязательного шага
+state machine; `SO_PEERCRED`-проверки не нужны.
+
+**FS-ONLY/Seccomp — Partial, потолок без pidns:**
+subreaper + kill(-pgid) + bounded sweep — текущий дизайн верный, но:
+(a) sweep-бюджет 2с и один проход — поднять до многоитерационного с
+эскалацией и финальной assertion (§10); (b) subreaper-fail сегодня только
+warn — добавить явное понижение assurance в отчёт/doctor; (c) cgroup
+(`pids.max` + `cgroup.kill`/`cgroup.procs` freeze) — поднять из
+best-effort-опции в обязательный второй рубеж, когда иерархия доступна;
+(d) `RLIMIT_NPROC` уже ставится pre-exec и наследуется — держать как
+anti-fork-bomb рубеж, задокументировать связку со sweep-бюджетом.
+Запрет `setsid/setpgid/daemon` через seccomp — **Unsupported**: ломает
+штатные рантаймы (shell job-control, setsid в PTY-пути самого vetto),
+фильтр неотличит «плохой» setsid от легитимного; containment обязан быть
+механическим ( adoption+sweep), а не запретительным. Фиксируем как осознанный
+отказ.
+
+**Примитивы:** strict = pidns + alive-pipe + B-reaper + pidfd + cgroup.kill
+(+ seccomp/Landlock как FS/нет-изоляция, не proctree). Optional = subreaper
+(нужен только вне pidns), orphan-scan (верификация, не убийство Strong).
+
+## 7. Windows design
+
+Текущий suspended→assign→resume — правильный ответ на creation race; держать
+как инвариант с регресс-тестом. Дополнительно (proposal):
+- nested jobs: агент не может вложить своё job с `BREAKAWAY_OK`, т.к. мы не
+  ставим `JOB_OBJECT_LIMIT_BREAKAWAY_OK` и члены job не могут выйти без
+  этого флага — держать + явно assert в probe; `kill_contract()` уже фиксирует
+  контракт — расширить его проверкой в `probe_job_object`.
+- handle inheritance: `inheritHandles=FALSE` уже; держать; captured-stdio путь
+  (`handle.rs:26-29`) открывать только с явным HANDLE-list, иначе fail-closed.
+- restricted token/AppContainer: ownership не дают, но сужают «чем внук может
+  стать» (no admin, low integrity) — держать как defense-in-depth, не как
+  cleanup-механизм.
+- limits: `ActiveProcessLimit` + `JobMemoryLimit` (уже в
+  `create_kill_on_close_job`) — обязательный anti-fork-bomb рубеж; добавить
+  post-cleanup assertion через Job accounting (запрос состояния job после
+  close-handle невозможен — assertion делать ДО drop: перечислить процессы
+  job, TerminateJobObject при остатке, затем close).
+- race окно между return experimental API и assign: покрыто suspended; если API
+  вернул уже-running процесс — считать нарушением контракта, Terminate+fail.
+
+## 8. macOS native design
+
+Потолок платформы без pidns/subreaper: pgid + watchdog. Proposal:
+- держать `pdeath_watch` (родительский fork, kqueue+poll-fallback) — Strong
+  для корня, Partial для дерева;
+- добавить subreaper-аналога НЕТ (Darwin не даёт) — фиксировать Unsupported;
+- добавить orphan-scan assertion после `terminate()` (перебор `sysctl
+  KERN_PROC` по ppid-цепочке от root pid + kill остатка + повтор) как
+  portable-аналог sweep с тем же бюджетом; сегодня `sweep=false` и никакой
+  проверки — главный macOS-gap;
+- Seatbelt наследование держать (потомки в профиле), но не выдавать за
+  cleanup;
+- launchd/`open -b`/cron-escape: агент внутри Seatbelt не может положить
+  persistent unit вне разрешённых путей записи — держать связку «FS-запрет =
+  persistence-запрет», задокументировать.
+- Endpoint Security: только notify/observe, не AUTH-allow/deny (уже честно);
+  не предлагать как cleanup-механизм без entitlement — Unsupported.
+
+## 9. VM design (Linux VM backend / win-sandbox)
+
+VM даёт Strong teardown бесплатно (уничтожение инстанса). Требования к
+дизайну: (a) termination boundary = граница VM, не внутренний pid; (b) агент
+никогда не держит handle наружу VM; (c) снапшот/откат не воскрешает «убитое»
+дерево как running; (d) host-side watchdog на гипервизор-объект на случай
+смерти vetto; (e) exfiltration через shared folders — вне proctree, но
+cleanup обязан закрывать гостевые mount-ручки до teardown. win-sandbox
+модуль уже генерирует .wsb — добавить в него kill-контракт (текущий файл —
+только спек, без lifecycle).
+
+## 10. Cleanup state machine (target)
+
+```text
+EXIT_REQUEST ──► GRACEFUL (SIGTERM/job-soft, T_grace≈2с; FS-ONLY: SIGTERM группе)
+   │ alive?            │ exited → VERIFY
+   ▼                   ▼ timeout
+ESCALATE (SIGKILL / kill(-1) / TerminateJobObject / drop-job; cgroup.kill+freeze)
+   │                   ▼
+   └──────────────► VERIFY (descendant-proof: pidns-empty / job-empty /
+                   │         orphan-scan-empty + cgroup.procs-empty)
+                   ├── CLEAN → post-cleanup assertion → SUCCESS
+                   └── RESIDUE ──► RETRY-SWEEP (bounded, ≤N, backoff) ──► CLEAN?
+                                     │ fail → FAIL-CLOSED: FAIL + residual report
+                                     │ (pids, cmdlines, tier, механизм), non-zero exit,
+                                     │ запись в registry, никаких «успех по waitpid»
+```
+
+Правила: graceful — только там, где есть кому ловить (Unix SIGTERM; Job —
+TerminateJobObject сразу, graceful опционален); `waitpid(root)` — необходимое,
+но не достаточное условие; каждый переход с дедлайном; общий бюджет teardown
+ограничен (sweep-DoS через fork-bomb обязан упираться в `pids.max`+бюджет, а
+не в бесконечность); сегодняшнего graceful вообще нет (`terminate()` =
+сразу SIGKILL) — это честно для adversarial, но §17 вводит опциональный
+GRACEFUL как настраиваемый, default = immediate-SIGKILL.
+
+## 11. Crash resilience
+
+| Сценарий | FULL | FS-ONLY | macOS | Windows Job |
+|---|---|---|---|---|
+| vetto SIGKILL | alive-pipe EOF → B kill(-1) — Strong | atexit НЕ бежит; остаётся kill(-pgid)? нет — **gap**: только PDEATHSIG корня; внуки-сироты вне subreaper-окна выживают | watchdog kqueue ловит — корень; внуки — gap | job kill-on-close — Strong |
+| vetto SIGTERM | forwarder → нормальный teardown | то же | то же | teardown через handler |
+| B/supervisor crash (внутри) | kernel reaps pidns — Strong | N/A (нет B) | watchdog двусторонний (следит и агента) | job держит |
+| host reboot/power | всё умирает | всё умирает | всё умирает | всё умирает |
+| daemon crash (`stop_session` недожал) | дерево уже убито teardown vetto-child | best-effort остаток | best-effort остаток | job держит |
+
+Главный crash-gap: **FS-ONLY + SIGKILL(vetto)**: `arm_exit_sweep` (atexit) не
+исполняется, `terminate()` не вызывается, subreaper-сироты остаются, т.к.
+усыновивший их родитель (vetto) мёртв и sweep некому бежать; PDEATHSIG покрывает
+только прямого ребёнка. Закрытие: pidfd+subreaper в daemon-стороже ИЛИ
+документированный downgrade assurance + `vetto kill --hung` как внешний
+sweeper (уже есть сканер, но он шлёт сигналы по pid, не sweep сирот —
+предлагается расширить, §17).
+
+## 12. Race analysis + false-positive cleanup checks
+
+R1. fork→PDEATHSIG окно: закрыто getppid-check (везде) + alive-pipe в FULL.
+R2. CreateProcess→assign: закрыто suspended (Windows). Unix-аналога нет —
+    компенсируется §5 п.2.
+R3. kill(-pgid)→setsid внука: reparent+sweep; окно = sweep-бюджет (residual).
+R4. waitpid(root)→рождение ребёнка после смерти родителя (delayed child,
+    `sleep 1 && evil &`): sweep ловит только усыновлённых к моменту скана;
+    каскад глубже бюджета — escape. Лечится VERIFY-циклом (§10), не одним
+    проходом.
+R5. PID reuse: `kill(pid)`/`/proc/pid` после reap может бить по чужому;
+    sweep исключает root_pid, но нерутовые пиды переиспользуемы между сканами.
+    Лечится pidfd (`pidfd_open` + `pidfd_send_signal`) и стартовым временем
+    из `/proc` (как уже в visibility `LifecycleToken`) — proposal.
+R6. `vetto kill <pid>` по группе `-pid` при неверном pgid бьёт по чужой
+    группе (fail-open наружу!). Предложение: kill только через registry +
+    верификация `start_time`/cmdline перед сигналом.
+R7. Daemon `stop_session`: `child.kill()` убивает vetto-child; если это был
+    SIGKILL при FS-ONLY — см. §11. Предложение: graceful SIGTERM vetto-child
+    с таймаутом вместо kill, чтобы его teardown успел отработать.
+
+False-positive checks (супервизор думает «чисто», а сущность жива):
+F1. `waitpid(root)==exited` при живых detached-внуках (главный кейс промпта).
+F2. `kill(-pgid)==ESRCH` — группы уже нет, а setsid-внуки живы.
+F3. `pgrep -f marker` пуст — процесс переименовался (`exec -a`, argv[0]
+    перезапись) или cmdline недоступен (зомби/kernel-thread вид).
+F4. orphan-scan пуст, т.к. ребёнок ещё не переродился (родитель-зомби не
+    подождён) — scan до `root_settled` обязателен (в `sweep_reparented` уже
+    есть `root_settled` — держать).
+F5. cgroup.procs пуст, т.к. процесс в D-state (uninterruptible) — kill
+    отложен ядром; VERIFY обязан отличать «пусто» от «D-state остаток».
+F6. Job handle закрыт → «дерево убито», но nested-breakaway процесс вне job
+    (если флаг когда-либо ослабят) — assertion ДО close обязательна.
+F7. macOS `kill(agent)==ESRCH`, а внук в другой группе жив — сегодня вообще
+    не проверяется.
+F8. Redteam `test_setsid_escape` (`redteam.rs:85-129`): проверяет ФЛАГ
+    subreaper/pidns, а не факт смерти потомка — self-attested Pass, классический
+    false-positive. Заменить execution-пробой (§15).
+
+## 13. Resource containment (связка с proctree)
+
+CPU/mem (`limits.rs` RLIMIT_* + `cgroup.rs` cpu.max/memory.max) — наследуются,
+снижают blast radius, но не убивают дерево. `pids.max` (cgroup) +
+`RLIMIT_NPROC` (уже pre-exec) — прямой anti-fork-bomb рубеж для sweep-бюджета:
+предложение сделать `pids.max` обязательным, когда cgroup доступен
+(сегодня опционален и молча None). Open files (`RLIMIT_NOFILE`), fsize —
+наследуются; сокеты — seccomp-семейства + netns/Job/AppContainer; IPC —
+разделённые IPC-ns (FULL) vs общий host IPC (FS-ONLY/macOS — shm как
+covert-канал между «убитыми» и живыми, учесть в VERIFY). FD-exfiltration:
+передача дескрипторов наружу дерева (SCM_RIGHTS, pidfd_getfd — уже blocked)
+не воскрешает процесс, но удерживает пайпы открытыми → ложное «дерево висит»
+(EOF не приходит); B уже закрывает stdio-копии (`close_stdio_fds`), watchdog
+чистит все fd — держать паттерн везде.
+
+## 14. Verification strategy
+
+Уровни: unit (парсинг `/proc`, BPF-офсеты — уже есть) → execution-probes
+(реальный setsid-внук, см. `linux_orphans.rs:100` — уже execution, держать как
+образец) → adversarial suite (§15) → post-cleanup assertion в проде (§10) →
+`doctor --probe` отражает assurance-tier честно. Наблюдение
+(visibility-poller, audit, ETW, FSEvents) — только evidence, никогда вход
+VERIFY-решения (уже принцип threat-model.md:65-70 — держать).
+
+## 15. Adversarial tests (минимум промпта → файлы)
+
+Каждый кейс: spawn → teardown (graceful + SIGKILL-vetto) → assertion
+«ноль session-owned». Матрица tier × кейс: FULL/Job = must-pass; FS-ONLY/macOS
+= must-report (pass либо FAIL+residual, молчаливый pass запрещён).
+Кейсы: double-fork; daemonize (`daemon()`); setsid; background shell
+(`sh -c 'sleep 9999 &'`); spawn-loop/fork-bomb (под `pids.max`); delayed
+child (`(sleep 3; evil)&` при teardown на t=0); child-after-parent-exit;
+socket-open-then-detach (файл/сокет-якорь + setsid); files-kept-open
+(EOF-hang проверка); respawn-loop (`while true; do evil; done` + watcher).
+Плюс: exec-rename evasion (F3), PID-reuse окно (R5), TUI-timeout-ignore
+проверка. Исполнение вне дерева запретов: at/cron/systemd --user только там,
+где FS позволяет (expected-residual, не flake).
+
+## 16. Repo/module changes (каждое изменение → файлы)
+
+| # | Изменение | Файлы/модули | Tier | Класс |
+|---|---|---|---|---|
+| 1 | Cleanup state machine: graceful→escalate→verify→assert (`CleanupReport`) | `src/sandbox/handle.rs` (расширить `terminate`), новый `src/sandbox/cleanup.rs`, `src/main.rs` (`wait_with_timeout`), `src/tui/{full,statusline}.rs` | все | Partial→Strong-verify |
+| 2 | Orphan-scan VERIFY-цикл + residual-отчёт вместо одного sweep | `src/sandbox/linux/proctrack.rs` (расширить `sweep_reparented`), `src/sandbox/cleanup.rs` | FS-ONLY/Seccomp | Partial (потолок) |
+| 3 | pidfd-ожидание/сигналы против PID-reuse | `src/sandbox/linux/proctrack.rs`, `src/sandbox/linux/mod.rs` (хранить pidfd в handle) | Linux | Strong |
+| 4 | cgroup.kill+freeze как обязательный второй рубеж + `pids.max` default при доступной иерархии | `src/sandbox/linux/cgroup.rs`, `src/sandbox/handle.rs`, `src/sandbox/linux/mod.rs` | Linux | Partial→Stronger |
+| 5 | macOS orphan-scan assertion после terminate | `src/sandbox/macos/mod.rs`, новый `src/sandbox/macos/orphan_scan.rs`, `src/sandbox/handle.rs` (`sweep:true` для macOS с новым сканером) | macOS | Partial (потолок) |
+| 6 | Windows assertion ДО drop job (перечень процессов, Terminate при остатке) + nested-breakaway assert в probe | `src/sandbox/windows/mod.rs`, `src/sandbox/windows/job_object.rs`, `src/sandbox/handle.rs` | Windows | Strong |
+| 7 | Crash-path: graceful SIGTERM daemon-child вместо kill; внешний sweeper для FS-ONLY-сирот | `src/daemon/registry.rs` (`stop_session`), `src/cli/kill.rs` (registry-верификация перед сигналом) | все | Partial |
+| 8 | HANDLE-list captured-stdio контракт (иначе fail-closed) | `src/sandbox/handle.rs` (`StdioMode`), `src/sandbox/windows/mod.rs` | Windows | Strong |
+| 9 | Adversarial suite (§15) + замена self-attested redteam-пробы execution-тестом | `tests/integration/linux_proctree_adversarial.rs` (новый), `tests/integration/macos_proctree.rs` (новый), `tests/integration/windows_proctree.rs` (новый), `src/redteam.rs` (`test_setsid_escape`), `tests/integration/linux_orphans.rs` (расширить) | все | Test |
+| 10 | `doctor --probe` assurance-репорт (tier × механизм × residual) + SECURITY.md sync | `src/doctor/probe.rs`, `SECURITY.md`, `docs/platform-backends.md`, `ARCHITECTURE.md` | все | Docs |
+| 11 | VM kill-контракт в спеке + host-watchdog | `src/sandbox/windows/windows_sandbox.rs`, docs | VM | Strong |
+| 12 | Graceful-флаг (default immediate-SIGKILL) + TUI-timeout паритет | `src/main.rs`, `src/config.rs`, `src/tui/*` | все | UX/compat |
+
+Не менять молча: `KillStrategy` варианты, `SWEEP_BUDGET_MS`, `sweep:false` на
+macOS, daemon stop-семантика, redteam-статусы — всё через этот proposal.
+
+## 17. Migration plan
+
+Фаза A (верификация без смены поведения): п.9-тесты + п.10-docs + п.8-контракт;
+adversarial suite в CI как must-report (не блокирует). Фаза B (state machine):
+п.1+п.2+п.5 за флагом, default старое поведение; включить VERIFY-assertion с
+репортом, graceful default off. Фаза C (ужесточение): п.3 pidfd, п.4 cgroup
+default, п.6 windows-assertion, п.7 daemon-graceful; adversarial становится
+must-pass на Strong tier. Фаза D: п.11 VM-контракт, п.12 graceful-флаг/TUI
+паритет. Каждая фаза: `docs/proctree-proposal.md` ← статус, SECURITY.md sync,
+версионный бамп +0.0.1 по AGENTS.md-политике отдельным коммитом.
+
+## 18. Security limitations (честные остатки)
+
+- FS-ONLY/macOS: detached grandchild при SIGKILL(vetto) или вне бюджета —
+  выживает;入学 Landlock/seccomp наследуются, но живость — нет. Unsupported
+  без pidns/Job: запретить setsid, получить crash-proof sweep.
+- Любой tier: respawn через внешнюю сущность (cron/systemd/host-процесс того
+  же uid вне границы, daemon-registry) — вне proctree-границы по определению;
+  закрывается FS-политикой (некуда записать unit), не kill-логикой.
+- D-state процессы: SIGKILL отложен ядром; VERIFY отличает, но не ускоряет.
+- PID-reuse между наивными сканами — до внедрения pidfd (п.3).
+- Наблюдение (audit/poller/ETW/FSEvents) — evidence only, пропуск ≠ разрешение.
+- Prompt-injection внутри разрешённого, записи в `$PROJECT`, side-channels,
+  враждебное ядро/root — out of scope (threat-model.md).

--- a/docs/secrets-proposal.md
+++ b/docs/secrets-proposal.md
@@ -1,0 +1,271 @@
+# Prompt 04 — Secret & Credential Isolation: архитектурный proposal
+
+Статус: предложение, не implementation. Production-код не пишется. Scope: `docs/`,
+анализ `src/cred_broker.rs`, `src/policy/secretscan.rs`, secret_masking тестов.
+`src/verify_ng/` не тронут.
+
+## 1. Current secret exposure inventory (реально enforced / best effort / documented)
+
+### Реально enforced (Strong, но только там где указано)
+- Env allowlist-only: `src/policy/defaults.rs:61` (`DEFAULT_ENV_PASSTHROUGH`),
+  `src/policy/types.rs:204` (`EnvironmentPolicy::allows`, deny приоритетнее),
+  `src/policy/loader.rs:2271` тесты на `AWS_SECRET_ACCESS_KEY` deny-by-default.
+  Применение перед execve: `src/sandbox/linux/mod.rs:664` (`child_exec`),
+  `src/sandbox/macos/mod.rs:425` (`build_envp`),
+  `src/sandbox/windows/mod.rs:1114` (`environment_block`).
+  `GH_TOKEN`/`OPENAI_API_KEY`/`AWS_*`/`ANTHROPIC_API_KEY` по умолчанию не проходят. Вердикт: **Strong** (все 3 backend фильтруют одинаково).
+- `filter_proxy_secrets` (`src/cred_broker.rs:59`, вызовы в linux `mod.rs:668,677`,
+  macos `mod.rs:432,441`; Windows: fail-closed bail в `src/main.rs:863`).
+  Вердикт: **Strong** как strip-механизм, **но** сам брокер возвращает секрет (см. §2).
+- Linux Tier FULL mount overlays: `src/sandbox/linux/mounts.rs:274` (`mask_path` —
+  `/dev/null` на файлы, пустой tmpfs на директории), вызов в `mod.rs:1056`,
+  `make_root_private`, `isolate_tmp`, `isolate_dev_shm`, `mask_sensitive_proc_paths`.
+  Landlock сам вычитать не умеет (allowlist), overlay — единственный механизм карвинга.
+  Вердикт: **Strong** внутри FULL.
+- Linux FS-ONLY enumeration carve-out: `src/policy/loader.rs:1804`
+  (`mask_project_reads_for_fs_only` + `enumerate_tree`, бюджет `FS_ONLY_ENUMERATION_BUDGET`,
+  fail-closed при превышении). Вердикт: **Partial** (TOCTOU, бюджет, late-created файлы).
+- Seccomp netblock FS-ONLY (`src/sandbox/linux/seccomp_netblock.rs`) + запрет
+  `ptrace/process_vm/pidfd_getfd/mount/io_uring/bpf` — Strong против снятия оверлеев,
+  но **Unsupported** для файловой части секретов (нет карвинга).
+- Network broker DNS/IP pinning: `src/sandbox/linux/net_relay.rs:333,551` —
+  реджект private/loopback/link-local/metadata/multicast/reserved incl. NAT64/mapped,
+  CONNECT-level mediation. Вердикт: **Strong** (Linux allowlist/strict).
+  `GIT_SSH_COMMAND` через `ssh-proxy` helper (`net_relay.rs:1274`, `BatchMode=yes`,
+  дочерний процесс OpenSSH, не демон). Вердикт: **Strong**.
+- macOS Seatbelt tail-deny: `src/sandbox/macos/seatbelt.rs:49` (deny после broad read,
+  last-match-wins). Вердикт: **Partial** — рабочий профиль Shape A
+  (`SBPL_MAXIMUM_READ_SHAPE`, broad `(allow file-read* (subpath "/"))`), известный
+  провал read-изоляции доказан тестом
+  `tests/integration/macos_seatbelt.rs:17` (`secret_reads_are_not_yet_isolated_on_macos`).
+- Windows: `src/sandbox/windows/mod.rs:1172` (`build_sandbox_spec`) — deny внутри
+  гранта = fail-closed bail (честно, без выдуманного FlatBuffer-слота).
+  Вердикт: **Strong** как fail-closed, **Unsupported** как субтракция.
+- Report sinks санитизированы: `src/report/json.rs:19`, `src/report/mod.rs:163`,
+  `src/report/html.rs`, `markdown.rs`; JSONL sink `src/logger/jsonl.rs:58` через
+  `sanitizer::sanitize_line` + `open_append_nofollow` (no-symlink, regular, nlink==1).
+  Вердикт: **Strong** для этих путей (при BEST-EFFORT оговорке).
+
+### Best effort (не граница, честно помечено)
+- `src/logger/sanitizer.rs:1` (BEST-EFFORT, FP+FN), `src/pty/redact.rs` (Aho-Corasick +
+  entropy), `src/pty/entropy.rs` (H>4.5, len>=20), `src/cli/mask.rs` (`vetto mask` pipe),
+  `src/policy/secretscan.rs` (сканер 1MB/5000 файлов/3s, `mask_secret` prefix4+suffix4).
+- `src/classifier/suspicious.rs` — только audit hints (`credential_path_access`,
+  `non_public_network_target`), never enforcement. Вердикт: **Partial** по определению.
+- `vetto scan-secrets` (`src/main.rs:550`) и `auto_deny_secrets` (`loader.rs:1536`).
+  Вердикт: **Partial** (покрывает только известные regex + имена файлов в $PROJECT).
+
+### Merely documented / честные Unsupported
+- macOS read-изоляция (`SECURITY.md`, `docs/platform-backends.md`, doctor probe
+  `sbpl-read-fragment`): заявлен Unsupported без VM.
+- Windows per-domain allowlist без admin (WFP требует elevation, vetto отказываться
+  требовать): fail-closed, честно.
+- Late-created secret-shaped файлы в writable $PROJECT (SECURITY.md residual risks).
+- `~/.gitconfig` читаем intentionally (credential в URL rewrite = exposure, documented).
+- Taint-tracking/DLP: отсутствует, заявлено честно (threat-model §"What Vetto Does NOT Protect").
+
+## 2. Найденные дыры (проверено по коду, не по памяти)
+
+1. **Брокер возвращает секрет в песочницу.** `BrokerResponse::Ok { header_value }`
+   (`src/cred_broker.rs:47`) — любой держатель сокета читает raw secret.
+   Нет `SO_PEERCRED` auth, нет привязки к session/pid, `allowlist "*"`, секреты в
+   `HashMap<String,String>` без zeroize/mlock, сокет-путь через
+   `VETTO_CRED_BROKER_SOCK` в `env_extra` (`src/main.rs:873`), сам сокет в
+   `temp_dir()` (= host `/tmp`, который FULL прячет `isolate_tmp` — брокер может быть
+   **недоступен**; либо доступен через проброшенный путь — оба исхода плохи).
+   Вердикт текущего: **Partial/Unsafe**. Fail-closed риск: escape через чтение сокета.
+2. **Лог/audit пути без санитайзера.** `src/logger/oslog.rs:42` (`{:?}` fallback для
+   `ExecObserved` incl. argv), `src/logger/system_log.rs:26` (comm/path/message как есть
+   в journald/logger/eventcreate), `src/notify/mod.rs:76` (path/host в
+   notify-send/osascript/PowerShell), `src/audit/history.rs:101`
+   (`append_record_to_file` — plain append, без nofollow/hardlink проверок jsonl.rs,
+   `AuditRecord.command = argv.join(" ")` без санитайзера). Вердикт: **Partial**,
+   exfiltration через crash/log/notify.
+3. **`mask_secret` течёт 8 символов.** `src/policy/secretscan.rs:62`
+   (prefix4+suffix4) + `SecretFinding.preview` печатается в `scan-secrets`
+   (`src/main.rs:584`). Вердикт: **Partial** — preview должен быть класс-only.
+4. **Core dumps не запрещены.** `src/sandbox/linux/limits.rs:43` — нет `RLIMIT_CORE=0`;
+   `PR_SET_DUMPABLE=1` ставится для observe (`linux/mod.rs:382`) и не сбрасывается
+   явно в agent child. Вердикт: **Partial** (эксфильтрация секретов из памяти через дамп).
+5. **Env passthrough содержит риски.** `XDG_RUNTIME_DIR` в passthrough
+   (`defaults.rs:87`) — доступ к bus/waylandсокетам и кэшам; `GIT_*` identity ок,
+   но нет явного deny для `GIT_ASKPASS`/`GIT_CREDENTIAL_HELPER`/`SSH_AUTH_SOCK`/
+   `GPG_AGENT_INFO`/`KUBECONFIG`/`DOCKER_CONFIG`/`*_TOKEN`. Сейчас они deny-by-absence
+   (Strong по умолчанию), но без явного списка один `pass_through: ["*"]` в custom
+   политике всё откроет без предупреждения. Вердикт: **Strong по умолчанию,
+   Partial по footgun-устойчивости**.
+6. **Credential helpers / keystores без явного deny.** Linux D-Bus (`AF_UNIX` разрешён,
+   `DBUS_SESSION_BUS_ADDRESS` не фильтруется), macOS `security`/Keychain (в SBPL-шаблоне
+   нет keychain-deny), Windows Credential Manager/DPAPI (без заявлений — честно
+   Unsupported). Вердикт: **Partial (Linux/macOS) / Unsupported (Windows native)**.
+7. **Shell history / browser / cloud paths вне deny-листа.** Профили покрывают
+   `.ssh/.aws/.gnupg/.kube/.docker/.config/gcloud|gh|copilot/.npmrc/.netrc/
+   .git-credentials/.cargo/credentials*/.claude/.codex` + $PROJECT shapes, но не
+   `~/.bash_history|~/.zsh_history`, `~/.local/share/keyrings`, browser profiles,
+   `~/.config/gcloud/application_default_credentials.json` (частично через dir),
+   `~/.aws/sso/cache`, `~/.kube/cache`, systemd-credentials, CI secret mounts
+   (`/run/secrets`), `/proc/self/environ` чужих процессов (закрыто pidns в FULL,
+   открыто в FS-ONLY/macOS/Windows). Вердикт: **Partial**.
+8. **Несуществующие deny-пути = тихий no-op.** `mask_path` → `Ok(false)`
+   (`mounts.rs:274`), glob no-match → empty set (`glob_resolve.rs:48`).
+   Late-created `$PROJECT/.env` после старта не маскируется. Вердикт: **Unsupported**
+   без fanotify/eBPF/VM (честно).
+
+## 3. Threat model / taxonomy / invariants (кратко)
+
+Threat: враждебный агент с произвольным кодом как invoking user: читает файлы/env/
+helpers/keys/caches, исполняет хелперы, пишет temp/log, ходит в сеть (где разрешено),
+переживает supervisor (orphan/setsid). Non-goals: hostile kernel, root, физика,
+злонамеренный vetto (как в `docs/threat-model.md`).
+
+Taxonomy классов: A) long-term identity (ssh/gpg), B) cloud/IaC (aws/gcp/azure/kube),
+C) VCS/registry tokens (gh/gl/npm/cargo/pypi/hf), D) API keys (openai/anthropic/gemini),
+E) local trust (netrc/git-credentials/.env/kdbx/p12/pfx/pem/key), F) session/bearer
+(env/argv/tmp/core/log), G) platform stores (keychain/credential-manager/libsecret/
+browser), H) metadata endpoints (169.254.169.254, metadata.google.internal).
+
+Invariants (fail-closed):
+- I1: deny-by-default на секреты на всех OS; grant только explicit + session-scoped.
+- I2: санитайзер никогда не граница; граница только kernel/token/namespace/VM.
+- I3: секрет никогда не возвращается в песочницу — только host-side attachment.
+- I4: неизвестное = запрещено (неизвестный профиль/env/socket/helper → bail, exit 103).
+- I5: в логах только класс, никогда значение (path+rule+line, без preview байт).
+- I6: child не наследует ambient credentials (env strip + no helper sock + no bus).
+
+## 4. Архитектурные варианты (trade-offs)
+
+1. **deny-path** — дёшево, точно по известным путям; не ловит неизвестные места,
+   symlink-alias (лечится canonicalize, уже есть в `types.rs:409`), late-created файлы.
+2. **environment filtering** — allowlist-only Strong и дёшев; не покрывает файлы/helpers;
+   footgun при `pass_through=["*"]` — лечить lint+deny-пресеты.
+3. **secret broker / capability broker** — единственный путь дать доступ без раскрытия;
+   цена: IPC-auth, session binding, revocation, audit; текущий GetHeader — антипаттерн
+   (возврат значения), чинить в proxy-attach.
+4. **trusted helper process** — git-ssh-proxy образец (дочерний, не демон); цена:
+   каждый helper — новый аудит поверхности.
+5. **host-side secret injection** — env/argv инъекция host-стороной; env/argv всё равно
+   видны `/proc` и логам → только для эфемерных + RLIMIT_CORE=0 + санитайзер логов.
+6. **temporary ephemeral credential** — сужает blast radius (TTL/scope/session-bind);
+   цена: нужен issuer (cloud IAM, gh apps); без него — только обёртка над long-term.
+7. **network proxy with credential attachment** — лучший для egress-секретов: секрет не
+   пересекает границу, брокер пинает DNS/IP (уже умеет); цена: только proxy-shaped
+   протоколы (документировано), не покрывает локальные файлы.
+
+## 5. Default policy (deny-by-default)
+
+Автоматически скрывать (все OS, где механизм есть): §2.7 список + shell history,
+keyrings, browser credential stores (deny-правила даже на несуществующие пути —
+сигнал для lint), cloud metadata (сеть). Explicit grant: только через
+`[secrets] grant = [{class, session, ttl, scope}]`, одноразовый, привязан к
+`session_id+root_pid`, revoke при `SessionEnded`/timeout; read-only grant для файлов =
+overlay-remount ro невозможен → grant только через broker-read (host отдаёт bytes по
+fd, не путь). Наследование в child: env strip на каждом exec (не только на входе),
+`close_all_except` уже есть; добавить `RLIMIT_CORE=0` + сброс `DUMPABLE`.
+
+## 6. Exfiltration-разбор (честно)
+
+- read+net-off: безопасно кроме side-channels (shm в том же trust boundary, timing) —
+  можно читать, вынести некуда; остаток: запись в $PROJECT/.vetto-reports (маскировать
+  sibling dirs уже делает `isolate_agent_state_dirs`).
+- read+net-allowed: **DLP невозможен без taint-tracking** — брокер видит домен/байты,
+  но не semantic origin; allowlist + per-domain quota + no-TLS-intercept (заявлено).
+  Не обещать контент-инспекцию.
+- env/argv: allowlist + strip + санитизация логов + CORE=0; argv всё равно виден в
+  `/proc` внутри той же pidns — считать argv публичным внутри сессии.
+- helper/credential-helper: только host-side; in-sandbox helper = confused deputy.
+
+## 7. Platform mapping
+
+- **Linux**: protected paths → deny_resolved+overlay (FULL Strong / FS-ONLY Partial /
+  Seccomp Unsupported); env filter Strong; Landlock implications (чистый allowlist,
+  карвинг только оверлеями/энумерацией); credential helper isolation → host broker +
+  D-Bus deny (новое); namespaces (уже есть); metadata → broker reject Strong.
+- **Windows**: AppContainer caps + low-integrity + Job kill-on-close (есть);
+  ACL/DACL субтракции нет → deny-inside-grant fail-closed (есть, оставить);
+  user profile: default-deny вне грантов; Credential Manager/DPAPI → **Unsupported**,
+  только VM; PowerShell env — тот же `environment_block` (Strong); WSL interop →
+  рекомендовать WSL2 Tier 1.
+- **macOS**: App Sandbox/Seatbelt Shape A + tail-deny (Partial); Keychain/TCC →
+  добавить явный keychain-deny или честно Unsupported; user profile paths — broad read
+  (Unsupported); native vs VM → для строгих требовать OrbStack/Linux VM.
+- **VM strategy**: `--backend win-sandbox` (.wsb, host secrets не мапятся — Strong),
+  macOS → OrbStack/devcontainer, Linux → microVM для DLP/taint (будущее, не обещать).
+
+## 8. Audit/observability
+
+Писать: access attempts (BlockedAttempt — есть), denials (есть), secret **class**
+(rule/path/line, без value — новое), policy decisions (warnings уже есть в
+`checker.rs`/`lint.rs`), broker operations (lease issue/attach/deny/revoke —
+новое, без значений). Все sinks через `sanitizer::sanitize_line`; history.jsonl —
+туда же + nofollow/hardlink как в jsonl.rs. Core/argv — санитизировать до записи.
+
+## 9. Adversarial tests (новые, к существующим `secret_masking.rs`, `adv_isolation.rs`)
+
+`cat ~/.ssh/id_rsa`, `env|grep -i token`, argv-секрет в jsonl/history/report/oslog/
+notify, symlink/`..`/double-slash/trailing-dot обходы deny, REFER/move/hardlink секрета
+в readable subtree (есть прецедент `linux_landlock.rs:236`), late-created `.env`,
+`git credential fill`, `SSH_AUTH_SOCK` inherit, `secret-tool`/`security dump-keychain`/
+`CredRead`, `curl 169.254.169.254`, DNS rebinding, core dump (`kill -ABRT; gdb core`),
+чужой session читает чужой broker socket, `allowlist ["*"]` reject, `pass_through ["*"]`
+lint-warn.
+
+## 10. Exact repo changes (файлы/модули, без production-кода в этом ходе)
+
+1. `src/cred_broker.rs` — протокол без возврата значения (proxy-attach), SO_PEERCRED,
+   session-bind, TTL/revoke, запрет `*`, zeroize+mlock. **Partial→Strong**.
+2. `src/sandbox/linux/net_relay.rs`, `src/main.rs:863`, `src/sandbox/linux/mod.rs:1128`
+   — слить cred broker с net relay; сокет через SCM_RIGHTS, не `/tmp` путь.
+   **Partial→Strong** (escape-закрытие).
+3. `src/policy/types.rs`, `loader.rs`, `defaults.rs`, `presets.rs`, `profiles/*.toml` —
+   `SecretClass` + `secrets.deny_by_default` + session grants; расширить deny-лист
+   (§2.7). **Partial→Strong (FULL) / честный Partial (остальные)**.
+4. `src/policy/secretscan.rs`, `src/main.rs:569` — preview → класс-only, расширить
+   правила (kube/docker/auth.json/sso cache), лимиты оставить. **Partial→Strong-er
+   (всё равно не граница)**.
+5. `src/logger/oslog.rs`, `system_log.rs`, `src/notify/mod.rs`,
+   `src/audit/history.rs`, `src/events/replay.rs`, `tail.rs` — санитайзер везде +
+   nofollow для history. **Partial→Strong (как courtesy layer)**.
+6. `src/sandbox/linux/limits.rs`, `src/sandbox/macos/limits.rs`,
+   `src/sandbox/linux/mod.rs:382`, `src/sandbox/windows/mod.rs` — `RLIMIT_CORE=0`,
+   сброс DUMPABLE в agent child, WerDump off. **Partial→Strong**.
+7. `src/sandbox/linux/mod.rs:664`, `macos/mod.rs:425`, `windows/mod.rs:1114`,
+   `src/policy/defaults.rs`, `lint.rs`, `checker.rs` — явный env deny-пресет
+   (ASKPASS/HELPER/SSH_AUTH_SOCK/GPG/KUBECONFIG/DOCKER/*TOKEN), lint против
+   `pass_through=["*"]`, убрать/сжать `XDG_RUNTIME_DIR`. **Strong 유지**.
+8. `src/sandbox/macos/seatbelt.rs` — keychain-deny или документированный Unsupported;
+   `src/sandbox/windows/*` — Credential Manager Unsupported + VM путь.
+   **Partial→честный Unsupported**.
+9. `src/sandbox/linux/seccomp_netblock.rs`, D-Bus env — abstract-socket/bus deny для
+   secret классов. **Partial**.
+10. `docs/*`, `SECURITY.md`, `docs/threat-model.md`, `docs/platform-backends.md` —
+    обновить claims (что можно/нельзя). Тесты: `tests/integration/secret_masking.rs`
+    (расширить на history/oslog/notify/preview/core), новый
+    `tests/integration/secret_isolation.rs`.
+
+## 11. Migration plan
+
+Фаза 0: этот proposal + lint-warnings (не ломать). Фаза 1: лог/аудит санитайзер +
+CORE=0 + preview класс-only + env deny-пресет (обратно совместимо). Фаза 2: брокер
+proxy-attach + SCM_RIGHTS (флаг-гейт, старый GetHeader deprecated→удалён). Фаза 3:
+SecretClass/grants + расширенный deny-лист + VM-документация. Каждая фаза — свои
+adversarial тесты, fail-closed по умолчанию.
+
+## 12. Security claims: можно / нельзя
+
+Можно (после фаз): ambient credentials не наследуются; секреты deny-by-default;
+брокерные секреты не пересекают границу; логи не содержат значений; FULL скрывает
+известные пути kernel-уровнем; metadata недоступна через брокер.
+Нельзя: DLP/taint без VM; read-изоляция на macOS native и субтракция на Windows
+native; late-created файлы без перезапуска сессии; защита от prompt injection внутри
+разрешённых API; side-channels; hostile kernel/root.
+
+## 13. Critical questions (ответы)
+
+- Deny-by-default на всех OS: §5 список + metadata + helper socks (где механизм
+  отсутствует — fail-closed отказ запуска, как Windows делает сегодня).
+- Только через trusted broker: любой секрет, нужный агенту для egress (API keys,
+  registry tokens, git/cloud creds) — host-side attach, никогда файлом/env/argv.
+- Где без VM/host component нельзя: macOS read-deny, Windows subpath-subtract и
+  Credential Manager, полный DLP/taint, late-created файлы строго.
+- Accidental exposure (logs/dumps/argv/env): санитайзер везде + класс-only preview +
+  CORE=0/DUMPABLE=0 + allowlist env + argv считать публичным внутри сессии.

--- a/docs/security-levels-proposal.md
+++ b/docs/security-levels-proposal.md
@@ -1,0 +1,248 @@
+# Security Levels + Capability-Aware Policy — архитектурное предложение (Prompt 08)
+
+Ветка: `arch/prompt-08`. Production-код не пишется. `src/verify_ng/` не затронут.
+Статус каждого требования prompt: **Strong** (уже есть фундамент), **Partial** (есть частично, нужны изменения), **Unsupported** (нет, проектировать с нуля).
+
+## 1. Current modes inventory
+
+CLI (`src/cli.rs`, `src/config.rs`): `--profile` (default `default`), `--preset paranoid|balanced|yolo`,
+`--policy PATH`, `--net off|allowlist:|strict:|ask`, `--backend auto|process|win-sandbox`, `--lpac`,
+`--observe-seccomp`, `--shadow`, `--verify`, `--dry-run`, `--ci`, `--limits SPEC`, `--fail-on-block`,
+`--git-ssh`, `--mask-secrets/--no-mask-secrets`, `--deny-glob`, `--git-guard`, `--snapshot/--ephemeral`,
+`--auto-deny-secrets`. Пресеты (`src/policy/presets.rs`): paranoid (net off), balanced/yolo (net allowlist
+по агенту). Профили (`profiles/*.toml`): default/strict/audit/permissive — различаются только FS/env/limits,
+сеть ими не управляется (сеть — вне policy, `Policy::deny_network` лишь intent, `src/policy/types.rs:253`).
+
+Реальные тиры исполнения: Linux Full / FsOnly / **Seccomp** (`src/policy/types.rs:9`, `src/sandbox/linux/mod.rs:108`);
+macOS Seatbelt; Windows AppContainer/LPAC+Job; Windows Sandbox VM (opt-in `--backend win-sandbox`).
+`VETTO_FORCE_TIER` — только downgrade-тест, bypass невозможен (`linux/mod.rs:106`).
+
+Несоответствия, найденные в репо (не принимать prompt на веру, не принимать и docs на веру):
+
+- **F1. Tier Seccomp недокументирован.** `SECURITY.md` знает только FULL/FS-ONLY; код имеет третий тир
+  `Tier::Seccomp` — только seccomp-фильтр и лимиты, **без filesystem-изоляции вообще**
+  (`spawn_seccomp_only`, `linux/mod.rs:1489`; `explain.rs:211` честно пишет `unmasked-filesystem-seccomp-only`).
+  Это главный кандидат на «называет слабый режим sandboxed».
+- **F2. Exit-код fail-closed противоречив.** `docs/threat-model.md:110` обещает `103`,
+  `src/exit_codes.rs:16` и `docs/exit-codes.md:10` — `125`. Docs врут в одну из сторон.
+- **F3. README обещает несуществующий код.** README (`README.md:168`) заявляет uniform VM path
+  `mac-vm` (Virtualization.framework) и WSL2-guest+sync-back как дефолт на macOS/Windows.
+  Grep по `src/`: `mac-vm|mac_vm|VmConfig` — **0 совпадений**. Docs ahead of code; в матрицах ниже
+  mac-VM помечен Unsupported.
+- **F4. Сеть тихо расширяется при auto-detect.** `src/config.rs:211` — дефолт `NetMode::Off` (Strong, задокументирован),
+  но `src/main.rs:532` и `:202` при zero-config auto-detect переключают `Off → Allowlist(домены агента)`.
+  Дефолт `off` реален только при явном агенте/флаге; Detected-путь — silent widening. Опасный дефолт.
+- **F5. Lint не ловит `allow_read=["/"]`.** `lint.rs` R2 ловит только read-root `== $HOME`; пресет `yolo`
+  ставит `allow_read=["/"]` (`presets.rs:273`) — линт молчит. Плюс `yolo allow_write` включает `$HOME`
+  (R1 ловит, severity high — ок), но связка `yolo + agent preset` нигде не ранжируется по силе.
+- **F6. `--dry-run` врёт про тир при недоступном бэкенде.** `main.rs:644` — при failed detect + dry-run
+  подставляется воображаемый `Tier::Full`. Dry-run показывает политику, которой не будет.
+- **F7. `--shadow` персистентен через global config** (`config.rs:305`) и гасит **два** fail-closed пути:
+  verify-leaks (`main.rs:805`) и fail-on-block (`main.rs:1353`). Shadow для верификации — легитимный
+  use-case, но shadow для fail-on-block стирает границу enforcement/observation.
+- **F8. `Tier::Seccomp` молча принимает relay-требование?** Нет — ок: `linux/mod.rs:150` + `main.rs:781`
+  реджектят relay на FsOnly/Seccomp до спавна. Strong, сохранить как compile-rule.
+
+## 2. Threat model (дельта к `docs/threat-model.md`)
+
+База уже сильная: агент = произвольный код юзера; enforcement ≠ observation; non-goals зафиксированы.
+Для levels добавить: (a) **adversarial capability downgrade** — злоумышленник (или баг), управляющий env
+(`VETTO_FORCE_TIER`, global config) или project policy, не должен мочь ослабить уровень без explicit opt-in;
+(b) **exfiltration через allowlist-сеть** — prompt-injection в разрешённый API остаётся out-of-scope, уровень
+обязан это декларировать, а не скрывать; (c) **escape-классы по тирам**: FS-ONLY `setsid`-orphans,
+Seccomp — отсутствие FS-изоляции полностью, macOS — broad reads, Windows — no unprivileged LSM;
+(d) **late-created secrets** (`$PROJECT/.env`, созданный после старта) — не маскируется ни на одном тире,
+уровень обязан это говорить.
+
+## 3. Security level semantics (предложение)
+
+Вердикт по именам: `strict/standard/compat` из prompt — плохи тем же, чем плохи `secure/strong`:
+прилагательные без семантики. Предлагаю имена-обязательства: **`lockdown` / `standard` / `compat`**
+с машиночитаемым `guarantees[]` в каждом выводе. `compat` честно содержит слово «совместимость»,
+а не «безопасность».
+
+| Гарантия | `lockdown` | `standard` (дефолт) | `compat` (explicit opt-in) |
+|---|---|---|---|
+| filesystem | мин. write (`$PROJECT`+/dev/null), мин. read, secret-overlays обязательны | write `$PROJECT`+`/tmp`, toolchain reads, overlays обязательны | широкие reads допустимы, overlays best-effort; каждый пробел — в отчёте |
+| network | `off`, relay запрещён на компиляции | `off` либо allowlist/strict по backend-возможностям | `ask` допустим; allowlist только через broker |
+| process | PID-ns / Job kill-on-close обязательны; `setsid`-escape недопустим | best available, escape-окно декларируется | watchdog-допуски с явным флагом |
+| secrets | deny-list non-overridable (см. §6), env allowlist-only, API-ключи агентов только через broker/`secret_proxies` | то же, минус часть toolchain-deny | env-расширения только явными флагами, каждое — в `policy explain` |
+| environment | минимальный passthrough | default passthrough | расширения видны в dry-run diff |
+| resources | лимиты обязательны (lint R5 → high) | лимиты дефолтны, отсутствие — warn | отсутствие — warn + запись в отчёт |
+| cleanup | snapshot/rollback где поддерживается | best-effort | best-effort |
+| verification | `--verify` обязателен перед стартом, leak = отказ без override | leak = отказ, `--shadow` только логирует | leak = отказ; shadow запрещён |
+| fallbacks | запрещены все | только Full→FsOnly с явным флагом и бейджем `degraded` | любой downgrade — только explicit opt-in, каждый — в отчёт |
+
+Non-overridable гарантии (ответ на critical review): secret deny-list ядра (`standard_secret_deny_paths`),
+env default-deny, `strictest-wins` для лимитов, запрет relay вне FULL, запрет запуска без бэкенда.
+
+## 4. Capability schema
+
+```toml
+[capability.fs.write_deny]  status = "enforced"   # enforced|partial|unavailable|degraded|virtualized
+[capability.fs.read_deny]   status = "partial"     # + evidence = "verify:deny-path"
+[capability.net.off]        status = "enforced"
+[capability.net.allowlist]  status = "unavailable" # + reason = "no netns on this backend"
+[capability.process.reap]   status = "degraded"    # + reason = "setsid escape window, FS-ONLY"
+[capability.secret.overlay] status = "unavailable"
+[capability.env.isolation]  status = "enforced"
+[capability.resource.ceiling] status = "enforced"
+[capability.cleanup.rollback]  status = "partial"
+```
+
+Статусы: `enforced` (ядро/платформа гарантирует, есть verify-тест), `partial` (гарантия с известным окном,
+окно названо), `unavailable` (backend не умеет — только fail-closed или explicit opt-in), `degraded`
+(запрошенное ослаблено с согласия — всегда с бейджем), `virtualized` (гарантия исходит от VM, не хоста).
+Схема одна на всех (`src/policy/capability.rs` новый), значения — на бэкенд (`capabilities()` рядом
+с каждым `spawn`, по образцу `windows::capabilities()` / `linux::probe()`).
+
+## 5. Backend capability reporting
+
+Каждый backend возвращает `CapabilityReport` до спавна: machine-readable (JSON в `policy explain --json`,
+`doctor --json` — новый флаг) + human-readable (таблица в `doctor`). Источники: Linux — существующий
+`linux::probe()` (Strong) + новый маппинг probe→статусы; macOS — `seatbelt_available()` +
+`probe_sbpl_read_fragment()` (Strong); Windows — `windows::probe()` + `optional_backend_report()`
+(Strong). Новое: WinSandbox и будущий mac-VM отчитываются как `virtualized`, а не `enforced`.
+
+## 6. Policy compilation rules (`requested → capabilities → compile → validate → execute`)
+
+Новый модуль `src/policy/compiler.rs` (Partial: куски есть в `main.rs:781`, `linux/mod.rs:150`,
+`macos/mod.rs:60`, loader — собрать в одно место). Правила: `strict net=off` на backend без net-deny →
+**отказ**, не downgrade (пример из prompt — уже так, закрепить правилом R-NET-01); relay вне FULL →
+отказ (R-NET-02, уже есть); secret-deny вне coverage тира → отказ, кроме `compat` с opt-in (R-SEC-01,
+закрывает F1: Seccomp-тир больше никогда не стартует «тихо»); `yolo allow_read=["/"]` → минимум warn,
+в `lockdown` → отказ (R-FS-01, закрывает F5); auto-detect не вправе расширять сеть (R-NET-03, закрывает F4:
+detected-путь обязан спрашивать/оставаться off); preset `yolo` несовместим с `lockdown` (R-LVL-01).
+
+## 7. Fallback/downgrade semantics
+
+Warning допустим только для observation/visibility (audit feed, FSEvents, R5-отсутствие лимитов в standard).
+Failure обязателен для: сеть, FS-изоляция, secret-маскировка, отсутствие бэкенда, verify-leak
+(кроме shadow в standard). Explicit opt-in downgrade: `--compat` + `--allow-degraded <что>` поимённо,
+каждый — в dry-run, statusline-бейдж `degraded`, отчёт. Automatic refusal — дефолт везде. `--shadow`
+разделить: `--shadow-verify` (наблюдение) vs запрет shadow для fail-on-block (закрывает F7).
+
+## 8. UX/CLI
+
+`--security-level lockdown|standard|compat` (дефолт `standard` = сегодняшнее поведение минус F4),
+`--allow-degraded`, `--shadow-verify` вместо `--shadow`, `doctor --json`, `policy explain` показывает
+`level + guarantees[] + degraded[] + backend + vm? + fallback?`. Statusline-бейдж уровня; никакого
+зелёного «sandboxed» без перечисления активных гарантий (закрывает misleading-green-check).
+`dry-run` при недоступном бэкенде пишет `tier: unavailable`, а не воображаемый Full (закрывает F6).
+
+## 9–12. Capability matrices
+
+### Linux Full — Strong (есть код + verify)
+
+| Измерение | Статус | Evidence |
+|---|---|---|
+| FS write/read deny | enforced | Landlock ABI 1–6 + overlays; verify `deny-path`, `write-outside` |
+| net off | enforced | netns; verify `net-loopback` |
+| net allowlist/strict | enforced | broker + DNS-pinning; relay-код |
+| process reap | enforced | PID-ns init; kill-стратегия `PidNsPipe` |
+| secret overlay | enforced | tmpfs//dev/null binds; verify |
+| env | enforced | allowlist-only; `environment_tests` |
+| resources | enforced | rlimits+cgroup перед exec |
+| cleanup | partial | snapshot best-effort, 50MB-лимит молча пропускается (`main.rs:727`) |
+
+### Linux FsOnly — Partial (честно задокументирован, окно названо)
+
+FS deny — enforced-via-carveout (имена видны, контент запрещён); relay — unavailable→отказ;
+reap — degraded (`setsid`-окно, subreaper+sweep best-effort); overlays — unavailable (компенсация enumeration).
+
+### Linux Seccomp — Partial→необходимо переименовать
+
+Сегодня: NO FS backend вообще. Статус FS/read/secret — `unavailable`. Правило: уровни выше `compat`
+на нём отказываются; в `compat` — только с `--allow-degraded fs,read-deny,secrets` и красным бейджем.
+**Запретить слово «sandboxed» для этого тира без квалификатора** (F1 — главная дыра нейминга).
+
+### macOS native — Partial
+
+write — enforced (SBPL Shape A); read-deny — partial (broad reads + tail-deny, dyld #62);
+net off — enforced, allowlist/strict/ask — unavailable→отказ (уже есть); reap — degraded (kqueue watchdog);
+overlays — unavailable. Verify battery на macOS существует (`verify.rs`), но `probe-stderr`/FSEvents —
+observation, не enforcement.
+
+### macOS Linux-VM / Windows WSL2 — Unsupported в коде
+
+README заявляет (F3), кода нет. Матрица: после реализации — всё `virtualized`, verify внутри геста,
+хост-сторона отчитывается `virtualized`, не `enforced`. До реализации — docs обязаны помечать «план».
+
+### Windows native — Partial
+
+FS/process — enforced-via-AppContainer/LPAC+Job (админ-прав не требует); per-domain WFP —
+unavailable без admin opt-in → отказ, не degrade (уже так); overlays/mounts — unavailable;
+verify battery — unavailable на Windows (`verify.rs:156`), только capability probe.
+
+### Windows Sandbox VM — Partial
+
+Всё `virtualized`, opt-in `--backend win-sandbox`, fail-closed без Hyper-V (уже есть,
+`sandbox/mod.rs:74`). Verify внутри VM — будущая работа.
+
+## 13. Verification integration
+
+Связь `Capability → invariant → scenario → evidence`: каждый `enforced`-статус обязан иметь verify-сценарий
+с stable-id (`deny-path`, `net-loopback`, `write-outside` уже есть — Strong). Новое: unit-тесты компилятора
+на каждую R-*** (отказ, а не downgrade), lint-правила как инварианты уровней (R1/R2 → high в lockdown),
+`doctor --probe` и `--verify` обязаны печатать активный level. Непокрытое (окна без сценария: `setsid`-orphan
+на FS-ONLY, late-created `.env`, WSL-interop) — статус не выше `partial`, в отчёте как known-limitation.
+
+## 14. Docs/security claims model
+
+Каждое клеймо в `README.md/docs/*.md` получает класс: `enforced` (код+verify+ссылка), `platform-limited`
+(со ссылкой на матрицу), `plan` (без кода — запрещено настоящее время, см. F3). Фиксы: exit-код `103→125`
+в threat-model (F2), задокументировать Tier Seccomp (F1), пометить mac-VM/WSL2-guest как plan (F3),
+дефолт сети описать с auto-detect-исключением до закрытия F4, `compat.md` «✅ Verified» для агентов —
+привязать к тиру (verify-бейджи сегодня без указания тира исполнения).
+
+## 15. Repo/module changes (файлы)
+
+| Файл | Изменение |
+|---|---|
+| `src/policy/capability.rs` (new) | схема статусов, `CapabilityReport`, JSON/human рендер |
+| `src/policy/compiler.rs` (new) | R-NET-01/02/03, R-SEC-01, R-FS-01, R-LVL-01; `requested→compile→validate→execute` |
+| `src/policy/types.rs` | `SecurityLevel` enum, `Policy.level`, `degraded[]` в `Policy` |
+| `src/policy/lint.rs` | R2 расширить на предков `/` и `$HOME`; R5 severity по уровню; новое R-FS для `yolo⊂lockdown` |
+| `src/cli.rs`, `src/config.rs` | `--security-level`, `--allow-degraded`, `--shadow-verify` (deprecated `--shadow`), dry-run `tier: unavailable` |
+| `src/main.rs` | вызов compiler до policy-load; убрать silent net-widen при auto-detect; разделить shadow-пути; dry-run честность |
+| `src/sandbox/linux/mod.rs` | expose probe→capability mapping; Seccomp-тир отдаёт `unavailable` по FS |
+| `src/sandbox/macos/*`, `src/sandbox/windows/*` | capability-маппинги, без изменения enforcement |
+| `src/doctor/*` | `doctor --json`, capability-таблица, level в выводе |
+| `src/policy/explain.rs`, `src/cli/status.rs` | level + guarantees + degraded-бейджи |
+| `src/verify.rs` | level в `VerifyReport`, связка capability→сценарий |
+| `docs/*.md`, `README.md`, `SECURITY.md` | claims-классы, F1–F8 фиксы, матрицы 9–12 |
+| `docs/security-levels-proposal.md` (new, этот файл) | архитектурный документ |
+
+`src/verify_ng/` — не трогать.
+
+## 16. Migration plan
+
+1. Типы+схема (`capability.rs`, `types.rs`) — additive, дефолт `standard` = текущее поведение.
+2. Compiler с правилами-отказами за флагом, затем по дефолту; F4/F6 фиксы — сразу (баги, не фичи).
+3. CLI/UX (`--security-level`, бейджи, `doctor --json`).
+4. Docs-классы + F1/F2/F3 правки.
+5. VM-путь (mac-VM/WSL2-guest) — отдельный эпик, до него docs только `plan`.
+6. Версия: +0.0.1 по политике репо (факт: `Cargo.toml` сейчас `0.2.18`, `VERSIONS.md` в worktree нет —
+   сверить с основным репо перед релизом, прыжков и пропусков номеров нет).
+
+## Critical review (вывод)
+
+- Слабый режим под именем «sandboxed»: **Tier Seccomp без FS-изоляции** (F1) — единственное место,
+  где слово «sandbox» сегодня технически ложно без квалификатора.
+- Опасные дефолты: silent net-widen при auto-detect (F4); персистентный `--shadow` на fail-on-block (F7).
+- Compat→bypass: `yolo allow_read=["/"]` мимо линтa (F5); воображаемый Full в dry-run (F6).
+- Non-overridable: secret deny-list, env default-deny, strictest-wins лимитов, relay-только-FULL,
+  запуск-без-бэкенда. Всё это уже код — compiler должен окаменеть их как правила, а не полагаться
+  на разбросанные bail!-ы.
+
+## Implementation plan + acceptance criteria
+
+План: P0 — F4, F6, F2 (однострочные правки поведения/docs); P1 — `capability.rs` + маппинги бэкендов +
+`compiler.rs` с R-правилами и тестами-отказами; P2 — CLI (`--security-level`, `--allow-degraded`,
+`--shadow-verify`, `doctor --json`, бейджи); P3 — docs-классы и матрицы; P4 — VM-эпик.
+Acceptance: (1) `strict + net=off` на backend без net-deny — отказ с action, никогда degrade;
+(2) Seccomp-тир не стартует выше `compat` без `--allow-degraded fs,read-deny,secrets`;
+(3) auto-detect не расширяет сеть молча; (4) dry-run без бэкенда пишет `unavailable`;
+(5) каждый `enforced`-статус имеет verify-сценарий; (6) `policy lint --strict` ловит `allow_read=["/"]`;
+(7) docs без глаголов настоящего времени для несуществующего VM-кода; (8) `src/verify_ng/` untouched;
+(9) версия +0.0.1, коммит только в `arch/prompt-08`.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -107,4 +107,4 @@ numbers come from `libc::SYS_*`, so x86-64 constants are never reused on ARM64.
   (prompt injection inside allowed tools/APIs, legitimate writes to allowed
   paths, microarchitectural side-channels, compromised kernel/root operator).
 - **No silent downgrade:** when a requested boundary cannot be guaranteed,
-  vetto exits fail-closed (`103`) instead of running unconfined.
+  vetto exits fail-closed (`125`, `EXIT_FAIL_CLOSED`) instead of running unconfined.

--- a/docs/verify-ng.md
+++ b/docs/verify-ng.md
@@ -1,0 +1,102 @@
+# verify-ng — Adversarial Security Verification
+
+Измерительный harness поверх sandbox-бэкендов. Enforcement остаётся в
+`src/sandbox/*`; этот модуль только измеряет и отчитывается. Не является
+частью security boundary.
+
+## Две оси
+
+- `Verdict`: `PASS` / `FAIL` / `INCONCLUSIVE` / `NOT_APPLICABLE`
+  (`src/verify_ng/model.rs`). Fail-closed: не-PASS в blocker-категории
+  блокирует релиз. `NOT_APPLICABLE` требует probe-доказательства отсутствия
+  capability, иначе блокирует как `N/A-without-evidence`.
+- `ClaimStrength`: `STRONG` / `PARTIAL` / `UNSUPPORTED` — статическое
+  свойство пары (сценарий, платформа-тир) в registry. Нет «Partial-PASS»:
+  отчёт несёт обе оси.
+
+## Уровни evidence
+
+1. `HOST_FACT` — наблюдено доверенным хостом после wait (post-mortem stat,
+   wait-status, sweep, canary-сравнение, spec-hash). Единственный уровень,
+   поддерживающий PASS.
+2. `CONSTRAINED` — узкий nonce-bound сигнал изнутри (errno-класс + nonce).
+   Поддерживает FAIL, никогда PASS в одиночку.
+3. `SELF_REPORT` — stdout-маркеры атаки. Только hint для triage.
+
+## Nonce-связка (FM-02)
+
+Engine выдаёт nonce сессии. Негативная проба и позитивный контроль обязаны
+его использовать; хост сверяет совпадение. Расхождение — INCONCLUSIVE.
+Ловушки `ORACLE-DECEIT-001` / `CONTROL-SPLIT-001` — постоянные regression.
+
+## FrozenSpec (FM-03)
+
+Один `detect` на сценарий; хэш считается один раз из той же `&Policy`-ссылки,
+что уходит в `Backend::spawn`; сериализация каноническая (сортировка,
+`NetMode::label`, tier, backend-describe, argv/env/cwd, nonce, хэш реестра).
+Повторная заморозка перед spawn обязана совпасть (`verify_spec_continuity`).
+
+## Spawn-контракт (FM-09)
+
+Все `Backend::spawn` — под `SPAWN_SERIAL` от detect до fork-возврата.
+Блокирующий `wait()` в runner запрещён; только `try_wait`-poll +
+`kill_on_deadline` + deadline-aware drain (`collector::drain_with_deadline`).
+
+## Cleanup-матрица (FM-05)
+
+- Linux FULL — Strong (PIDns teardown).
+- Windows Job — Strong (kill-on-close).
+- Linux FS-ONLY / macOS — BestEffort (group-kill + sweep-бюджет 2с);
+  destructive-сьюты там только в disposable VM.
+
+## Fixture (FM-06)
+
+Один spawn — один сценарий. Хэш payload до/после; мутация — INCONCLUSIVE.
+HOME изолирован на прогон. `env_extra` engine-контролируем.
+
+## Redaction (FM-07)
+
+Все detail-строки через `redact_text`: секреты → `[REDACTED]`, control-байты
+чистятся, лимит `MAX_DETAIL`. HOME-префикс маскируется.
+
+## Diagnostic env (FM-08)
+
+`VETTO_SEATBELT_MODE`, `VETTO_NO_MAC_LIMITS`, `VETTO_CHILD_TRACE` (и
+`VETTO_FORCE_TIER` вне tier-differential job) — отравление: FAIL на
+блокерах, INCONCLUSIVE на aux. Детект до spawn.
+
+## Gate (FM-12)
+
+`exit::evaluate_gate`: canary (`VFS-TRAV-001`, `ENV-LEAK-001`, `PROC-ESC-001`)
+обязаны PASS; ноль INCONCLUSIVE в I1–I6; NOT_APPLICABLE только с evidence;
+минимум PASS по каждой blocker-категории. Пустой сьют — gate FAIL
+(`GATE-VACUUM-001`).
+
+## Кворум и повторы (FM-13)
+
+Multivector-сценарии требуют ≥quorum независимых согласующихся векторов,
+иначе INCONCLUSIVE. Stress — медиана ≥3 прогонов. Ретраи не превращают FAIL
+в PASS.
+
+## Потолки платформ (FM-11)
+
+- macOS `VFS-READ` — максимум PARTIAL (Shape-A + tail-deny; `MAC-SHAPE-001`
+  сверяет профиль побайтово). Strong read-secrecy — только Linux VM.
+- Windows per-domain egress без admin — UNPROVABLE (WFP требует elevation).
+- `WIN-WSL-001` — UNSUPPORTED baseline; любой PASS — баг oracle.
+- Windows evidence — host-fact-only, пока нет HANDLE-capture в backend
+  (требует отдельного backend-ревью, не входит в этот план).
+
+## Pipeline (FM-14)
+
+`Engine` — единственный владелец `SandboxHandle`:
+Engine → Killer → Collector → Oracle (чистая функция, без IO) → Reporter.
+Oracle не управляет сбором: collector всегда собирает фиксированный
+суперсет фактов.
+
+## Что всё ещё нельзя доказать
+
+См. Prompt-01 §20 и self-review §E: TLS-payload к allowed-API, целостность
+`$PROJECT` внутри, side-channels, kernel-0day, полнота логов, привязка хэша
+к живому процессу (только непрерывность владения до fork), полнота sweep
+при SIGKILL на FS-ONLY/macOS, UDS/IPC-exfil на mac/Win, статистика CI-таймингов.

--- a/docs/verify-ng.md
+++ b/docs/verify-ng.md
@@ -72,6 +72,85 @@ HOME изолирован на прогон. `env_extra` engine-контроли
 минимум PASS по каждой blocker-категории. Пустой сьют — gate FAIL
 (`GATE-VACUUM-001`).
 
+> Итерация 2: gate-минимум по `fs-write` закрывается сценарием
+> `VFS-WRITE-001` (blocker, `linux-full`/`linux-fsonly` STRONG). Без его PASS
+> gate остаётся красным по правилу per-category minimum — vacuum по записи
+> невозможен.
+
+## Сьюты итерации 2 (карта покрытия Prompt 01)
+
+Linux suite (полностью, fail-closed/escape/exfil приоритет):
+
+- `VFS-WRITE-001` (blocker, fs-write) — STRONG на full/fs-only. Закрывает
+  пустую blocker-категорию `fs-write` и правило gate-minimum.
+- `VFS-PROC-001` (blocker, fs-read) — `/proc|/sys|/dev`/fd-инъекции.
+- `NET-EXFIL-001` (blocker, net, quorum 3) — мультивекторная эксфильтрация:
+  curl, python-socket, native TCP4/6, DNS, alt-HTTP, UDS/IPC, raw-syscall.
+- `SHELL-ESC-001` (blocker, spawn) — alt-shell/interpreter/PATH-confusion.
+- `ENV-SECRETS-001` (blocker, secrets) — env/fd/argv/SSH-Git-cloud canary.
+- `PROC-TREE-001` (blocker, proc) — sibling/detached/handles escape.
+- `RACE-TOCTOU-001` (blocker, spawn, quorum 3) — freeze-spawn + symlink-swap
+  TOCTOU, медиана ≥3 прогонов.
+- `SEC-BLOCKS-001` (blocker, spawn) — seccomp/syscall denial по native ABI
+  (ptrace/process_vm/pidfd, mount/pivot, io_uring, userfaultfd, bpf/perf).
+- `RES-EXHAUST-001` (high, proc) — fork/pids/IO/disk/mem; полный вариант
+  только disposable VM.
+- `STRESS-SWEEP-001` (high, proc) — stress/race контракт: медиана, кворум,
+  sweep-бюджеты.
+- `FUZZ-CORPUS-001` (high, spawn) — контракт fuzz-корпуса (path/env/argv/cwd/
+  symlink мутации) и oracle-правила без production-fuzz кода.
+- `TIER-DIFF-001` (high, spawn) — differential full vs fs-only vs seccomp:
+  расхождение только в задокументированную слабую сторону, без silent
+  downgrade.
+
+Windows suite (host-fact-only):
+
+- `WIN-ESC-001` (blocker, proc) — PowerShell/cmd/API, token, integrity, Job,
+  ACL; evidence строго host-fact-only (pipe-drain stub даёт not-EOF →
+  INCONCLUSIVE, никогда PASS).
+- `WIN-NET-001` (blocker, net) — `--net=off` через AppContainer capabilities
+  (PARTIAL); per-domain без admin UNPROVABLE и обязан fail-closed.
+- `WIN-UNC-001` (high, fs-read) — PARTIAL/advisory до маппинга алиасов.
+- `WIN-WSL-001` (high, fs-read) — UNSUPPORTED baseline; любой PASS — баг.
+
+macOS suite (потолок MAC-SHAPE):
+
+- `MAC-ESC-001` (high, fs-read) — Shape-A + tail-deny побайтово; read вне
+  tail-deny успешен по построению (подтверждение потолка PARTIAL, не FAIL).
+- `MAC-PROC-001` (high, proc) — kqueue watchdog + group-kill + sweep 2с
+  (BestEffort); destructive только в VM.
+- `MAC-SHAPE-001` — побайтовый gate профиля.
+
+Уровни запуска: smoke (малые квоты/seed-наборы, локально) → core → platform
+→ destructive/adversarial (только disposable VM/CI-runner) → stress/race
+(медиана) → regression (ловушки) → release-gate. Без elevated privileges
+локально запускается только smoke/core на Strong тирах; всё destructive,
+RES-EXHAUST полный, fuzz-корпус полный — CI-runner/VM.
+
+## Race/stress стратегия
+
+`RACE-TOCTOU-001` + `STRESS-SWEEP-001`: медиана ≥3 (на практике runs=5),
+кворум векторов на прогон, sweep-бюджет 2с на BestEffort тирах, ретраи не
+превращают FAIL в PASS, расхождение прогонов — INCONCLUSIVE (блокирует gate
+в I1–I6 через ноль-INCONCLUSIVE правило). Параллельные spawn только через
+`SPAWN_SERIAL` (detect→fork-возврат); параллелится подготовка и judging.
+
+## Fuzzing стратегия
+
+`FUZZ-CORPUS-001` фиксирует контракт: детерминированные seeds в CI, корпус
+мутаций path/env/argv0/cwd/locale/symlink-forest, oracle-правило
+fail-closed (любое нарушение host-fact границы — FAIL/INCONCLUSIVE).
+Находки обязаны становиться новыми векторами/quorum в реестре; сам fuzzer
+— вне verify-ng (не production-код enforcement).
+
+## Differential testing стратегия
+
+`TIER-DIFF-001` + `SEC-BLOCKS-001[not_applicable]` + `WIN-*/MAC-*` N/A-секции:
+full vs fs-only vs seccomp обязаны совпадать либо слабеть строго
+задокументированно; `VETTO_FORCE_TIER` разрешён только в tier-differential
+CI job. Кросс-OS differential — через N/A с probe-доказательством, без
+молчаливых скипов (иначе `N/A-without-evidence` блокирует gate).
+
 ## Кворум и повторы (FM-13)
 
 Multivector-сценарии требуют ≥quorum независимых согласующихся векторов,

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ GITHUB_REPO="shleder/vetto"
 # Last version verified published on ALL channels (GitHub tag + npm + crates.io).
 # Bump only after the release-train publish + registry verification for the new
 # version succeed (see pages/ops/release-process.md). Verified 2026-09-06.
-DEFAULT_FALLBACK_VERSION="0.2.18"
+DEFAULT_FALLBACK_VERSION="0.2.19"
 
 # Initialize colors if stdout is connected to a terminal
 if [ -t 1 ]; then

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shledery/vetto",
-  "version": "0.2.18",
+  "version": "0.2.19",
 
   "description": "Cross-platform vetto sandbox and security layer for AI coding agents",
   "license": "Apache-2.0",

--- a/packaging/aur/vetto/PKGBUILD
+++ b/packaging/aur/vetto/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: vetto contributors
 pkgname=vetto
-pkgver=0.2.18
+pkgver=0.2.19
 pkgrel=1
 pkgdesc='Daemon-less sandbox and audit layer for AI coding agents'
 arch=('x86_64' 'aarch64')

--- a/packaging/chocolatey/vetto.nuspec
+++ b/packaging/chocolatey/vetto.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vetto</id>
-    <version>0.2.18</version>
+    <version>0.2.19</version>
     <title>vetto</title>
     <authors>vetto contributors</authors>
     <projectUrl>https://github.com/shleder/vetto</projectUrl>

--- a/packaging/homebrew/vetto.rb
+++ b/packaging/homebrew/vetto.rb
@@ -1,12 +1,12 @@
 class Vetto < Formula
   desc "Daemon-less OS sandbox and subagent security layer for AI coding agents"
   homepage "https://github.com/shleder/vetto"
-  version "0.2.18"
+  version "0.2.19"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.18/vetto-macos-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.19/vetto-macos-aarch64.tar.gz"
       sha256 "5e0abff03602319d64d1f43642bda41ce44722c71c24553adc0507dfea368eb1"
     else
       url "https://github.com/shleder/vetto/releases/download/v0.2.17/vetto-macos-x86_64.tar.gz"

--- a/packaging/rpm/vetto.spec
+++ b/packaging/rpm/vetto.spec
@@ -1,5 +1,5 @@
 Name:           vetto
-Version: 0.2.18
+Version: 0.2.19
 Release:        1%{?dist}
 Summary:        Daemon-less sandbox and audit layer for AI coding agents
 License:        Apache-2.0

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -315,6 +315,18 @@ pub enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Adversarial verification harness: runs the frozen scenario registry
+    /// through host-fact-only oracle judging (measurement only, not part of
+    /// the security boundary).
+    #[command(name = "verify-ng")]
+    VerifyNg {
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+        /// Lint the frozen scenario registry without executing anything.
+        #[arg(long)]
+        lint: bool,
+    },
     /// Run an agent command under the Vetto sandbox supervisor
     #[command(hide = true)]
     Run {

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,8 @@ pub enum VettoError {
     PolicyLockdownViolation(String),
     #[error("{0} is not supported by this vetto 0.x build (see SECURITY.md roadmap)")]
     UnsupportedPlatform(&'static str),
+    #[error("verify-ng harness unavailable: {0}")]
+    HarnessUnavailable(String),
 }
 
 pub type VettoResult<T> = Result<T, VettoError>;
@@ -42,7 +44,8 @@ impl VettoError {
             | VettoError::Mount(_)
             | VettoError::Seccomp(_)
             | VettoError::Sandbox(_)
-            | VettoError::UnsupportedPlatform(_) => EXIT_FAIL_CLOSED,
+            | VettoError::UnsupportedPlatform(_)
+            | VettoError::HarnessUnavailable(_) => EXIT_FAIL_CLOSED,
             VettoError::Pty(_) => EXIT_AGENT_ERROR,
             VettoError::Policy(_) => EXIT_AGENT_ERROR,
             VettoError::PolicyLockdownViolation(_) => EXIT_POLICY_BLOCKED,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod tour;
 #[cfg(unix)]
 pub mod tui;
 pub mod verify;
+pub mod verify_ng;
 pub mod version;
 pub mod watch;
 pub mod watchdog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,6 +339,7 @@ fn run() -> Result<()> {
                 &net,
             )
         }
+        Some(cli::Command::VerifyNg { json, lint }) => vetto::verify_ng::run_verify_ng(*json, *lint),
         Some(cli::Command::Redteam { json }) => {
             let report = vetto::redteam::run_redteam_battery();
             if *json {
@@ -642,7 +643,9 @@ fn supervise(cfg: RunConfig) -> Result<()> {
         }
         Err(e) => {
             if cfg.dry_run && cfg.backend.as_deref().unwrap_or("auto") == "auto" {
-                (None, Some(policy::Tier::Full))
+                // F6: dry-run never fabricates a tier — None renders as
+                // "unknown (dry-run, NOT ENFORCED)", never "full".
+                (None, None)
             } else {
                 return Err(e);
             }
@@ -765,7 +768,13 @@ fn supervise(cfg: RunConfig) -> Result<()> {
     }
 
     if cfg.dry_run {
-        return dry_run(&cfg, &pol, &agent_cmd, tier_label(tier));
+        // F6: backend detection failed + dry-run => None tier renders as
+        // "unknown (dry-run)", never a fabricated "full".
+        let label = match tier {
+            Some(_) => tier_label(tier),
+            None => "unknown (dry-run)",
+        };
+        return dry_run(&cfg, &pol, &agent_cmd, label);
     }
 
     let backend = match backend_opt {
@@ -1547,7 +1556,7 @@ fn format_duration(limit: std::time::Duration) -> String {
 }
 
 fn dry_run(cfg: &RunConfig, pol: &policy::Policy, agent_cmd: &[String], tier: &str) -> Result<()> {
-    println!("vetto dry-run — nothing enforced, nothing executed");
+    println!("vetto dry-run — NOT ENFORCED, nothing executed");
     println!("  tier:  {tier}");
     println!("  net:   {}", cfg.net.label());
     println!("  git ssh: {}", if cfg.git_ssh { "enabled" } else { "off" });
@@ -1586,7 +1595,7 @@ fn dry_run(cfg: &RunConfig, pol: &policy::Policy, agent_cmd: &[String], tier: &s
             println!("  explicit CLI policy: {count} deny {noun} included above");
         }
     }
-    println!("  agent: {}", agent_cmd.join(" "));
+    println!("  agent: {}", vetto::logger::sanitizer::sanitize_line(&agent_cmd.join(" ")));
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,7 +339,9 @@ fn run() -> Result<()> {
                 &net,
             )
         }
-        Some(cli::Command::VerifyNg { json, lint }) => vetto::verify_ng::run_verify_ng(*json, *lint),
+        Some(cli::Command::VerifyNg { json, lint }) => {
+            vetto::verify_ng::run_verify_ng(*json, *lint)
+        }
         Some(cli::Command::Redteam { json }) => {
             let report = vetto::redteam::run_redteam_battery();
             if *json {
@@ -1595,7 +1597,10 @@ fn dry_run(cfg: &RunConfig, pol: &policy::Policy, agent_cmd: &[String], tier: &s
             println!("  explicit CLI policy: {count} deny {noun} included above");
         }
     }
-    println!("  agent: {}", vetto::logger::sanitizer::sanitize_line(&agent_cmd.join(" ")));
+    println!(
+        "  agent: {}",
+        vetto::logger::sanitizer::sanitize_line(&agent_cmd.join(" "))
+    );
     Ok(())
 }
 

--- a/src/policy/defaults.rs
+++ b/src/policy/defaults.rs
@@ -58,6 +58,14 @@ pub const AGENT_PROFILE_NAMES: [&str; 21] = [
 /// The list is deliberately small: the parent environment is never inherited
 /// wholesale. A trailing `*` is treated as a prefix pattern by
 /// `EnvironmentPolicy::allows` (used for locale variables only).
+///
+/// D1: the TOML profiles are the single source of truth for the default
+/// baseline (`profiles/default.toml [environment]`). This constant exists
+/// only as a fallback when a builtin profile text has no `[environment]`
+/// section at all — it must stay in sync with that TOML list. Proxy
+/// variables are intentionally ABSENT here: in relay mode the relay injects
+/// them via `env_extra`; host passthrough would duplicate and leak the
+/// host's proxy choice (P07 env proposal).
 pub const DEFAULT_ENV_PASSTHROUGH: &[&str] = &[
     "HOME",
     "PATH",
@@ -77,10 +85,6 @@ pub const DEFAULT_ENV_PASSTHROUGH: &[&str] = &[
     "RUSTUP_HOME",
     "NVM_DIR",
     "NODE_PATH",
-    "HTTP_PROXY",
-    "HTTPS_PROXY",
-    "ALL_PROXY",
-    "NO_PROXY",
     "TMPDIR",
     "PWD",
     "OLDPWD",

--- a/src/policy/types.rs
+++ b/src/policy/types.rs
@@ -216,9 +216,10 @@ impl EnvironmentPolicy {
             let pattern_cmp: String = pattern.to_uppercase();
             #[cfg(not(target_os = "windows"))]
             let pattern_cmp: &str = pattern;
-            pattern_cmp
-                .strip_suffix('*')
-                .map_or_else(|| pattern_cmp == key_cmp, |prefix| key_cmp.starts_with(prefix))
+            pattern_cmp.strip_suffix('*').map_or_else(
+                || pattern_cmp == key_cmp,
+                |prefix| key_cmp.starts_with(prefix),
+            )
         });
         if is_denied {
             return false;

--- a/src/policy/types.rs
+++ b/src/policy/types.rs
@@ -204,11 +204,21 @@ pub struct EnvironmentPolicy {
 impl EnvironmentPolicy {
     pub fn allows(&self, key: &OsStr) -> bool {
         let key = key.to_string_lossy();
-        // Deny takes precedence
+        // Deny takes precedence. On Windows env names are case-insensitive
+        // (W1): match upper-cased so `aws_secret_access_key` cannot bypass
+        // `deny = ["AWS_SECRET*"]`.
+        #[cfg(target_os = "windows")]
+        let key_cmp: String = key.to_uppercase();
+        #[cfg(not(target_os = "windows"))]
+        let key_cmp: &str = &key;
         let is_denied = self.deny.iter().any(|pattern| {
-            pattern
+            #[cfg(target_os = "windows")]
+            let pattern_cmp: String = pattern.to_uppercase();
+            #[cfg(not(target_os = "windows"))]
+            let pattern_cmp: &str = pattern;
+            pattern_cmp
                 .strip_suffix('*')
-                .map_or_else(|| pattern == key.as_ref(), |prefix| key.starts_with(prefix))
+                .map_or_else(|| pattern_cmp == key_cmp, |prefix| key_cmp.starts_with(prefix))
         });
         if is_denied {
             return false;

--- a/src/sandbox/linux/mod.rs
+++ b/src/sandbox/linux/mod.rs
@@ -103,13 +103,22 @@ fn kernel_release() -> String {
 
 /// Fail-closed tier selection. `Err` means: the agent does NOT run.
 ///
-/// `VETTO_FORCE_TIER=full|fs-only|seccomp` (testing override) can only select a tier
-/// whose primitives are actually available — it can never bypass fail-closed.
+/// `VETTO_FORCE_TIER=full|fs-only|seccomp` is a testing override honored in
+/// debug/test builds (CI runs `cargo test` unoptimized: `debug_assertions`
+/// on) and ignored in release builds. It can only select a tier whose
+/// primitives are actually available — it can never bypass fail-closed.
+/// Production downgrade requires an explicit CLI opt-in (P03), not env.
 pub fn pick_tier(probe: &Probe) -> Result<Tier> {
-    match std::env::var("VETTO_FORCE_TIER").as_deref() {
-        Ok("seccomp") if probe.seccomp_filter_available => return Ok(Tier::Seccomp),
-        Ok("fs-only") if probe.seccomp_filter_available => return Ok(Tier::FsOnly),
-        Ok("full") if probe.full_tier_available => return Ok(Tier::Full),
+    // Release binaries ignore the override: silent downgrade via inherited
+    // env (CI wrappers, outer vetto) must not weaken enforcement.
+    #[cfg(not(debug_assertions))]
+    let force_tier: Option<String> = None;
+    #[cfg(debug_assertions)]
+    let force_tier: Option<String> = std::env::var("VETTO_FORCE_TIER").ok();
+    match force_tier.as_deref() {
+        Some("seccomp") if probe.seccomp_filter_available => return Ok(Tier::Seccomp),
+        Some("fs-only") if probe.seccomp_filter_available => return Ok(Tier::FsOnly),
+        Some("full") if probe.full_tier_available => return Ok(Tier::Full),
         _ => {}
     }
     if probe.landlock_abi.is_none() {
@@ -702,6 +711,13 @@ fn child_exec(policy: &Policy, opts: &SpawnOptions) -> ! {
     }
 
     // SAFETY: execve with NUL-terminated argv/envp vectors built above.
+    // C1: secrets live in env (agent presets!) — disable core dumps before
+    // exec so env never lands in a core file (RLIMIT_CORE=0).
+    {
+        let zero = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        // SAFETY: zeroing core limit on our own process before exec.
+        unsafe { libc::setrlimit(libc::RLIMIT_CORE, &zero) };
+    }
     if let Err(error) = limits::apply_before_exec(&policy.limits) {
         let message = format!("[vetto-child] resource limits failed: {error}\n");
         // SAFETY: raw write to stderr for diagnostics before dying.

--- a/src/sandbox/linux/mod.rs
+++ b/src/sandbox/linux/mod.rs
@@ -714,7 +714,10 @@ fn child_exec(policy: &Policy, opts: &SpawnOptions) -> ! {
     // C1: secrets live in env (agent presets!) — disable core dumps before
     // exec so env never lands in a core file (RLIMIT_CORE=0).
     {
-        let zero = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+        let zero = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
         // SAFETY: zeroing core limit on our own process before exec.
         unsafe { libc::setrlimit(libc::RLIMIT_CORE, &zero) };
     }

--- a/src/sandbox/linux/net_relay.rs
+++ b/src/sandbox/linux/net_relay.rs
@@ -409,7 +409,9 @@ pub fn domain_allowed(host: &str, allowlist: &[String]) -> bool {
 }
 
 /// Strict mode checks both the normalized host and the requested port before
-/// DNS resolution.
+/// DNS resolution. A bare `*` pattern never matches: use an explicit
+/// `*.domain` suffix or an exact host (P06 network proposal: `strict:*`
+/// is rejected, not silently allowed).
 pub fn strict_allowed(host: &str, port: u16, rules: &[NetRule]) -> bool {
     let host = host.trim().trim_end_matches('.').to_ascii_lowercase();
     rules.iter().any(|rule| {
@@ -421,8 +423,8 @@ pub fn strict_allowed(host: &str, port: u16, rules: &[NetRule]) -> bool {
             .trim()
             .trim_end_matches('.')
             .to_ascii_lowercase();
-        if pat == "*" {
-            return true;
+        if pat == "*" || pat.is_empty() {
+            return false;
         }
         if let Some(suffix) = pat.strip_prefix("*.") {
             host.ends_with(&format!(".{suffix}"))

--- a/src/sandbox/macos/mod.rs
+++ b/src/sandbox/macos/mod.rs
@@ -364,8 +364,7 @@ fn child(
             child_fail(err_w, 125, &format!("VETTO_SEATBELT_MODE={mode} is debug-only; refusing to weaken enforcement in release"));
         }
     };
-    match seatbelt_mode.as_deref()
-    {
+    match seatbelt_mode.as_deref() {
         Some("none") => {
             child_trace("seatbelt-skipped-by-env");
         }

--- a/src/sandbox/macos/mod.rs
+++ b/src/sandbox/macos/mod.rs
@@ -346,16 +346,25 @@ fn child(
     child_trace("cwd-set");
 
     // Apply native Seatbelt sandbox via dynamic C API in memory.
-    // VETTO_SEATBELT_MODE is a diagnostic bisect switch (SIGABRT hunt):
-    //   none           — do not sandbox at all (CI-only; never a fallback)
-    //   allow-all      — "(allow default)" profile
-    //   deny-net-only  — everything allowed except the network
-    //   wb-tcpudp      — deny TCP/UDP outbound only (no blanket network*)
-    //   wb-mach        — blanket deny network* + mach-lookup/system-socket
-    //   wb-socket      — blanket deny network* + system-socket allowed
-    match std::env::var_os("VETTO_SEATBELT_MODE")
+    // VETTO_SEATBELT_MODE is a DEBUG-ONLY diagnostic bisect switch (SIGABRT
+    // hunt). In release builds any value fails closed: the kill-switch must
+    // never silently strip enforcement in production (P03 fail-closed).
+    #[cfg(debug_assertions)]
+    let seatbelt_mode = std::env::var_os("VETTO_SEATBELT_MODE")
         .as_deref()
         .and_then(|m| m.to_str())
+        .map(|s| s.to_string());
+    #[cfg(not(debug_assertions))]
+    let seatbelt_mode: Option<String> = match std::env::var_os("VETTO_SEATBELT_MODE")
+        .as_deref()
+        .and_then(|m| m.to_str())
+    {
+        None => None,
+        Some(mode) => {
+            child_fail(err_w, 125, &format!("VETTO_SEATBELT_MODE={mode} is debug-only; refusing to weaken enforcement in release"));
+        }
+    };
+    match seatbelt_mode.as_deref()
     {
         Some("none") => {
             child_trace("seatbelt-skipped-by-env");
@@ -439,12 +448,14 @@ fn build_envp(policy: &Policy, opts: &SpawnOptions) -> Vec<CString> {
     // env_extra bypasses the allowlist by design (internal VETTO_* only):
     // re-strip fail-closed so a colliding extra can never reintroduce one.
     crate::cred_broker::filter_proxy_secrets(&mut env, &policy.secret_proxies);
+    // M1: entries with interior NUL are dropped like the Linux backend
+    // does — never silently replaced with an empty string.
     env.iter()
-        .map(|(k, v)| {
+        .filter_map(|(k, v)| {
             let mut entry = k.as_encoded_bytes().to_vec();
             entry.push(b'=');
             entry.extend_from_slice(v.as_encoded_bytes());
-            CString::new(entry).unwrap_or_default()
+            CString::new(entry).ok()
         })
         .collect()
 }

--- a/src/sandbox/macos/seatbelt.rs
+++ b/src/sandbox/macos/seatbelt.rs
@@ -204,6 +204,7 @@ pub fn apply_seatbelt_raw(profile: &str, params: &[(String, String)]) -> Result<
 /// (`deny_resolved`) is the maximum enforceable read boundary today.
 pub const SBPL_MAXIMUM_READ_SHAPE: &str = "shape-A-broad-plus-tail-deny";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SbplFragmentStatus {
     Broken,
     Ok,

--- a/src/sandbox/macos/seatbelt.rs
+++ b/src/sandbox/macos/seatbelt.rs
@@ -192,7 +192,6 @@ pub fn apply_seatbelt_raw(profile: &str, params: &[(String, String)]) -> Result<
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Stable read-deny shapes per agent runtime (issue #62).
 ///
 /// Empirical result of the SBPL matrix (`.github/workflows/macos-sbpl-matrix.yml`,

--- a/src/sandbox/macos/seatbelt.rs
+++ b/src/sandbox/macos/seatbelt.rs
@@ -193,6 +193,18 @@ pub fn apply_seatbelt_raw(profile: &str, params: &[(String, String)]) -> Result<
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Stable read-deny shapes per agent runtime (issue #62).
+///
+/// Empirical result of the SBPL matrix (`.github/workflows/macos-sbpl-matrix.yml`,
+/// `scripts/sbpl-matrix-test.sh`, macos 14/15/15-intel): ONLY Shape A (single
+/// broad `(allow file-read* (subpath "/"))` + trailing secret denies) runs —
+/// every fragmented shape (B/C/D/E/F) SIGABRTs ALL binaries including static
+/// Go. There is no per-runtime narrow shape on current macOS: dynamic
+/// (Swift/Rust) and static (Go) behave identically. Narrow read-deny stays
+/// closed until Apple fixes dyld; the tail-deny carve-out on known secrets
+/// (`deny_resolved`) is the maximum enforceable read boundary today.
+pub const SBPL_MAXIMUM_READ_SHAPE: &str = "shape-A-broad-plus-tail-deny";
+
 pub enum SbplFragmentStatus {
     Broken,
     Ok,

--- a/src/sandbox/windows/mod.rs
+++ b/src/sandbox/windows/mod.rs
@@ -1135,8 +1135,11 @@ fn environment_block(policy: &Policy, opts: &SpawnOptions) -> Result<Vec<u16>> {
     // in depth alongside the main.rs bail). Compare case-insensitively:
     // Windows env names collide regardless of spelling.
     if !policy.secret_proxies.is_empty() {
-        let proxies_upper: Vec<String> =
-            policy.secret_proxies.iter().map(|p| p.to_uppercase()).collect();
+        let proxies_upper: Vec<String> = policy
+            .secret_proxies
+            .iter()
+            .map(|p| p.to_uppercase())
+            .collect();
         env.retain(|norm, _| !proxies_upper.iter().any(|p| p == norm.to_uppercase()));
     }
     // Windows requires the supplied block to be sorted by variable name using

--- a/src/sandbox/windows/mod.rs
+++ b/src/sandbox/windows/mod.rs
@@ -1140,7 +1140,7 @@ fn environment_block(policy: &Policy, opts: &SpawnOptions) -> Result<Vec<u16>> {
             .iter()
             .map(|p| p.to_uppercase())
             .collect();
-        env.retain(|norm, _| !proxies_upper.iter().any(|p| p == norm.to_uppercase()));
+        env.retain(|norm, _| !proxies_upper.iter().any(|p| p == &norm.to_uppercase()));
     }
     // Windows requires the supplied block to be sorted by variable name using
     // case-insensitive Unicode order. BTreeMap's bytewise ordering is not that

--- a/src/sandbox/windows/mod.rs
+++ b/src/sandbox/windows/mod.rs
@@ -1131,6 +1131,14 @@ fn environment_block(policy: &Policy, opts: &SpawnOptions) -> Result<Vec<u16>> {
     for (key, value) in &opts.env_extra {
         env.insert(key.to_lowercase(), (key.clone(), value.clone()));
     }
+    // W2: strip broker-injected proxy secrets like Linux/macOS do (defense
+    // in depth alongside the main.rs bail). Compare case-insensitively:
+    // Windows env names collide regardless of spelling.
+    if !policy.secret_proxies.is_empty() {
+        let proxies_upper: Vec<String> =
+            policy.secret_proxies.iter().map(|p| p.to_uppercase()).collect();
+        env.retain(|norm, _| !proxies_upper.iter().any(|p| p == norm.to_uppercase()));
+    }
     // Windows requires the supplied block to be sorted by variable name using
     // case-insensitive Unicode order. BTreeMap's bytewise ordering is not that
     // contract, so sort the final entries explicitly and use the original name

--- a/src/verify_ng/caps.rs
+++ b/src/verify_ng/caps.rs
@@ -1,0 +1,168 @@
+//! Platform capability evidence: every NOT_APPLICABLE needs proof.
+//!
+//! A scenario may only be skipped as NOT_APPLICABLE when the harness holds
+//! positive probe evidence that the required capability is absent (FM-12).
+//! Missing evidence degrades to INCONCLUSIVE, never to PASS and never to a
+//! silent skip.
+
+use serde::{Deserialize, Serialize};
+
+/// One probed capability with its evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Capability {
+    pub name: String,
+    pub present: bool,
+    /// How presence/absence was determined (probe name + raw outcome).
+    pub evidence: String,
+}
+
+impl Capability {
+    pub fn present(name: impl Into<String>, evidence: impl Into<String>) -> Self {
+        Self { name: name.into(), present: true, evidence: evidence.into() }
+    }
+
+    pub fn absent(name: impl Into<String>, evidence: impl Into<String>) -> Self {
+        Self { name: name.into(), present: false, evidence: evidence.into() }
+    }
+}
+
+/// Capability snapshot for one gate run.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CapabilitySet {
+    pub capabilities: Vec<Capability>,
+}
+
+impl CapabilitySet {
+    /// Check `required` against the snapshot. Returns the subset of missing
+    /// capabilities with their absence evidence. An empty required list is
+    /// always satisfied.
+    pub fn missing<'a>(&self, required: &'a [String]) -> Vec<&'a String> {
+        required
+            .iter()
+            .filter(|name| {
+                self.capabilities
+                    .iter()
+                    .find(|c| &c.name == *name)
+                    .map(|c| c.present)
+                    .unwrap_or(false)
+                    == false
+            })
+            .collect()
+    }
+
+    /// Absence evidence for the missing capabilities (FM-12: no silent N/A).
+    pub fn absence_evidence(&self, missing: &[&String]) -> Vec<String> {
+        missing
+            .iter()
+            .map(|name| {
+                self.capabilities
+                    .iter()
+                    .find(|c| &c.name == name.as_str())
+                    .map(|c| {
+                        if c.present {
+                            format!("{}: unexpectedly present", c.name)
+                        } else {
+                            format!("{}: absent ({})", c.name, c.evidence)
+                        }
+                    })
+                    .unwrap_or_else(|| format!("{name}: never probed (no evidence)"))
+            })
+            .collect()
+    }
+
+    /// Collect host capabilities. Pure-Rust probe surface: kernel release,
+    /// tier probe on Linux, seatbelt presence on macOS, process-model
+    /// presence on Windows. Never shells out; never elevates.
+    pub fn probe_host() -> Self {
+        let mut capabilities = Vec::new();
+        capabilities.push(Capability::present(
+            "spawn",
+            "harness process can fork/exec (self-evident by running)",
+        ));
+        #[cfg(target_os = "linux")]
+        {
+            let probe = crate::sandbox::linux::probe();
+            capabilities.push(if probe.landlock_abi.is_some() {
+                Capability::present(
+                    "landlock",
+                    format!("landlock ABI {:?}", probe.landlock_abi),
+                )
+            } else {
+                Capability::absent("landlock", "no Landlock ABI reported")
+            });
+            capabilities.push(if probe.full_tier_available {
+                Capability::present("netns", "full-tier probe: userns+net+pid available")
+            } else {
+                Capability::absent("netns", "full-tier probe failed")
+            });
+            capabilities.push(if probe.full_tier_available {
+                Capability::present("tree-sweep", "pidns teardown available")
+            } else if probe.seccomp_filter_available {
+                Capability::absent(
+                    "tree-sweep",
+                    "pidns unavailable; bounded reparent-sweep only (partial)",
+                )
+            } else {
+                Capability::absent("tree-sweep", "no containment teardown available")
+            });
+        }
+        #[cfg(target_os = "macos")]
+        {
+            if crate::sandbox::macos::MacosSandbox::seatbelt_available() {
+                capabilities.push(Capability::present(
+                    "seatbelt",
+                    "sandbox_init_with_parameters or sandbox-exec present",
+                ));
+            } else {
+                capabilities.push(Capability::absent(
+                    "seatbelt",
+                    "no Seatbelt API and no sandbox-exec",
+                ));
+            }
+            capabilities.push(Capability::absent(
+                "netns",
+                "Darwin has no unprivileged network namespaces",
+            ));
+            capabilities.push(Capability::absent(
+                "tree-sweep",
+                "no pid namespace; kqueue watchdog is best-effort only",
+            ));
+        }
+        #[cfg(target_os = "windows")]
+        {
+            capabilities.push(Capability::absent(
+                "netns",
+                "Windows has no network namespaces for unprivileged processes",
+            ));
+            capabilities.push(Capability::present(
+                "tree-sweep",
+                "Job Object kill-on-close terminates the tree",
+            ));
+        }
+        Self { capabilities }
+    }
+}
+
+#[cfg(test)]
+mod caps_tests {
+    use super::*;
+
+    #[test]
+    fn missing_lists_absent_and_unprobed() {
+        let set = CapabilitySet {
+            capabilities: vec![Capability::absent("netns", "probe said no")],
+        };
+        let required = vec!["netns".to_string(), "landlock".to_string(), "spawn".to_string()];
+        let missing = set.missing(&required);
+        assert_eq!(missing.len(), 3);
+        let ev = set.absence_evidence(&missing);
+        assert!(ev.iter().any(|e| e.contains("probe said no")));
+        assert!(ev.iter().any(|e| e.contains("never probed")));
+    }
+
+    #[test]
+    fn empty_required_is_satisfied() {
+        let set = CapabilitySet::default();
+        assert!(set.missing(&[]).is_empty());
+    }
+}

--- a/src/verify_ng/caps.rs
+++ b/src/verify_ng/caps.rs
@@ -18,11 +18,19 @@ pub struct Capability {
 
 impl Capability {
     pub fn present(name: impl Into<String>, evidence: impl Into<String>) -> Self {
-        Self { name: name.into(), present: true, evidence: evidence.into() }
+        Self {
+            name: name.into(),
+            present: true,
+            evidence: evidence.into(),
+        }
     }
 
     pub fn absent(name: impl Into<String>, evidence: impl Into<String>) -> Self {
-        Self { name: name.into(), present: false, evidence: evidence.into() }
+        Self {
+            name: name.into(),
+            present: false,
+            evidence: evidence.into(),
+        }
     }
 }
 
@@ -83,10 +91,7 @@ impl CapabilitySet {
         {
             let probe = crate::sandbox::linux::probe();
             capabilities.push(if probe.landlock_abi.is_some() {
-                Capability::present(
-                    "landlock",
-                    format!("landlock ABI {:?}", probe.landlock_abi),
-                )
+                Capability::present("landlock", format!("landlock ABI {:?}", probe.landlock_abi))
             } else {
                 Capability::absent("landlock", "no Landlock ABI reported")
             });
@@ -152,7 +157,11 @@ mod caps_tests {
         let set = CapabilitySet {
             capabilities: vec![Capability::absent("netns", "probe said no")],
         };
-        let required = vec!["netns".to_string(), "landlock".to_string(), "spawn".to_string()];
+        let required = vec![
+            "netns".to_string(),
+            "landlock".to_string(),
+            "spawn".to_string(),
+        ];
         let missing = set.missing(&required);
         assert_eq!(missing.len(), 3);
         let ev = set.absence_evidence(&missing);

--- a/src/verify_ng/caps.rs
+++ b/src/verify_ng/caps.rs
@@ -48,12 +48,12 @@ impl CapabilitySet {
         required
             .iter()
             .filter(|name| {
-                self.capabilities
+                !self
+                    .capabilities
                     .iter()
                     .find(|c| &c.name == *name)
                     .map(|c| c.present)
                     .unwrap_or(false)
-                    == false
             })
             .collect()
     }
@@ -65,7 +65,7 @@ impl CapabilitySet {
             .map(|name| {
                 self.capabilities
                     .iter()
-                    .find(|c| &c.name == name.as_str())
+                    .find(|c| c.name == name.as_str())
                     .map(|c| {
                         if c.present {
                             format!("{}: unexpectedly present", c.name)

--- a/src/verify_ng/collector.rs
+++ b/src/verify_ng/collector.rs
@@ -7,7 +7,9 @@
 //!   host-side post-mortem inputs); the oracle decides. The collector never
 //!   judges (FM-14).
 
-use std::time::{Duration, Instant};
+#[cfg(unix)]
+use std::time::Duration;
+use std::time::Instant;
 
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, OwnedFd};

--- a/src/verify_ng/collector.rs
+++ b/src/verify_ng/collector.rs
@@ -40,7 +40,10 @@ pub fn drain_with_deadline(fd: &OwnedFd, deadline: Instant) -> (Vec<u8>, bool) {
             }
         }
     }
-    let _restore = Restore { fd: raw, flags: orig };
+    let _restore = Restore {
+        fd: raw,
+        flags: orig,
+    };
 
     let mut out = Vec::new();
     let mut buf = [0u8; 8192];
@@ -119,10 +122,7 @@ mod collector_tests {
 
     #[test]
     fn postmortem_present_for_content() {
-        let p = std::env::temp_dir().join(format!(
-            "vetto-vng-pm-{}",
-            std::process::id()
-        ));
+        let p = std::env::temp_dir().join(format!("vetto-vng-pm-{}", std::process::id()));
         std::fs::write(&p, b"leak").expect("write");
         assert_eq!(PostMortem::stat(&p, false), PostMortem::Present);
         let _ = std::fs::remove_file(&p);

--- a/src/verify_ng/collector.rs
+++ b/src/verify_ng/collector.rs
@@ -1,0 +1,130 @@
+//! Collector stage: deadline-aware drain + post-mortem (FM-04).
+//!
+//! Two rules that fix the inherited `run_probe_script` hang:
+//! - Pipes are drained with a deadline (poll on the read end); a grandchild
+//!   holding the write end open cannot hang the harness forever.
+//! - The collector gathers the fixed superset of facts (stdout hint,
+//!   host-side post-mortem inputs); the oracle decides. The collector never
+//!   judges (FM-14).
+
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, OwnedFd};
+
+/// Drain `fd` until EOF or `deadline`. Returns bytes read and whether EOF
+/// was reached (`false` = deadline hit with the pipe still open, e.g. a
+/// grandchild holds the write end: FM-04 HANG-GRANDCHILD-001).
+///
+/// Unix-only: pipe draining needs raw fds. On Windows the evidence path is
+/// host-fact-only (see docs/verify-ng.md); the stub below returns
+/// not-EOF so the oracle degrades to INCONCLUSIVE, never PASS.
+#[cfg(unix)]
+pub fn drain_with_deadline(fd: &OwnedFd, deadline: Instant) -> (Vec<u8>, bool) {
+    let raw = fd.as_raw_fd();
+    // SAFETY: F_GETFL on our own pipe fd.
+    let orig = unsafe { libc::fcntl(raw, libc::F_GETFL) };
+    // SAFETY: restoring O_NONBLOCK on our own pipe fd.
+    unsafe {
+        libc::fcntl(raw, libc::F_SETFL, orig | libc::O_NONBLOCK);
+    }
+    struct Restore {
+        fd: i32,
+        flags: i32,
+    }
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            // SAFETY: restoring saved flags on our own pipe fd.
+            unsafe {
+                libc::fcntl(self.fd, libc::F_SETFL, self.flags);
+            }
+        }
+    }
+    let _restore = Restore { fd: raw, flags: orig };
+
+    let mut out = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        // SAFETY: read into a stack buffer of known length.
+        let n = unsafe { libc::read(raw, buf.as_mut_ptr().cast(), buf.len()) };
+        if n > 0 {
+            out.extend_from_slice(&buf[..n as usize]);
+            continue;
+        }
+        if n == 0 {
+            return (out, true);
+        }
+        let err = std::io::Error::last_os_error();
+        if let Some(code) = err.raw_os_error() {
+            if code == libc::EAGAIN || code == libc::EWOULDBLOCK {
+                if Instant::now() >= deadline {
+                    return (out, false);
+                }
+                std::thread::sleep(Duration::from_millis(10));
+                continue;
+            }
+            if code == libc::EINTR {
+                continue;
+            }
+        }
+        return (out, false);
+    }
+}
+
+/// Windows stub: no raw-fd pipe drain on this platform. Returns not-EOF so
+/// callers degrade to INCONCLUSIVE/FAIL, never PASS.
+#[cfg(not(unix))]
+pub fn drain_with_deadline(
+    _fd: &std::os::windows::io::OwnedHandle,
+    _deadline: Instant,
+) -> (Vec<u8>, bool) {
+    (Vec::new(), false)
+}
+
+/// Post-mortem filesystem probe result observed by the host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostMortem {
+    /// Target absent (or empty where emptiness is the enforced shape).
+    Absent,
+    /// Target exists with unexpected content (violation evidence).
+    Present,
+}
+
+impl PostMortem {
+    /// Stat `path` from the host after wait. `expect_empty_file` covers the
+    /// overlay shape (masked files appear empty).
+    pub fn stat(path: &std::path::Path, expect_empty_file: bool) -> Self {
+        match std::fs::metadata(path) {
+            Err(_) => PostMortem::Absent,
+            Ok(meta) => {
+                if expect_empty_file || meta.len() == 0 {
+                    PostMortem::Absent
+                } else {
+                    PostMortem::Present
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod collector_tests {
+    use super::*;
+
+    #[test]
+    fn postmortem_absent_for_missing() {
+        let p = std::env::temp_dir().join("vetto-vng-no-such-file-xyz");
+        assert_eq!(PostMortem::stat(&p, false), PostMortem::Absent);
+    }
+
+    #[test]
+    fn postmortem_present_for_content() {
+        let p = std::env::temp_dir().join(format!(
+            "vetto-vng-pm-{}",
+            std::process::id()
+        ));
+        std::fs::write(&p, b"leak").expect("write");
+        assert_eq!(PostMortem::stat(&p, false), PostMortem::Present);
+        let _ = std::fs::remove_file(&p);
+    }
+}

--- a/src/verify_ng/engine.rs
+++ b/src/verify_ng/engine.rs
@@ -1,0 +1,182 @@
+//! Engine: single-owner pipeline Engine -> Killer -> Collector -> Oracle.
+//!
+//! Ownership rules (FM-14):
+//! - Only the engine touches `Backend` and `SandboxHandle`. The handle is
+//!   moved through killer/collector stages and never cloned.
+//! - Fork-safety (FM-09): every `Backend::spawn` call site must hold
+//!   [`SPAWN_SERIAL`] from before `detect` until after fork-return, because
+//!   the Linux/macOS backends fork and forking a multi-threaded process can
+//!   deadlock. Parallelize preparation and judging, never the spawn.
+//! - One `detect` per scenario run; the detected tier is compared to the
+//!   expected tier before spawn (FM-03 binding).
+//! - Diagnostic env (`VETTO_SEATBELT_MODE`, `VETTO_NO_MAC_LIMITS`,
+//!   `VETTO_FORCE_TIER` outside the tier-differential job) invalidates the
+//!   run (FM-08). Detection happens before spawn; the poisoned run never
+//!   reports PASS.
+
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
+
+use super::frozen::FrozenSpec;
+use super::frozen::hex_encode;
+use super::model::{Category, ClaimStrength, ScenarioResult, Verdict};
+use super::registry::{Scenario, Target};
+
+/// Global spawn serializer (FM-09). Hold from `detect` to fork-return.
+pub static SPAWN_SERIAL: OnceLock<Mutex<()>> = OnceLock::new();
+
+pub fn spawn_serial() -> &'static Mutex<()> {
+    SPAWN_SERIAL.get_or_init(|| Mutex::new(()))
+}
+
+/// Diagnostic env switches that weaken enforcement. Presence (except an
+/// explicit opt-in for the tier-differential job) poisons the run.
+pub const POISON_ENV: &[&str] =
+    &["VETTO_SEATBELT_MODE", "VETTO_NO_MAC_LIMITS", "VETTO_CHILD_TRACE"];
+
+/// Detect poisoned diagnostic env. `allow_force_tier` is true only in the
+/// tier-differential CI job, where the actual tier is cross-checked.
+pub fn detect_env_poison(allow_force_tier: bool) -> Vec<String> {
+    let mut poisoned = Vec::new();
+    for key in POISON_ENV {
+        if std::env::var_os(key).is_some() {
+            poisoned.push(key.to_string());
+        }
+    }
+    if !allow_force_tier && std::env::var_os("VETTO_FORCE_TIER").is_some() {
+        poisoned.push("VETTO_FORCE_TIER".to_string());
+    }
+    poisoned
+}
+
+/// Current platform target for strength lookup.
+pub fn current_target(tier_label: Option<&str>) -> Target {
+    #[cfg(target_os = "linux")]
+    {
+        match tier_label {
+            Some("full") => Target::LinuxFull,
+            Some("fs-only") => Target::LinuxFsOnly,
+            Some("seccomp") => Target::LinuxSeccomp,
+            _ => Target::LinuxSeccomp,
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = tier_label;
+        Target::Macos
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = tier_label;
+        Target::Windows
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    {
+        let _ = tier_label;
+        Target::LinuxSeccomp
+    }
+}
+
+/// Session nonce: 128 bits from `/dev/urandom` (fallback: time+pid mix;
+/// uniqueness only, not secrecy from the host's perspective).
+pub fn new_nonce() -> String {
+    let mut bytes = [0u8; 16];
+    let read_ok = std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| {
+            use std::io::Read;
+            f.read_exact(&mut bytes).map(|_| ())
+        })
+        .is_ok();
+    if !read_ok {
+        let t = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        for (i, b) in bytes.iter_mut().enumerate() {
+            *b = ((t >> (8 * (i % 8))) ^ (std::process::id() as u128) ^ (i as u128 * 0x9E37)) as u8;
+        }
+    }
+    hex_encode(bytes)
+}
+
+/// Evaluate the gate-relevant outcome for a poisoned run without spawning
+/// (FM-08: environment interference -> FAIL on blockers, INCONCLUSIVE on aux).
+pub fn poisoned_result(scenario: &Scenario, target: Target, poison: &[String]) -> ScenarioResult {
+    let verdict = match scenario.category {
+        Category::Aux => Verdict::Inconclusive,
+        _ => Verdict::Fail,
+    };
+    ScenarioResult {
+        id: scenario.id.clone(),
+        category: scenario.category,
+        strength: scenario.strength_for(target),
+        verdict,
+        detail: super::redact::redact_text(&format!(
+            "diagnostic env interference, refusing PASS: {}",
+            poison.join(",")
+        )),
+    }
+}
+
+/// Frozen-spec continuity check (FM-03): the spec handed to spawn must hash
+/// identically when re-frozen from the same references. Any drift means the
+/// policy object was mutated between freeze and spawn.
+pub fn verify_spec_continuity(before: &FrozenSpec, after: &FrozenSpec) -> bool {
+    before.hash() == after.hash()
+}
+
+/// Required env mapping for a scenario run: isolated HOME plus the session
+/// nonce. The caller merges this over an allowlist-filtered base; `env_extra`
+/// bypasses the allowlist by backend design (internal VETTO_* only), so the
+/// engine passes exactly these keys and nothing else.
+pub fn run_env(home: &std::path::Path, nonce: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("VETTO_VNG_NONCE".to_string(), nonce.to_string()),
+        ("VETTO_VNG_HOME".to_string(), home.display().to_string()),
+    ])
+}
+
+#[cfg(test)]
+mod engine_tests {
+    use super::*;
+
+    #[test]
+    fn poison_detects_seatbelt_mode() {
+        // Only assert the pure shape: detection reads the live env, so we
+        // test the constant list instead of mutating process-global env.
+        assert!(POISON_ENV.contains(&"VETTO_SEATBELT_MODE"));
+        assert!(POISON_ENV.contains(&"VETTO_NO_MAC_LIMITS"));
+    }
+
+    #[test]
+    fn nonce_is_unique_and_hex() {
+        let a = new_nonce();
+        let b = new_nonce();
+        assert_eq!(a.len(), 32);
+        assert_ne!(a, b);
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn spec_continuity_detects_drift() {
+        use crate::verify_ng::frozen::FrozenSpec;
+        let mk = |nonce: &str| FrozenSpec {
+            scenario_id: "s".to_string(),
+            registry_hash: "r".to_string(),
+            tier: "full".to_string(),
+            net_mode: "off".to_string(),
+            backend: "b".to_string(),
+            argv: vec![],
+            env: BTreeMap::new(),
+            cwd: std::path::PathBuf::from("/tmp"),
+            allow_read: vec![],
+            allow_write: vec![],
+            deny_read: vec![],
+            deny_write: vec![],
+            deny_resolved: vec![],
+            nonce: nonce.to_string(),
+        };
+        assert!(verify_spec_continuity(&mk("n"), &mk("n")));
+        assert!(!verify_spec_continuity(&mk("n"), &mk("m")));
+    }
+}

--- a/src/verify_ng/engine.rs
+++ b/src/verify_ng/engine.rs
@@ -99,7 +99,7 @@ pub fn new_nonce() -> String {
             *b = ((t >> (8 * (i % 8))) ^ (std::process::id() as u128) ^ (i as u128 * 0x9E37)) as u8;
         }
     }
-    hex_encode(bytes)
+    hex_encode(&bytes)
 }
 
 /// Evaluate the gate-relevant outcome for a poisoned run without spawning

--- a/src/verify_ng/engine.rs
+++ b/src/verify_ng/engine.rs
@@ -17,9 +17,9 @@
 use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 
-use super::frozen::FrozenSpec;
 use super::frozen::hex_encode;
-use super::model::{Category, ClaimStrength, ScenarioResult, Verdict};
+use super::frozen::FrozenSpec;
+use super::model::{Category, ScenarioResult, Verdict};
 use super::registry::{Scenario, Target};
 
 /// Global spawn serializer (FM-09). Hold from `detect` to fork-return.
@@ -31,8 +31,11 @@ pub fn spawn_serial() -> &'static Mutex<()> {
 
 /// Diagnostic env switches that weaken enforcement. Presence (except an
 /// explicit opt-in for the tier-differential job) poisons the run.
-pub const POISON_ENV: &[&str] =
-    &["VETTO_SEATBELT_MODE", "VETTO_NO_MAC_LIMITS", "VETTO_CHILD_TRACE"];
+pub const POISON_ENV: &[&str] = &[
+    "VETTO_SEATBELT_MODE",
+    "VETTO_NO_MAC_LIMITS",
+    "VETTO_CHILD_TRACE",
+];
 
 /// Detect poisoned diagnostic env. `allow_force_tier` is true only in the
 /// tier-differential CI job, where the actual tier is cross-checked.

--- a/src/verify_ng/evidence.rs
+++ b/src/verify_ng/evidence.rs
@@ -1,0 +1,78 @@
+//! Three-tier evidence model (FM-01).
+//!
+//! - [`EvidenceTier::HostFact`]: observed by the trusted host after wait
+//!   (post-mortem stat, wait status, sweep result, canary comparison).
+//!   The only tier that can support a PASS.
+//! - [`EvidenceTier::Constrained`]: narrow in-sandbox signal through a
+//!   nonce-bound channel (errno class + nonce). Supports FAIL, never PASS
+//!   alone.
+//! - [`EvidenceTier::SelfReport`]: attacker-controlled stdout markers.
+//!   Hints for triage only; never decide a verdict.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EvidenceTier {
+    HostFact,
+    Constrained,
+    SelfReport,
+}
+
+/// One collected fact with its tier.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Fact {
+    pub tier: EvidenceTier,
+    pub name: String,
+    pub value: String,
+}
+
+/// Collected evidence for one scenario run.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Evidence {
+    pub facts: Vec<Fact>,
+}
+
+impl Evidence {
+    pub fn push(&mut self, tier: EvidenceTier, name: &str, value: String) {
+        self.facts.push(Fact { tier, name: name.to_string(), value });
+    }
+
+    pub fn host_fact(&mut self, name: &str, value: String) {
+        self.push(EvidenceTier::HostFact, name, value);
+    }
+
+    pub fn constrained(&mut self, name: &str, value: String) {
+        self.push(EvidenceTier::Constrained, name, value);
+    }
+
+    pub fn self_report(&mut self, name: &str, value: String) {
+        self.push(EvidenceTier::SelfReport, name, value);
+    }
+
+    /// PASS requires at least one host fact (FM-01 structural rule).
+    pub fn has_host_fact(&self) -> bool {
+        self.facts.iter().any(|f| f.tier == EvidenceTier::HostFact)
+    }
+
+    pub fn host_fact_value(&self, name: &str) -> Option<&str> {
+        self.facts
+            .iter()
+            .find(|f| f.tier == EvidenceTier::HostFact && f.name == name)
+            .map(|f| f.value.as_str())
+    }
+}
+
+#[cfg(test)]
+mod evidence_tests {
+    use super::*;
+
+    #[test]
+    fn pass_requires_host_fact() {
+        let mut e = Evidence::default();
+        e.self_report("marker", "PASS".to_string());
+        e.constrained("errno", "EACCES".to_string());
+        assert!(!e.has_host_fact());
+        e.host_fact("postmortem", "absent".to_string());
+        assert!(e.has_host_fact());
+    }
+}

--- a/src/verify_ng/evidence.rs
+++ b/src/verify_ng/evidence.rs
@@ -34,7 +34,11 @@ pub struct Evidence {
 
 impl Evidence {
     pub fn push(&mut self, tier: EvidenceTier, name: &str, value: String) {
-        self.facts.push(Fact { tier, name: name.to_string(), value });
+        self.facts.push(Fact {
+            tier,
+            name: name.to_string(),
+            value,
+        });
     }
 
     pub fn host_fact(&mut self, name: &str, value: String) {

--- a/src/verify_ng/exit.rs
+++ b/src/verify_ng/exit.rs
@@ -105,16 +105,17 @@ pub fn evaluate_gate(
     for (category, min) in min_pass_per_category() {
         let got = pass_per_category.get(&category).copied().unwrap_or(0);
         if got < min {
-            blocking.push(format!(
-                "{}:only-{got}-pass-min-{min}",
-                category.label()
-            ));
+            blocking.push(format!("{}:only-{got}-pass-min-{min}", category.label()));
         }
     }
 
     // Zero INCONCLUSIVE in blockers (fail-closed): already covered by
     // blocks_release, but stated explicitly for the report.
-    let status = if blocking.is_empty() { "pass" } else { "failed" };
+    let status = if blocking.is_empty() {
+        "pass"
+    } else {
+        "failed"
+    };
     let _ = registry_hash;
     GateReport {
         status: status.to_string(),
@@ -179,8 +180,14 @@ mod exit_tests {
             result("ENV-LEAK-001", Category::Secrets, Verdict::NotApplicable),
         ];
         let mut ev = BTreeMap::new();
-        ev.insert("VFS-TRAV-001".to_string(), vec!["netns: absent (x)".to_string()]);
-        ev.insert("ENV-LEAK-001".to_string(), vec!["spawn: absent (y)".to_string()]);
+        ev.insert(
+            "VFS-TRAV-001".to_string(),
+            vec!["netns: absent (x)".to_string()],
+        );
+        ev.insert(
+            "ENV-LEAK-001".to_string(),
+            vec!["spawn: absent (y)".to_string()],
+        );
         let report = evaluate_gate(&results, &ev, "reg");
         assert_eq!(report.status, "failed");
     }
@@ -189,10 +196,17 @@ mod exit_tests {
     #[test]
     fn na_without_evidence_blocks() {
         let mut results = full_pass_set();
-        results.push(result("WIN-WSL-001", Category::FsRead, Verdict::NotApplicable));
+        results.push(result(
+            "WIN-WSL-001",
+            Category::FsRead,
+            Verdict::NotApplicable,
+        ));
         let report = evaluate_gate(&results, &BTreeMap::new(), "reg");
         assert_eq!(report.status, "failed");
-        assert!(report.blocking.iter().any(|b| b.contains("N/A-without-evidence")));
+        assert!(report
+            .blocking
+            .iter()
+            .any(|b| b.contains("N/A-without-evidence")));
     }
 
     /// Full PASS set with N/A evidence passes.
@@ -201,7 +215,10 @@ mod exit_tests {
         let mut results = full_pass_set();
         results.push(result("WIN-WSL-001", Category::Aux, Verdict::NotApplicable));
         let mut ev = BTreeMap::new();
-        ev.insert("WIN-WSL-001".to_string(), vec!["wsl: absent (unmapped)".to_string()]);
+        ev.insert(
+            "WIN-WSL-001".to_string(),
+            vec!["wsl: absent (unmapped)".to_string()],
+        );
         let report = evaluate_gate(&results, &ev, "reg");
         assert_eq!(report.status, "pass");
         assert_eq!(gate_exit_code(&report), 0);

--- a/src/verify_ng/exit.rs
+++ b/src/verify_ng/exit.rs
@@ -1,0 +1,218 @@
+//! Gate report + exit-code contract (FM-10/FM-12).
+//!
+//! The gate blocks promotion unless ALL hold:
+//! - No blocker-category FAIL or INCONCLUSIVE.
+//! - Zero INCONCLUSIVE in blocker categories (fail-closed).
+//! - Every NOT_APPLICABLE carries absence evidence (no silent skips).
+//! - Canary scenarios (proof-of-enforcement-alive) all PASS.
+//! - Per-category PASS minimums met (no vacuum PASS: FM-12).
+//! Exit codes reuse `crate::exit_codes`: 0 clean, 1 gate failure (leak or
+//! inconclusive-in-blocker), 125 harness fail-closed (could not run).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use super::model::{Category, ScenarioResult, Verdict};
+
+/// Canary scenario ids: proof the enforcement under test is alive.
+/// A green gate with a failing canary is a contradiction -> gate FAIL.
+pub const CANARY_IDS: &[&str] = &["VFS-TRAV-001", "ENV-LEAK-001", "PROC-ESC-001"];
+
+/// Minimum PASS counts per blocker category for a meaningful gate.
+pub fn min_pass_per_category() -> BTreeMap<Category, usize> {
+    BTreeMap::from([
+        (Category::FsRead, 1),
+        (Category::FsWrite, 1),
+        (Category::Net, 1),
+        (Category::Proc, 1),
+        (Category::Secrets, 1),
+        (Category::Spawn, 1),
+    ])
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GateReport {
+    pub status: String,
+    pub passed: usize,
+    pub failed: usize,
+    pub inconclusive: usize,
+    pub not_applicable: usize,
+    pub blocking: Vec<String>,
+    pub results: Vec<ScenarioResult>,
+}
+
+impl GateReport {
+    pub fn summary(&self) -> String {
+        format!(
+            "verify-ng gate: {} (pass={} fail={} inconclusive={} n/a={})",
+            self.status, self.passed, self.failed, self.inconclusive, self.not_applicable
+        )
+    }
+}
+
+/// Evaluate the gate. `na_evidence` maps scenario id -> absence evidence
+/// strings for NOT_APPLICABLE results; entries missing evidence fail the gate.
+pub fn evaluate_gate(
+    results: &[ScenarioResult],
+    na_evidence: &BTreeMap<String, Vec<String>>,
+    registry_hash: &str,
+) -> GateReport {
+    let mut blocking = Vec::new();
+    let mut passed = 0;
+    let mut failed = 0;
+    let mut inconclusive = 0;
+    let mut not_applicable = 0;
+    let mut pass_per_category: BTreeMap<Category, usize> = BTreeMap::new();
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+
+    for r in results {
+        match r.verdict {
+            Verdict::Pass => {
+                passed += 1;
+                *pass_per_category.entry(r.category).or_insert(0) += 1;
+            }
+            Verdict::Fail => failed += 1,
+            Verdict::Inconclusive => inconclusive += 1,
+            Verdict::NotApplicable => not_applicable += 1,
+        }
+        if r.blocks_release() {
+            blocking.push(r.id.clone());
+        }
+        if r.verdict == Verdict::NotApplicable {
+            let has_evidence = na_evidence
+                .get(&r.id)
+                .map(|e| !e.is_empty())
+                .unwrap_or(false);
+            if !has_evidence {
+                blocking.push(format!("{}:N/A-without-evidence", r.id));
+            }
+        }
+        seen.insert(r.id.as_str());
+    }
+
+    // Canary rule: every canary that ran must PASS; a canary that did not
+    // run at all also fails the gate (no vacuum PASS).
+    for canary in CANARY_IDS {
+        match results.iter().find(|r| &r.id == canary) {
+            Some(r) if r.verdict == Verdict::Pass => {}
+            Some(r) => blocking.push(format!("{canary}:canary-{:?}", r.verdict)),
+            None => blocking.push(format!("{canary}:canary-missing")),
+        }
+    }
+
+    // Per-category PASS minimums.
+    for (category, min) in min_pass_per_category() {
+        let got = pass_per_category.get(&category).copied().unwrap_or(0);
+        if got < min {
+            blocking.push(format!(
+                "{}:only-{got}-pass-min-{min}",
+                category.label()
+            ));
+        }
+    }
+
+    // Zero INCONCLUSIVE in blockers (fail-closed): already covered by
+    // blocks_release, but stated explicitly for the report.
+    let status = if blocking.is_empty() { "pass" } else { "failed" };
+    let _ = registry_hash;
+    GateReport {
+        status: status.to_string(),
+        passed,
+        failed,
+        inconclusive,
+        not_applicable,
+        blocking,
+        results: results.to_vec(),
+    }
+}
+
+/// CLI exit code for a gate report: 0 pass, 1 gate failure.
+pub fn gate_exit_code(report: &GateReport) -> i32 {
+    if report.status == "pass" {
+        0
+    } else {
+        1
+    }
+}
+
+#[cfg(test)]
+mod exit_tests {
+    use super::*;
+    use crate::verify_ng::model::ClaimStrength;
+
+    fn result(id: &str, category: Category, verdict: Verdict) -> ScenarioResult {
+        ScenarioResult {
+            id: id.to_string(),
+            category,
+            strength: ClaimStrength::Strong,
+            verdict,
+            detail: String::new(),
+        }
+    }
+
+    fn full_pass_set() -> Vec<ScenarioResult> {
+        vec![
+            result("VFS-TRAV-001", Category::FsRead, Verdict::Pass),
+            result("VFS-W-1", Category::FsWrite, Verdict::Pass),
+            result("NET-DNS-IPV6-001", Category::Net, Verdict::Pass),
+            result("PROC-ESC-001", Category::Proc, Verdict::Pass),
+            result("ENV-LEAK-001", Category::Secrets, Verdict::Pass),
+            result("RACE-BINDING-001", Category::Spawn, Verdict::Pass),
+        ]
+    }
+
+    /// FM-12 GATE-VACUUM-001: empty suite must FAIL the gate, never pass.
+    #[test]
+    fn gate_vacuum_001_empty_suite_fails() {
+        let report = evaluate_gate(&[], &BTreeMap::new(), "reg");
+        assert_eq!(report.status, "failed");
+        assert_eq!(gate_exit_code(&report), 1);
+        assert!(report.blocking.iter().any(|b| b.contains("canary-missing")));
+    }
+
+    /// All-N/A suite must FAIL (missing canaries + minimums).
+    #[test]
+    fn all_na_suite_fails() {
+        let results = vec![
+            result("VFS-TRAV-001", Category::FsRead, Verdict::NotApplicable),
+            result("ENV-LEAK-001", Category::Secrets, Verdict::NotApplicable),
+        ];
+        let mut ev = BTreeMap::new();
+        ev.insert("VFS-TRAV-001".to_string(), vec!["netns: absent (x)".to_string()]);
+        ev.insert("ENV-LEAK-001".to_string(), vec!["spawn: absent (y)".to_string()]);
+        let report = evaluate_gate(&results, &ev, "reg");
+        assert_eq!(report.status, "failed");
+    }
+
+    /// N/A without absence evidence blocks even a passing suite.
+    #[test]
+    fn na_without_evidence_blocks() {
+        let mut results = full_pass_set();
+        results.push(result("WIN-WSL-001", Category::FsRead, Verdict::NotApplicable));
+        let report = evaluate_gate(&results, &BTreeMap::new(), "reg");
+        assert_eq!(report.status, "failed");
+        assert!(report.blocking.iter().any(|b| b.contains("N/A-without-evidence")));
+    }
+
+    /// Full PASS set with N/A evidence passes.
+    #[test]
+    fn full_pass_set_passes() {
+        let mut results = full_pass_set();
+        results.push(result("WIN-WSL-001", Category::Aux, Verdict::NotApplicable));
+        let mut ev = BTreeMap::new();
+        ev.insert("WIN-WSL-001".to_string(), vec!["wsl: absent (unmapped)".to_string()]);
+        let report = evaluate_gate(&results, &ev, "reg");
+        assert_eq!(report.status, "pass");
+        assert_eq!(gate_exit_code(&report), 0);
+    }
+
+    /// One INCONCLUSIVE in a blocker fails the gate.
+    #[test]
+    fn inconclusive_in_blocker_fails() {
+        let mut results = full_pass_set();
+        results[2] = result("NET-DNS-IPV6-001", Category::Net, Verdict::Inconclusive);
+        let report = evaluate_gate(&results, &BTreeMap::new(), "reg");
+        assert_eq!(report.status, "failed");
+    }
+}

--- a/src/verify_ng/exit.rs
+++ b/src/verify_ng/exit.rs
@@ -1,11 +1,13 @@
 //! Gate report + exit-code contract (FM-10/FM-12).
 //!
 //! The gate blocks promotion unless ALL hold:
+//!
 //! - No blocker-category FAIL or INCONCLUSIVE.
 //! - Zero INCONCLUSIVE in blocker categories (fail-closed).
 //! - Every NOT_APPLICABLE carries absence evidence (no silent skips).
 //! - Canary scenarios (proof-of-enforcement-alive) all PASS.
 //! - Per-category PASS minimums met (no vacuum PASS: FM-12).
+//!
 //! Exit codes reuse `crate::exit_codes`: 0 clean, 1 gate failure (leak or
 //! inconclusive-in-blocker), 125 harness fail-closed (could not run).
 

--- a/src/verify_ng/fixture.rs
+++ b/src/verify_ng/fixture.rs
@@ -26,15 +26,16 @@ impl Fixture {
     /// Create a fresh unique fixture root under the system temp dir.
     pub fn create(tag: &str) -> std::io::Result<Self> {
         let n = FIXTURE_COUNTER.fetch_add(1, Ordering::SeqCst);
-        let root = std::env::temp_dir().join(format!(
-            "vetto-vng-{}-{}-{n}",
-            tag,
-            std::process::id()
-        ));
+        let root =
+            std::env::temp_dir().join(format!("vetto-vng-{}-{}-{n}", tag, std::process::id()));
         let home = root.join("home");
         std::fs::create_dir_all(&root)?;
         std::fs::create_dir_all(&home)?;
-        Ok(Self { root, home, payload_hashes: Vec::new() })
+        Ok(Self {
+            root,
+            home,
+            payload_hashes: Vec::new(),
+        })
     }
 
     pub fn root(&self) -> &Path {

--- a/src/verify_ng/fixture.rs
+++ b/src/verify_ng/fixture.rs
@@ -1,0 +1,119 @@
+//! Hermetic fixture builder (FM-06).
+//!
+//! Rules:
+//! - One spawn = one scenario: each run gets a fresh unique directory.
+//! - The payload staged inside the writable project is hashed before spawn
+//!   and re-hashed after wait; any mutation (including self-rewrite by the
+//!   payload, FM-06) invalidates the run as INCONCLUSIVE.
+//! - The harness HOME for a run is a fresh subdirectory, never a shared
+//!   global root: parallel or sequential runs cannot cross-contaminate.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use sha2::{Digest, Sha256};
+
+static FIXTURE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// One hermetic run directory.
+pub struct Fixture {
+    root: PathBuf,
+    home: PathBuf,
+    payload_hashes: Vec<(PathBuf, String)>,
+}
+
+impl Fixture {
+    /// Create a fresh unique fixture root under the system temp dir.
+    pub fn create(tag: &str) -> std::io::Result<Self> {
+        let n = FIXTURE_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let root = std::env::temp_dir().join(format!(
+            "vetto-vng-{}-{}-{n}",
+            tag,
+            std::process::id()
+        ));
+        let home = root.join("home");
+        std::fs::create_dir_all(&root)?;
+        std::fs::create_dir_all(&home)?;
+        Ok(Self { root, home, payload_hashes: Vec::new() })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Isolated HOME for this run (FM-06: never shared).
+    pub fn home(&self) -> &Path {
+        &self.home
+    }
+
+    /// Write a file inside the fixture and record its pre-spawn hash.
+    pub fn stage(&mut self, rel: &str, content: &[u8]) -> std::io::Result<PathBuf> {
+        let path = self.root.join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, content)?;
+        let hash = hash_bytes(content);
+        self.payload_hashes.push((path.clone(), hash));
+        Ok(path)
+    }
+
+    /// Re-hash every staged payload after wait. `Ok(())` means untouched;
+    /// `Err(paths)` lists mutated payloads (FM-06 -> INCONCLUSIVE).
+    pub fn verify_untouched(&self) -> Result<(), Vec<PathBuf>> {
+        let mut mutated = Vec::new();
+        for (path, before) in &self.payload_hashes {
+            let after = std::fs::read(path)
+                .map(|b| hash_bytes(&b))
+                .unwrap_or_else(|_| "unreadable".to_string());
+            if &after != before {
+                mutated.push(path.clone());
+            }
+        }
+        if mutated.is_empty() {
+            Ok(())
+        } else {
+            Err(mutated)
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+pub fn hash_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    super::frozen::hex_encode(&hasher.finalize())
+}
+
+#[cfg(test)]
+mod fixture_tests {
+    use super::*;
+
+    #[test]
+    fn detects_self_mutation() {
+        let mut fx = Fixture::create("mut").expect("create fixture");
+        let p = fx.stage("payload.sh", b"echo hi").expect("stage");
+        std::fs::write(&p, b"echo PASS").expect("mutate");
+        assert!(fx.verify_untouched().is_err());
+    }
+
+    #[test]
+    fn untouched_passes() {
+        let mut fx = Fixture::create("clean").expect("create fixture");
+        fx.stage("payload.sh", b"echo hi").expect("stage");
+        assert!(fx.verify_untouched().is_ok());
+    }
+
+    #[test]
+    fn homes_are_unique_per_fixture() {
+        let a = Fixture::create("a").expect("create a");
+        let b = Fixture::create("b").expect("create b");
+        assert_ne!(a.home(), b.home());
+        assert_ne!(a.root(), b.root());
+    }
+}

--- a/src/verify_ng/frozen.rs
+++ b/src/verify_ng/frozen.rs
@@ -54,6 +54,7 @@ impl FrozenSpec {
 /// Build the canonical spec from a resolved policy plus the effective
 /// launch context. Callers must pass the same `policy` reference onward
 /// to `Backend::spawn` (FM-03 continuity rule).
+#[allow(clippy::too_many_arguments)]
 pub fn freeze_spec(
     scenario_id: &str,
     registry_hash: &str,

--- a/src/verify_ng/frozen.rs
+++ b/src/verify_ng/frozen.rs
@@ -1,0 +1,164 @@
+//! FrozenSpec: what was verified is what was launched (FM-03).
+//!
+//! Binding rules:
+//! - Exactly one `Backend::detect` per scenario run; the detected tier is
+//!   compared against the expected tier before spawn.
+//! - The spec hash is computed once, in the same single-threaded section,
+//!   from the same `&Policy` reference handed to `Backend::spawn`.
+//! - Serialization is canonical: sorted paths, normalized strings, explicit
+//!   tier/net/backend/argv/env/cwd. `Policy::deny_network` is intent-only;
+//!   the effective [`crate::config::NetMode`] is hashed separately and
+//!   explicitly.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Canonical, hashable snapshot of everything that defines a scenario run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FrozenSpec {
+    pub scenario_id: String,
+    pub registry_hash: String,
+    pub tier: String,
+    pub net_mode: String,
+    pub backend: String,
+    pub argv: Vec<String>,
+    pub env: BTreeMap<String, String>,
+    pub cwd: PathBuf,
+    pub allow_read: Vec<String>,
+    pub allow_write: Vec<String>,
+    pub deny_read: Vec<String>,
+    pub deny_write: Vec<String>,
+    pub deny_resolved: Vec<String>,
+    /// Session nonce binding the positive control to the negative proof.
+    pub nonce: String,
+}
+
+impl FrozenSpec {
+    /// Canonical bytes: JSON with sorted keys over normalized strings.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        // BTreeMap + sorted Vecs + explicit fields make serde_json output
+        // deterministic for a fixed struct layout.
+        serde_json::to_vec(self).unwrap_or_default()
+    }
+
+    pub fn hash(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(self.canonical_bytes());
+        hex_encode(&hasher.finalize())
+    }
+}
+
+/// Build the canonical spec from a resolved policy plus the effective
+/// launch context. Callers must pass the same `policy` reference onward
+/// to `Backend::spawn` (FM-03 continuity rule).
+pub fn freeze_spec(
+    scenario_id: &str,
+    registry_hash: &str,
+    policy: &crate::policy::Policy,
+    tier: &str,
+    net_mode: &crate::config::NetMode,
+    backend_describe: &str,
+    argv: &[String],
+    env: &BTreeMap<String, String>,
+    cwd: &std::path::Path,
+    nonce: &str,
+) -> FrozenSpec {
+    fn sorted(paths: &[PathBuf]) -> Vec<String> {
+        let mut out: Vec<String> =
+            paths.iter().map(|p| p.display().to_string()).collect();
+        out.sort();
+        out
+    }
+    let mut deny_resolved: Vec<String> = policy
+        .deny_resolved
+        .iter()
+        .map(|e| e.path.display().to_string())
+        .collect();
+    deny_resolved.sort();
+    FrozenSpec {
+        scenario_id: scenario_id.to_string(),
+        registry_hash: registry_hash.to_string(),
+        tier: tier.to_string(),
+        net_mode: net_mode.label(),
+        backend: backend_describe.to_string(),
+        argv: argv.to_vec(),
+        env: env.clone(),
+        cwd: cwd.to_path_buf(),
+        allow_read: sorted(&policy.allow_read),
+        allow_write: sorted(&policy.allow_write),
+        deny_read: sorted(&policy.deny_read),
+        deny_write: sorted(&policy.deny_write),
+        deny_resolved,
+        nonce: nonce.to_string(),
+    }
+}
+
+/// Hash of the compiled scenario registry (binding scenarios to results).
+pub fn registry_hash(ids: &[String]) -> String {
+    let mut sorted = ids.to_vec();
+    sorted.sort();
+    let mut hasher = Sha256::new();
+    for id in sorted {
+        hasher.update(id.as_bytes());
+        hasher.update([0u8]);
+    }
+    hex_encode(&hasher.finalize())
+}
+
+/// Minimal hex encoding (no new dependency; mirrors
+/// `sandbox::linux::debug_guard`).
+pub fn hex_encode(data: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut s = String::with_capacity(data.len() * 2);
+    for &b in data {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    s
+}
+
+#[cfg(test)]
+mod frozen_tests {
+    use super::*;
+
+    #[test]
+    fn hash_is_stable_and_order_independent() {
+        let mk = |writes: Vec<PathBuf>| FrozenSpec {
+            scenario_id: "s".to_string(),
+            registry_hash: "r".to_string(),
+            tier: "full".to_string(),
+            net_mode: "off".to_string(),
+            backend: "b".to_string(),
+            argv: vec!["a".to_string()],
+            env: BTreeMap::new(),
+            cwd: PathBuf::from("/tmp"),
+            allow_read: vec![],
+            allow_write: writes.iter().map(|p| p.display().to_string()).collect(),
+            deny_read: vec![],
+            deny_write: vec![],
+            deny_resolved: vec![],
+            nonce: "n".to_string(),
+        };
+        let a = mk(vec![PathBuf::from("/b"), PathBuf::from("/a")]);
+        let mut b = mk(vec![PathBuf::from("/a"), PathBuf::from("/b")]);
+        b.allow_write.sort();
+        // freeze_spec sorts; simulate by sorting both.
+        let mut a_sorted = a.clone();
+        a_sorted.allow_write.sort();
+        assert_eq!(a_sorted.hash(), b.hash());
+        let mut c = b.clone();
+        c.nonce = "other".to_string();
+        assert_ne!(b.hash(), c.hash());
+    }
+
+    #[test]
+    fn net_mode_label_distinguishes_relay() {
+        let off = crate::config::NetMode::Off.label();
+        let allow =
+            crate::config::NetMode::Allowlist(vec!["example.com".to_string()]).label();
+        assert_ne!(off, allow);
+    }
+}

--- a/src/verify_ng/frozen.rs
+++ b/src/verify_ng/frozen.rs
@@ -67,8 +67,7 @@ pub fn freeze_spec(
     nonce: &str,
 ) -> FrozenSpec {
     fn sorted(paths: &[PathBuf]) -> Vec<String> {
-        let mut out: Vec<String> =
-            paths.iter().map(|p| p.display().to_string()).collect();
+        let mut out: Vec<String> = paths.iter().map(|p| p.display().to_string()).collect();
         out.sort();
         out
     }
@@ -157,8 +156,7 @@ mod frozen_tests {
     #[test]
     fn net_mode_label_distinguishes_relay() {
         let off = crate::config::NetMode::Off.label();
-        let allow =
-            crate::config::NetMode::Allowlist(vec!["example.com".to_string()]).label();
+        let allow = crate::config::NetMode::Allowlist(vec!["example.com".to_string()]).label();
         assert_ne!(off, allow);
     }
 }

--- a/src/verify_ng/killer.rs
+++ b/src/verify_ng/killer.rs
@@ -34,18 +34,24 @@ impl CleanupExpectation {
         {
             return match tier_label {
                 Some("full") => CleanupExpectation::Strong,
-                _ => CleanupExpectation::BestEffort { sweep_budget_ms: 2000 },
+                _ => CleanupExpectation::BestEffort {
+                    sweep_budget_ms: 2000,
+                },
             };
         }
         #[cfg(target_os = "macos")]
         {
             let _ = tier_label;
-            return CleanupExpectation::BestEffort { sweep_budget_ms: 2000 };
+            return CleanupExpectation::BestEffort {
+                sweep_budget_ms: 2000,
+            };
         }
         #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
         {
             let _ = tier_label;
-            return CleanupExpectation::BestEffort { sweep_budget_ms: 2000 };
+            return CleanupExpectation::BestEffort {
+                sweep_budget_ms: 2000,
+            };
         }
     }
 }

--- a/src/verify_ng/killer.rs
+++ b/src/verify_ng/killer.rs
@@ -28,7 +28,7 @@ impl CleanupExpectation {
         #[cfg(target_os = "windows")]
         {
             let _ = tier_label;
-            return CleanupExpectation::Strong;
+            CleanupExpectation::Strong
         }
         #[cfg(target_os = "linux")]
         {
@@ -42,16 +42,16 @@ impl CleanupExpectation {
         #[cfg(target_os = "macos")]
         {
             let _ = tier_label;
-            return CleanupExpectation::BestEffort {
+            CleanupExpectation::BestEffort {
                 sweep_budget_ms: 2000,
-            };
+            }
         }
         #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
         {
             let _ = tier_label;
-            return CleanupExpectation::BestEffort {
+            CleanupExpectation::BestEffort {
                 sweep_budget_ms: 2000,
-            };
+            }
         }
     }
 }

--- a/src/verify_ng/killer.rs
+++ b/src/verify_ng/killer.rs
@@ -1,0 +1,124 @@
+//! Killer stage: deadline -> terminate -> re-wait (FM-04/FM-05).
+//!
+//! The engine owns the `SandboxHandle`; the killer borrows it mutably for
+//! exactly one stage and hands it back. No other module may terminate or
+//! drop the handle mid-run: cleanup responsibility is single-owner (FM-14).
+//!
+//! Cleanup strength by tier (FM-05), enforced by the caller selecting the
+//! matching [`CleanupExpectation`]:
+//! - FULL / Windows-Job: kernel/Job teardown, residue is a FAIL.
+//! - FS-ONLY / macOS: group-kill + bounded sweep, residue is FAIL with a
+//!   documented residual; destructive suites stay on Strong tiers or in a VM.
+
+use std::time::{Duration, Instant};
+
+/// What cleanup strength the caller may assume for this run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CleanupExpectation {
+    /// Kernel/Job teardown: any residue is a containment FAIL.
+    Strong,
+    /// Group-kill + bounded sweep: residue is FAIL with known residual text.
+    BestEffort { sweep_budget_ms: u64 },
+}
+
+impl CleanupExpectation {
+    /// Select from the current backend/tier. Windows Job and Linux FULL are
+    /// Strong; everything else is best-effort with the reparent-sweep budget.
+    pub fn for_current_tier(tier_label: Option<&str>) -> Self {
+        #[cfg(target_os = "windows")]
+        {
+            let _ = tier_label;
+            return CleanupExpectation::Strong;
+        }
+        #[cfg(target_os = "linux")]
+        {
+            return match tier_label {
+                Some("full") => CleanupExpectation::Strong,
+                _ => CleanupExpectation::BestEffort { sweep_budget_ms: 2000 },
+            };
+        }
+        #[cfg(target_os = "macos")]
+        {
+            let _ = tier_label;
+            return CleanupExpectation::BestEffort { sweep_budget_ms: 2000 };
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+        {
+            let _ = tier_label;
+            return CleanupExpectation::BestEffort { sweep_budget_ms: 2000 };
+        }
+    }
+}
+
+/// Outcome of the kill stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KillOutcome {
+    /// Child exited on its own before the deadline.
+    Exited,
+    /// Deadline hit; terminate was issued.
+    KilledOnDeadline,
+}
+
+/// Poll `try_wait` until `deadline`; on expiry call `terminate` once and do
+/// a final bounded re-wait so the caller always gets an exit value.
+/// Blocking `wait()` is never used here (FM-04).
+pub fn kill_on_deadline(
+    handle: &mut crate::sandbox::SandboxHandle,
+    deadline: Instant,
+    poll: Duration,
+) -> (KillOutcome, i32) {
+    loop {
+        if let Some(code) = handle.try_wait() {
+            return (KillOutcome::Exited, code);
+        }
+        if Instant::now() >= deadline {
+            handle.terminate();
+            let end = Instant::now() + Duration::from_secs(10);
+            loop {
+                if let Some(code) = handle.try_wait() {
+                    return (KillOutcome::KilledOnDeadline, code);
+                }
+                if Instant::now() >= end {
+                    handle.terminate();
+                    return (KillOutcome::KilledOnDeadline, -1);
+                }
+                std::thread::sleep(poll);
+            }
+        }
+        std::thread::sleep(poll);
+    }
+}
+
+#[cfg(test)]
+mod killer_tests {
+    use super::*;
+
+    #[test]
+    fn expectation_matrix() {
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(
+                CleanupExpectation::for_current_tier(Some("full")),
+                CleanupExpectation::Strong
+            );
+            assert!(matches!(
+                CleanupExpectation::for_current_tier(Some("fs-only")),
+                CleanupExpectation::BestEffort { .. }
+            ));
+        }
+        #[cfg(target_os = "windows")]
+        {
+            assert_eq!(
+                CleanupExpectation::for_current_tier(None),
+                CleanupExpectation::Strong
+            );
+        }
+        #[cfg(target_os = "macos")]
+        {
+            assert!(matches!(
+                CleanupExpectation::for_current_tier(None),
+                CleanupExpectation::BestEffort { .. }
+            ));
+        }
+    }
+}

--- a/src/verify_ng/killer.rs
+++ b/src/verify_ng/killer.rs
@@ -32,12 +32,12 @@ impl CleanupExpectation {
         }
         #[cfg(target_os = "linux")]
         {
-            return match tier_label {
+            match tier_label {
                 Some("full") => CleanupExpectation::Strong,
                 _ => CleanupExpectation::BestEffort {
                     sweep_budget_ms: 2000,
                 },
-            };
+            }
         }
         #[cfg(target_os = "macos")]
         {

--- a/src/verify_ng/mod.rs
+++ b/src/verify_ng/mod.rs
@@ -37,9 +37,8 @@ pub fn run_verify_ng(json: bool, lint: bool) -> anyhow::Result<()> {
     let scenarios = registry::registry();
     if lint {
         let errors = registry::lint_all(&scenarios);
-        let hash = frozen::registry_hash(
-            &scenarios.iter().map(|s| s.id.clone()).collect::<Vec<_>>(),
-        );
+        let hash =
+            frozen::registry_hash(&scenarios.iter().map(|s| s.id.clone()).collect::<Vec<_>>());
         if json {
             println!(
                 "{}",
@@ -51,7 +50,10 @@ pub fn run_verify_ng(json: bool, lint: bool) -> anyhow::Result<()> {
                 })
             );
         } else if errors.is_empty() {
-            println!("verify-ng lint clean: {} scenarios, registry {hash}", scenarios.len());
+            println!(
+                "verify-ng lint clean: {} scenarios, registry {hash}",
+                scenarios.len()
+            );
         } else {
             println!("verify-ng lint FAILED ({} error(s)):", errors.len());
             for e in &errors {
@@ -75,10 +77,12 @@ pub fn run_verify_ng(json: bool, lint: bool) -> anyhow::Result<()> {
         results: vec![],
     };
     if json {
-        let hash = frozen::registry_hash(
-            &scenarios.iter().map(|s| s.id.clone()).collect::<Vec<_>>(),
+        let hash =
+            frozen::registry_hash(&scenarios.iter().map(|s| s.id.clone()).collect::<Vec<_>>());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report::gate_report_json(&report, &hash))?
         );
-        println!("{}", serde_json::to_string_pretty(&report::gate_report_json(&report, &hash))?);
     } else {
         eprintln!("vetto: verify-ng: suite execution not wired yet; failing closed");
         println!("{}", report::render_text(&report));

--- a/src/verify_ng/mod.rs
+++ b/src/verify_ng/mod.rs
@@ -1,0 +1,28 @@
+//! Adversarial security verification (`verify-ng`).
+//!
+//! Design notes (from the Prompt-01 proposal and its adversarial self-review):
+//! - The oracle judges a [`Verdict`] from host-observable facts only.
+//!   Attacker-controlled stdout is a hint, never proof of PASS.
+//! - [`ClaimStrength`] (how strong the guarantee can ever be on this
+//!   platform/tier) is a static registry property, orthogonal to the per-run
+//!   [`Verdict`]. There is no "Partial-PASS": the report carries both axes.
+//! - Spawning follows the single-threaded fork contract of
+//!   `crate::sandbox::Backend::spawn`: [`engine::SPAWN_SERIAL`] serializes
+//!   every spawn up to fork-return. Parallelize preparation and judging,
+//!   never the spawn itself.
+//! - Enforcement stays in the sandbox backends. This module is a
+//!   measurement harness, not part of the security boundary.
+
+pub mod caps;
+pub mod collector;
+pub mod engine;
+pub mod evidence;
+pub mod exit;
+pub mod fixture;
+pub mod frozen;
+pub mod killer;
+pub mod model;
+pub mod oracle;
+pub mod redact;
+pub mod registry;
+pub mod report;

--- a/src/verify_ng/mod.rs
+++ b/src/verify_ng/mod.rs
@@ -26,3 +26,65 @@ pub mod oracle;
 pub mod redact;
 pub mod registry;
 pub mod report;
+
+/// CLI entry: `vetto verify-ng [--json] [--lint]`.
+///
+/// `--lint` checks the frozen scenario registry without spawning anything
+/// and always exits 0/1 via anyhow (lint errors fail the command).
+/// Without `--lint`, no execution engine is wired yet: fail closed with
+/// exit 125 and never emit a PASS.
+pub fn run_verify_ng(json: bool, lint: bool) -> anyhow::Result<()> {
+    let scenarios = registry::registry();
+    if lint {
+        let errors = registry::lint_all(&scenarios);
+        let hash = frozen::registry_hash(
+            &scenarios.iter().map(|s| s.id.clone()).collect::<Vec<_>>(),
+        );
+        if json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "tool": "vetto verify-ng",
+                    "registry_hash": hash,
+                    "scenarios": scenarios.len(),
+                    "errors": errors,
+                })
+            );
+        } else if errors.is_empty() {
+            println!("verify-ng lint clean: {} scenarios, registry {hash}", scenarios.len());
+        } else {
+            println!("verify-ng lint FAILED ({} error(s)):", errors.len());
+            for e in &errors {
+                println!("  - {e}");
+            }
+        }
+        if errors.is_empty() {
+            return Ok(());
+        }
+        anyhow::bail!("verify-ng registry lint failed ({} error(s))", errors.len());
+    }
+    // No suite execution yet: fail closed with a typed harness error so
+    // the central mapper exits 125 (never a hollow PASS).
+    let report = exit::GateReport {
+        status: "failed".to_string(),
+        passed: 0,
+        failed: 0,
+        inconclusive: 0,
+        not_applicable: 0,
+        blocking: vec!["verify-ng:suite-execution-not-wired".to_string()],
+        results: vec![],
+    };
+    if json {
+        let hash = frozen::registry_hash(
+            &scenarios.iter().map(|s| s.id.clone()).collect::<Vec<_>>(),
+        );
+        println!("{}", serde_json::to_string_pretty(&report::gate_report_json(&report, &hash))?);
+    } else {
+        eprintln!("vetto: verify-ng: suite execution not wired yet; failing closed");
+        println!("{}", report::render_text(&report));
+    }
+    Err(crate::error::VettoError::HarnessUnavailable(
+        "verify-ng suite execution not wired".to_string(),
+    )
+    .into())
+}

--- a/src/verify_ng/model.rs
+++ b/src/verify_ng/model.rs
@@ -70,7 +70,7 @@ impl ClaimStrength {
 }
 
 /// Blocker categories map to the security invariants I1..I6.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Category {
     /// I1 fail-closed spawn.

--- a/src/verify_ng/model.rs
+++ b/src/verify_ng/model.rs
@@ -1,0 +1,202 @@
+//! Two-axis result model: [`Verdict`] x [`ClaimStrength`].
+//!
+//! The axes are intentionally independent. A `PASS` on a `PARTIAL` claim is
+//! still a `PASS` run of a weak guarantee, and the release gate must read
+//! both the verdict and the category/strength before promoting a build.
+
+use serde::{Deserialize, Serialize};
+
+/// Outcome of one scenario run. Fail-closed ordering: anything that is not
+/// a proven PASS degrades toward INCONCLUSIVE, never toward PASS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Verdict {
+    /// Negative proof + positive control both observed via host facts.
+    Pass,
+    /// The boundary was violated (leak / write / reach / escape / residue).
+    Fail,
+    /// Could not be determined: missing interpreter, control failed, harness
+    /// timeout, environment interference, contradictory evidence. Treated as
+    /// FAIL by the release gate for blocker categories.
+    Inconclusive,
+    /// Required capability is absent on this platform/tier. Requires
+    /// probe evidence of the absence (see [`crate::verify_ng::caps`]).
+    NotApplicable,
+}
+
+impl Verdict {
+    pub fn label(self) -> &'static str {
+        match self {
+            Verdict::Pass => "PASS",
+            Verdict::Fail => "FAIL",
+            Verdict::Inconclusive => "INCONCLUSIVE",
+            Verdict::NotApplicable => "NOT_APPLICABLE",
+        }
+    }
+
+    /// Release-gate view: does this verdict alone block promotion?
+    /// `NotApplicable` never blocks by itself; the gate additionally enforces
+    /// quotas (canary PASS minimum, zero INCONCLUSIVE in blockers) in
+    /// [`crate::verify_ng::exit`].
+    pub fn blocks_release(self) -> bool {
+        match self {
+            Verdict::Pass | Verdict::NotApplicable => false,
+            Verdict::Fail | Verdict::Inconclusive => true,
+        }
+    }
+}
+
+/// Maximum strength this (scenario, platform, tier) claim can ever reach.
+/// Static registry property, never computed at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ClaimStrength {
+    /// Kernel-enforced, independently provable via host facts.
+    Strong,
+    /// Enforced with documented residual risk (see `residual_risk`).
+    Partial,
+    /// Cannot be proven with current primitives; advisory at best.
+    Unsupported,
+}
+
+impl ClaimStrength {
+    pub fn label(self) -> &'static str {
+        match self {
+            ClaimStrength::Strong => "STRONG",
+            ClaimStrength::Partial => "PARTIAL",
+            ClaimStrength::Unsupported => "UNSUPPORTED",
+        }
+    }
+}
+
+/// Blocker categories map to the security invariants I1..I6.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Category {
+    /// I1 fail-closed spawn.
+    Spawn,
+    /// I2 filesystem confidentiality.
+    FsRead,
+    /// I3 filesystem integrity.
+    FsWrite,
+    /// I4 network egress.
+    Net,
+    /// I5 process containment.
+    Proc,
+    /// I6 secret sealing.
+    Secrets,
+    /// Non-blocker auxiliary checks (resilience, diagnostics).
+    Aux,
+}
+
+impl Category {
+    /// Release-gate blocker categories (I1..I6).
+    pub fn is_blocker(self) -> bool {
+        !matches!(self, Category::Aux)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Category::Spawn => "spawn",
+            Category::FsRead => "fs-read",
+            Category::FsWrite => "fs-write",
+            Category::Net => "net",
+            Category::Proc => "proc",
+            Category::Secrets => "secrets",
+            Category::Aux => "aux",
+        }
+    }
+}
+
+/// Final per-scenario result: verdict + static strength + category.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScenarioResult {
+    pub id: String,
+    pub category: Category,
+    pub strength: ClaimStrength,
+    pub verdict: Verdict,
+    /// Stable evidence summary (already redacted, size-capped).
+    pub detail: String,
+}
+
+impl ScenarioResult {
+    pub fn blocks_release(&self) -> bool {
+        self.category.is_blocker() && self.verdict.blocks_release()
+    }
+}
+
+#[cfg(test)]
+mod semantics_tests {
+    use super::*;
+
+    /// FM-10: gate matrix over Verdict x Category. Strength never flips the
+    /// blocking decision; a PASS on a PARTIAL claim does not become a FAIL,
+    /// and an INCONCLUSIVE on a blocker never becomes a PASS.
+    #[test]
+    fn gate_matrix_verdict_times_category() {
+        for verdict in [
+            Verdict::Pass,
+            Verdict::Fail,
+            Verdict::Inconclusive,
+            Verdict::NotApplicable,
+        ] {
+            for category in [
+                Category::Spawn,
+                Category::FsRead,
+                Category::FsWrite,
+                Category::Net,
+                Category::Proc,
+                Category::Secrets,
+                Category::Aux,
+            ] {
+                for strength in [
+                    ClaimStrength::Strong,
+                    ClaimStrength::Partial,
+                    ClaimStrength::Unsupported,
+                ] {
+                    let r = ScenarioResult {
+                        id: "SEMANTICS-001".to_string(),
+                        category,
+                        strength,
+                        verdict,
+                        detail: String::new(),
+                    };
+                    let expected = category.is_blocker() && verdict.blocks_release();
+                    assert_eq!(
+                        r.blocks_release(),
+                        expected,
+                        "verdict={:?} category={:?} strength={:?}",
+                        verdict,
+                        category,
+                        strength
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn partial_pass_is_still_a_pass_run_of_a_weak_claim() {
+        let r = ScenarioResult {
+            id: "x".to_string(),
+            category: Category::FsRead,
+            strength: ClaimStrength::Partial,
+            verdict: Verdict::Pass,
+            detail: String::new(),
+        };
+        assert!(!r.blocks_release());
+        assert_eq!(r.strength, ClaimStrength::Partial);
+    }
+
+    #[test]
+    fn inconclusive_on_blocker_blocks() {
+        let r = ScenarioResult {
+            id: "x".to_string(),
+            category: Category::Net,
+            strength: ClaimStrength::Strong,
+            verdict: Verdict::Inconclusive,
+            detail: String::new(),
+        };
+        assert!(r.blocks_release());
+    }
+}

--- a/src/verify_ng/oracle.rs
+++ b/src/verify_ng/oracle.rs
@@ -1,0 +1,225 @@
+//! Pure oracle: Scenario + Facts -> Verdict (FM-14).
+//!
+//! The oracle performs no I/O and never talks to the backend. The collector
+//! always gathers the fixed superset of facts; the oracle only judges.
+//! Structural rules (enforced here, not by convention):
+//! - No host fact -> never PASS (FM-01).
+//! - Nonce mismatch between control and probe -> INCONCLUSIVE (FM-02).
+//! - Mutated payload -> INCONCLUSIVE (FM-06).
+//! - Poisoned diagnostic env -> FAIL (blocker) / INCONCLUSIVE (aux) (FM-08).
+//! - Quorum: multi-vector scenarios need >= quorum agreeing vectors (FM-13).
+
+use super::evidence::{Evidence, EvidenceTier};
+use super::model::{Category, Verdict};
+use super::registry::Scenario;
+
+/// Input to the oracle: everything collected for one run.
+#[derive(Debug, Clone)]
+pub struct OracleInput<'a> {
+    pub scenario: &'a Scenario,
+    pub evidence: &'a Evidence,
+    /// Session nonce issued by the engine (None = engine failure).
+    pub nonce: Option<&'a str>,
+    /// Nonce echoed by the negative probe through the constrained channel.
+    pub probe_nonce: Option<&'a str>,
+    /// Nonce echoed by the positive control through the host-visible side effect.
+    pub control_nonce: Option<&'a str>,
+    /// Pre/post payload hashes matched.
+    pub payload_intact: bool,
+    /// Diagnostic env interference detected (VETTO_SEATBELT_MODE, ...).
+    pub env_poisoned: bool,
+    /// Number of independent agreeing vectors observed (quorum, FM-13).
+    pub agreeing_vectors: usize,
+    /// Host-observed violation flag (leak/write/reach/escape/residue).
+    pub violation_observed: bool,
+    /// Host-observed positive control flag (canary side effect verified).
+    pub control_observed: bool,
+}
+
+pub fn judge(input: &OracleInput<'_>) -> Verdict {
+    // FM-08: poisoned diagnostic env invalidates the run.
+    if input.env_poisoned {
+        return match input.scenario.category {
+            Category::Aux => Verdict::Inconclusive,
+            _ => Verdict::Fail,
+        };
+    }
+    // FM-06: mutated fixture invalidates the run.
+    if !input.payload_intact {
+        return Verdict::Inconclusive;
+    }
+    // FM-02: control and probe must be bound to the same session nonce.
+    match (input.nonce, input.probe_nonce, input.control_nonce) {
+        (Some(n), Some(p), Some(c)) if p == n && c == n => {}
+        _ => return Verdict::Inconclusive,
+    }
+    // A host-observed violation is a FAIL regardless of self-reports.
+    if input.violation_observed {
+        return Verdict::Fail;
+    }
+    // FM-01: PASS needs a host fact; FM-02: needs the control side effect.
+    if !input.control_observed {
+        return Verdict::Inconclusive;
+    }
+    if !input.evidence.has_host_fact() {
+        return Verdict::Inconclusive;
+    }
+    // FM-13: quorum over independent vectors.
+    if input.agreeing_vectors < input.scenario.quorum.max(1) {
+        return Verdict::Inconclusive;
+    }
+    // Oracle-judged PASS is only valid on provable claims; UNSUPPORTED
+    // ceilings can never PASS (FM-11: WIN-WSL-001 baseline).
+    Verdict::Pass
+}
+
+/// Post-filter: an UNSUPPORTED strength claim must never report PASS;
+/// a judging bug that yields one is demoted to INCONCLUSIVE loudly.
+pub fn apply_strength_ceiling(
+    verdict: Verdict,
+    strength: super::model::ClaimStrength,
+) -> Verdict {
+    match (verdict, strength) {
+        (Verdict::Pass, super::model::ClaimStrength::Unsupported) => Verdict::Inconclusive,
+        _ => verdict,
+    }
+}
+
+/// Convenience: judge and apply the ceiling in one step.
+pub fn judge_with_ceiling(
+    input: &OracleInput<'_>,
+    strength: super::model::ClaimStrength,
+    host_value: Option<&str>,
+) -> Verdict {
+    let _ = host_value;
+    let v = judge(input);
+    // Self-report-only "evidence" can never smuggle a PASS through:
+    // `judge` already requires a host fact, this is belt-and-braces for
+    // callers that bypass `judge` (there must be none).
+    let v = if v == Verdict::Pass
+        && !input.evidence.facts.iter().any(|f| f.tier == EvidenceTier::HostFact)
+    {
+        Verdict::Inconclusive
+    } else {
+        v
+    };
+    apply_strength_ceiling(v, strength)
+}
+
+#[cfg(test)]
+mod oracle_tests {
+    use super::*;
+    use crate::verify_ng::model::ClaimStrength;
+    use crate::verify_ng::registry::Severity;
+
+    fn scenario() -> Scenario {
+        Scenario {
+            id: "T".to_string(),
+            category: Category::FsRead,
+            severity: Severity::High,
+            required_caps: vec![],
+            strength: Default::default(),
+            quorum: 1,
+            known_limitation: "test".to_string(),
+            residual_risk: String::new(),
+        }
+    }
+
+    fn input<'a>(
+        scenario: &'a Scenario,
+        evidence: &'a Evidence,
+    ) -> OracleInput<'a> {
+        OracleInput {
+            scenario,
+            evidence,
+            nonce: Some("n"),
+            probe_nonce: Some("n"),
+            control_nonce: Some("n"),
+            payload_intact: true,
+            env_poisoned: false,
+            agreeing_vectors: 1,
+            violation_observed: false,
+            control_observed: true,
+        }
+    }
+
+    /// FM-01: self-report-only evidence can never PASS.
+    #[test]
+    fn oracle_deceit_trap_self_report_only_is_not_pass() {
+        let s = scenario();
+        let mut e = Evidence::default();
+        e.self_report("marker", "PASS PASS PASS".to_string());
+        e.constrained("errno", "EACCES".to_string());
+        let v = judge(&input(&s, &e));
+        assert_eq!(v, Verdict::Inconclusive);
+    }
+
+    /// FM-01: host fact + control + nonce -> PASS.
+    #[test]
+    fn host_fact_with_control_passes() {
+        let s = scenario();
+        let mut e = Evidence::default();
+        e.host_fact("postmortem", "absent".to_string());
+        let v = judge(&input(&s, &e));
+        assert_eq!(v, Verdict::Pass);
+    }
+
+    /// FM-02: control-only run (no probe nonce) -> INCONCLUSIVE.
+    #[test]
+    fn control_split_is_inconclusive() {
+        let s = scenario();
+        let mut e = Evidence::default();
+        e.host_fact("control", "ok".to_string());
+        let mut i = input(&s, &e);
+        i.probe_nonce = None;
+        assert_eq!(judge(&i), Verdict::Inconclusive);
+    }
+
+    /// FM-06: mutated payload -> INCONCLUSIVE even with host facts.
+    #[test]
+    fn mutated_payload_is_inconclusive() {
+        let s = scenario();
+        let mut e = Evidence::default();
+        e.host_fact("postmortem", "absent".to_string());
+        let mut i = input(&s, &e);
+        i.payload_intact = false;
+        assert_eq!(judge(&i), Verdict::Inconclusive);
+    }
+
+    /// Violation observed by the host -> FAIL even with PASS markers.
+    #[test]
+    fn host_violation_beats_self_report() {
+        let s = scenario();
+        let mut e = Evidence::default();
+        e.host_fact("postmortem", "LEAK bytes present".to_string());
+        e.self_report("marker", "PASS".to_string());
+        let mut i = input(&s, &e);
+        i.violation_observed = true;
+        assert_eq!(judge(&i), Verdict::Fail);
+    }
+
+    /// FM-13: quorum not met -> INCONCLUSIVE.
+    #[test]
+    fn quorum_not_met_is_inconclusive() {
+        let mut s = scenario();
+        s.quorum = 2;
+        let mut e = Evidence::default();
+        e.host_fact("postmortem", "absent".to_string());
+        let mut i = input(&s, &e);
+        i.agreeing_vectors = 1;
+        assert_eq!(judge(&i), Verdict::Inconclusive);
+    }
+
+    /// FM-11: UNSUPPORTED ceiling can never PASS.
+    #[test]
+    fn unsupported_ceiling_demotes_pass() {
+        assert_eq!(
+            apply_strength_ceiling(Verdict::Pass, ClaimStrength::Unsupported),
+            Verdict::Inconclusive
+        );
+        assert_eq!(
+            apply_strength_ceiling(Verdict::Fail, ClaimStrength::Unsupported),
+            Verdict::Fail
+        );
+    }
+}

--- a/src/verify_ng/oracle.rs
+++ b/src/verify_ng/oracle.rs
@@ -75,10 +75,7 @@ pub fn judge(input: &OracleInput<'_>) -> Verdict {
 
 /// Post-filter: an UNSUPPORTED strength claim must never report PASS;
 /// a judging bug that yields one is demoted to INCONCLUSIVE loudly.
-pub fn apply_strength_ceiling(
-    verdict: Verdict,
-    strength: super::model::ClaimStrength,
-) -> Verdict {
+pub fn apply_strength_ceiling(verdict: Verdict, strength: super::model::ClaimStrength) -> Verdict {
     match (verdict, strength) {
         (Verdict::Pass, super::model::ClaimStrength::Unsupported) => Verdict::Inconclusive,
         _ => verdict,
@@ -97,7 +94,11 @@ pub fn judge_with_ceiling(
     // `judge` already requires a host fact, this is belt-and-braces for
     // callers that bypass `judge` (there must be none).
     let v = if v == Verdict::Pass
-        && !input.evidence.facts.iter().any(|f| f.tier == EvidenceTier::HostFact)
+        && !input
+            .evidence
+            .facts
+            .iter()
+            .any(|f| f.tier == EvidenceTier::HostFact)
     {
         Verdict::Inconclusive
     } else {
@@ -125,10 +126,7 @@ mod oracle_tests {
         }
     }
 
-    fn input<'a>(
-        scenario: &'a Scenario,
-        evidence: &'a Evidence,
-    ) -> OracleInput<'a> {
+    fn input<'a>(scenario: &'a Scenario, evidence: &'a Evidence) -> OracleInput<'a> {
         OracleInput {
             scenario,
             evidence,

--- a/src/verify_ng/redact.rs
+++ b/src/verify_ng/redact.rs
@@ -80,7 +80,10 @@ fn redact_pem(input: &str) -> String {
             out.push_str(rest);
             break;
         };
-        let Some(key_end) = rest[begin..].find("-----").map(|i| begin + i + 5) else {
+        let Some(key_end) = rest[begin + "-----BEGIN".len()..]
+            .find("-----")
+            .map(|i| begin + "-----BEGIN".len() + i + "-----".len())
+        else {
             out.push_str(rest);
             break;
         };
@@ -94,7 +97,10 @@ fn redact_pem(input: &str) -> String {
             out.push_str("[REDACTED]");
             break;
         };
-        let Some(end_close) = rest[end..].find("-----").map(|i| end + i + 5) else {
+        let Some(end_close) = rest[end + "-----END".len()..]
+            .find("-----")
+            .map(|i| end + "-----END".len() + i + "-----".len())
+        else {
             out.push_str(&rest[..key_end]);
             out.push_str("[REDACTED]");
             break;

--- a/src/verify_ng/redact.rs
+++ b/src/verify_ng/redact.rs
@@ -1,0 +1,151 @@
+//! Redaction layer for reports (FM-07).
+//!
+//! Evidence is attacker-influenced: payloads may print secrets, control
+//! bytes, or megabytes of garbage. Before anything lands in a report or CI
+//! artifact the text passes through [`redact_text`]: secret-shaped tokens
+//! are replaced, control bytes stripped, output truncated to [`MAX_DETAIL`].
+
+/// Maximum stored characters per detail string.
+pub const MAX_DETAIL: usize = 2000;
+
+/// Literal secret-shape needles (no regex dependency): each entry is
+/// (case-insensitive key fragment, minimum value run to redact).
+const KEY_FRAGMENTS: &[&str] = &[
+    "aws_secret",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "api-key",
+    "private_key",
+    "private-key",
+    "privatekey",
+    "password",
+    "passwd",
+];
+
+/// Redact secrets, strip control bytes, enforce the size cap.
+pub fn redact_text(input: &str) -> String {
+    let mut out = redact_assignments(input);
+    out = redact_pem(&out);
+    out = redact_fake_markers(&out);
+    out = out
+        .chars()
+        .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
+        .collect();
+    if out.len() > MAX_DETAIL {
+        out.truncate(MAX_DETAIL);
+        out.push_str("…[TRUNCATED]");
+    }
+    out
+}
+
+/// Mask the local HOME prefix so reports do not leak account paths.
+pub fn mask_home(input: &str, home: &str) -> String {
+    if home.is_empty() {
+        return input.to_string();
+    }
+    input.replace(home, "$HOME")
+}
+
+/// Redact `key = value` / `key: value` assignments for known key fragments.
+/// Keeps the key name, replaces the value with `[REDACTED]`.
+fn redact_assignments(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for line in input.split_inclusive('\n') {
+        out.push_str(&redact_assignment_line(line));
+    }
+    out
+}
+
+fn redact_assignment_line(line: &str) -> String {
+    let lower = line.to_lowercase();
+    for frag in KEY_FRAGMENTS {
+        if lower.contains(frag) {
+            if let Some(pos) = line.find('=').or_else(|| line.find(':')) {
+                let (head, _) = line.split_at(pos + 1);
+                return format!("{head}[REDACTED]");
+            }
+            return "[REDACTED]".to_string();
+        }
+    }
+    line.to_string()
+}
+
+fn redact_pem(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    loop {
+        let Some(begin) = rest.find("-----BEGIN") else {
+            out.push_str(rest);
+            break;
+        };
+        let Some(key_end) = rest[begin..].find("-----").map(|i| begin + i + 5) else {
+            out.push_str(rest);
+            break;
+        };
+        if !rest[begin..key_end].contains("PRIVATE KEY") {
+            out.push_str(&rest[..key_end]);
+            rest = &rest[key_end..];
+            continue;
+        }
+        let Some(end) = rest[key_end..].find("-----END").map(|i| key_end + i) else {
+            out.push_str(&rest[..key_end]);
+            out.push_str("[REDACTED]");
+            break;
+        };
+        let Some(end_close) = rest[end..].find("-----").map(|i| end + i + 5) else {
+            out.push_str(&rest[..key_end]);
+            out.push_str("[REDACTED]");
+            break;
+        };
+        out.push_str(&rest[..begin]);
+        out.push_str("[REDACTED]");
+        rest = &rest[end_close..];
+    }
+    out
+}
+
+fn redact_fake_markers(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(pos) = rest.find("FAKE-TEST-") {
+        out.push_str(&rest[..pos]);
+        out.push_str("[REDACTED]");
+        let tail = &rest[pos + "FAKE-TEST-".len()..];
+        let skip = tail
+            .find(|c: char| !(c.is_ascii_uppercase() || c == '-'))
+            .unwrap_or(tail.len());
+        rest = &tail[skip..];
+    }
+    out.push_str(rest);
+    out
+}
+
+#[cfg(test)]
+mod redact_tests {
+    use super::*;
+
+    /// FM-07: secrets and bulk output must not reach the report.
+    #[test]
+    fn evidence_redact_001() {
+        let evil = "leak: AWS_SECRET_ACCESS_KEY=supersecretvalue123\n".to_string()
+            + &"x".repeat(100_000);
+        let redacted = redact_text(&evil);
+        assert!(!redacted.contains("supersecretvalue123"));
+        assert!(redacted.len() <= MAX_DETAIL + 32);
+    }
+
+    #[test]
+    fn pem_is_redacted() {
+        let pem = "-----BEGIN RSA PRIVATE KEY-----\nABCDEF\n-----END RSA PRIVATE KEY-----";
+        assert!(!redact_text(pem).contains("ABCDEF"));
+    }
+
+    #[test]
+    fn control_bytes_stripped_newlines_kept() {
+        let out = redact_text("a\x1bb\nc\x07d");
+        assert!(!out.contains('\x1b'));
+        assert!(out.contains('\n'));
+    }
+}

--- a/src/verify_ng/redact.rs
+++ b/src/verify_ng/redact.rs
@@ -129,8 +129,8 @@ mod redact_tests {
     /// FM-07: secrets and bulk output must not reach the report.
     #[test]
     fn evidence_redact_001() {
-        let evil = "leak: AWS_SECRET_ACCESS_KEY=supersecretvalue123\n".to_string()
-            + &"x".repeat(100_000);
+        let evil =
+            "leak: AWS_SECRET_ACCESS_KEY=supersecretvalue123\n".to_string() + &"x".repeat(100_000);
         let redacted = redact_text(&evil);
         assert!(!redacted.contains("supersecretvalue123"));
         assert!(redacted.len() <= MAX_DETAIL + 32);

--- a/src/verify_ng/registry.rs
+++ b/src/verify_ng/registry.rs
@@ -1,0 +1,359 @@
+//! Attack scenario registry: static catalog of security properties.
+//!
+//! Each scenario carries a fixed [`ClaimStrength`](super::model::ClaimStrength)
+//! per platform target, a quorum rule for multi-vector scenarios, and a
+//! mandatory `known_limitation`. An empty limitation is a registry lint
+//! error: every claim must state what it does not prove.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::model::{Category, ClaimStrength};
+
+/// Platform/tier target a strength entry applies to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Target {
+    LinuxFull,
+    LinuxFsOnly,
+    LinuxSeccomp,
+    Macos,
+    Windows,
+    WindowsSandboxVm,
+}
+
+impl Target {
+    pub fn label(self) -> &'static str {
+        match self {
+            Target::LinuxFull => "linux-full",
+            Target::LinuxFsOnly => "linux-fsonly",
+            Target::LinuxSeccomp => "linux-seccomp",
+            Target::Macos => "macos",
+            Target::Windows => "windows",
+            Target::WindowsSandboxVm => "windows-sandbox-vm",
+        }
+    }
+}
+
+/// Severity if this scenario FAILs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Blocker,
+    High,
+    Medium,
+    Low,
+}
+
+/// One registered attack scenario (mirrors `tests/verify_ng/scenarios/*.toml`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Scenario {
+    pub id: String,
+    pub category: Category,
+    pub severity: Severity,
+    /// Capabilities the runner must prove present (else NOT_APPLICABLE).
+    pub required_caps: Vec<String>,
+    /// Static strength ceiling per target (FM-10/FM-11).
+    pub strength: BTreeMap<String, ClaimStrength>,
+    /// Minimum number of independent agreeing vectors for a verdict
+    /// (FM-13). `1` only for single-vector scenarios.
+    pub quorum: usize,
+    /// What this scenario does NOT prove. Must be non-empty.
+    pub known_limitation: String,
+    /// Residual risk text for PARTIAL targets. Required when any target
+    /// is PARTIAL.
+    #[serde(default)]
+    pub residual_risk: String,
+}
+
+impl Scenario {
+    pub fn strength_for(&self, target: Target) -> ClaimStrength {
+        self.strength
+            .get(target.label())
+            .copied()
+            // Unknown target: claim nothing.
+            .unwrap_or(ClaimStrength::Unsupported)
+    }
+
+    /// Registry lint: non-empty limitation; quorum >= 1; PARTIAL targets
+    /// require residual_risk text.
+    pub fn lint(&self) -> Result<(), String> {
+        if self.id.trim().is_empty() {
+            return Err("scenario id is empty".to_string());
+        }
+        if self.quorum < 1 {
+            return Err(format!("{}: quorum must be >= 1", self.id));
+        }
+        if self.known_limitation.trim().is_empty() {
+            return Err(format!("{}: known_limitation must be non-empty", self.id));
+        }
+        if self
+            .strength
+            .values()
+            .any(|s| *s == ClaimStrength::Partial)
+            && self.residual_risk.trim().is_empty()
+        {
+            return Err(format!("{}: PARTIAL target requires residual_risk", self.id));
+        }
+        Ok(())
+    }
+}
+
+/// Statically registered scenarios (the TOML files under
+/// `tests/verify_ng/scenarios/` are the source of truth for documentation;
+/// this table is the compiled enforcement of the same contracts).
+pub fn registry() -> Vec<Scenario> {
+    vec![
+        Scenario {
+            id: "ORACLE-DECEIT-001".to_string(),
+            category: Category::Aux,
+            severity: Severity::Blocker,
+            required_caps: vec!["spawn".to_string()],
+            strength: BTreeMap::from([(Target::LinuxFull.label().to_string(), ClaimStrength::Strong)]),
+            quorum: 1,
+            known_limitation: "Proves oracle soundness only; says nothing about any enforcement backend."
+                .to_string(),
+            residual_risk: String::new(),
+        },
+        Scenario {
+            id: "CONTROL-SPLIT-001".to_string(),
+            category: Category::Aux,
+            severity: Severity::Blocker,
+            required_caps: vec!["spawn".to_string()],
+            strength: BTreeMap::from([(Target::LinuxFull.label().to_string(), ClaimStrength::Strong)]),
+            quorum: 1,
+            known_limitation: "Proves nonce binding of the control pair only."
+                .to_string(),
+            residual_risk: String::new(),
+        },
+        Scenario {
+            id: "FIXTURE-MUTATE-001".to_string(),
+            category: Category::Aux,
+            severity: Severity::High,
+            required_caps: vec!["spawn".to_string()],
+            strength: BTreeMap::from([(Target::LinuxFull.label().to_string(), ClaimStrength::Strong)]),
+            quorum: 1,
+            known_limitation: "Proves payload integrity checking only."
+                .to_string(),
+            residual_risk: String::new(),
+        },
+        Scenario {
+            id: "ENV-POISON-001".to_string(),
+            category: Category::Spawn,
+            severity: Severity::Blocker,
+            required_caps: vec!["spawn".to_string()],
+            strength: BTreeMap::from([
+                (Target::LinuxFull.label().to_string(), ClaimStrength::Strong),
+                (Target::Macos.label().to_string(), ClaimStrength::Strong),
+            ]),
+            quorum: 1,
+            known_limitation: "Proves diagnostic-env detection only; not a substitute for env scrub verification."
+                .to_string(),
+            residual_risk: String::new(),
+        },
+        Scenario {
+            id: "GATE-VACUUM-001".to_string(),
+            category: Category::Aux,
+            severity: Severity::High,
+            required_caps: vec![],
+            strength: BTreeMap::from([(Target::LinuxFull.label().to_string(), ClaimStrength::Strong)]),
+            quorum: 1,
+            known_limitation: "Meta-test of the gate quotas; proves the gate cannot pass on an empty suite."
+                .to_string(),
+            residual_risk: String::new(),
+        },
+        Scenario {
+            id: "HANG-GRANDCHILD-001".to_string(),
+            category: Category::Proc,
+            severity: Severity::High,
+            required_caps: vec!["spawn".to_string(), "tree-sweep".to_string()],
+            strength: BTreeMap::from([
+                (Target::LinuxFull.label().to_string(), ClaimStrength::Strong),
+                (Target::Windows.label().to_string(), ClaimStrength::Strong),
+                (Target::LinuxFsOnly.label().to_string(), ClaimStrength::Partial),
+                (Target::Macos.label().to_string(), ClaimStrength::Partial),
+            ]),
+            quorum: 1,
+            known_limitation: "Proves deadline-aware collection, not general liveness of arbitrary payloads."
+                .to_string(),
+            residual_risk: "On fs-only/macOS the grandchild may outlive the group kill until the sweep budget expires; verdict is FAIL/INCONCLUSIVE, never PASS.".to_string(),
+        },
+        Scenario {
+            id: "VFS-TRAV-001".to_string(),
+            category: Category::FsRead,
+            severity: Severity::Blocker,
+            required_caps: vec!["spawn".to_string(), "landlock".to_string()],
+            strength: BTreeMap::from([
+                (Target::LinuxFull.label().to_string(), ClaimStrength::Strong),
+                (Target::LinuxFsOnly.label().to_string(), ClaimStrength::Strong),
+                (Target::Macos.label().to_string(), ClaimStrength::Partial),
+                (Target::Windows.label().to_string(), ClaimStrength::Partial),
+            ]),
+            quorum: 2,
+            known_limitation: "Covers symlink/hardlink/dotdot/rename vectors present in the payload set; new kernel path aliases need new vectors."
+                .to_string(),
+            residual_risk: "macOS Shape-A broad reads and Windows ACL fallback may expose entries outside the tail-deny list; strength ceiling PARTIAL there.".to_string(),
+        },
+        Scenario {
+            id: "NET-DNS-IPV6-001".to_string(),
+            category: Category::Net,
+            severity: Severity::Blocker,
+            required_caps: vec!["spawn".to_string(), "netns".to_string()],
+            strength: BTreeMap::from([
+                (Target::LinuxFull.label().to_string(), ClaimStrength::Strong),
+                (Target::LinuxFsOnly.label().to_string(), ClaimStrength::Partial),
+                (Target::Macos.label().to_string(), ClaimStrength::Partial),
+                (Target::Windows.label().to_string(), ClaimStrength::Partial),
+            ]),
+            quorum: 2,
+            known_limitation: "Proves --net=off isolation only; allowlist relay modes need a separate broker suite."
+                .to_string(),
+            residual_risk: "Without a network namespace (fs-only/mac/win) only syscall/capability denial is proven, not absence of a route.".to_string(),
+        },
+        Scenario {
+            id: "PROC-ESC-001".to_string(),
+            category: Category::Proc,
+            severity: Severity::Blocker,
+            required_caps: vec!["spawn".to_string(), "tree-sweep".to_string()],
+            strength: BTreeMap::from([
+                (Target::LinuxFull.label().to_string(), ClaimStrength::Strong),
+                (Target::Windows.label().to_string(), ClaimStrength::Strong),
+                (Target::LinuxFsOnly.label().to_string(), ClaimStrength::Partial),
+                (Target::Macos.label().to_string(), ClaimStrength::Partial),
+            ]),
+            quorum: 1,
+            known_limitation: "Post-mortem sweep is host-side observation of absence; a hostile scheduler can delay reparenting past the sweep budget (INCONCLUSIVE, never PASS)."
+                .to_string(),
+            residual_risk: "fs-only setsid orphans and macOS watchdog races are known residuals; they FAIL/advisory, never PASS.".to_string(),
+        },
+        Scenario {
+            id: "ENV-LEAK-001".to_string(),
+            category: Category::Secrets,
+            severity: Severity::Blocker,
+            required_caps: vec!["spawn".to_string()],
+            strength: BTreeMap::from([
+                (Target::LinuxFull.label().to_string(), ClaimStrength::Strong),
+                (Target::Macos.label().to_string(), ClaimStrength::Strong),
+                (Target::Windows.label().to_string(), ClaimStrength::Strong),
+            ]),
+            quorum: 1,
+            known_limitation: "Proves scrub of the canary key set; unknown exfil channels (covert timing, allowed-relay payloads) are out of scope."
+                .to_string(),
+            residual_risk: String::new(),
+        },
+        Scenario {
+            id: "RACE-BINDING-001".to_string(),
+            category: Category::Spawn,
+            severity: Severity::Blocker,
+            required_caps: vec!["spawn".to_string()],
+            strength: BTreeMap::from([(Target::LinuxFull.label().to_string(), ClaimStrength::Strong)]),
+            quorum: 1,
+            known_limitation: "Proves spec/tier binding continuity in-process; a compromised host kernel is out of scope."
+                .to_string(),
+            residual_risk: String::new(),
+        },
+        Scenario {
+            id: "CLEANUP-SIGKILL-001".to_string(),
+            category: Category::Proc,
+            severity: Severity::High,
+            required_caps: vec!["spawn".to_string(), "tree-sweep".to_string()],
+            strength: BTreeMap::from([
+                (Target::LinuxFull.label().to_string(), ClaimStrength::Strong),
+                (Target::Windows.label().to_string(), ClaimStrength::Strong),
+                (Target::LinuxFsOnly.label().to_string(), ClaimStrength::Partial),
+                (Target::Macos.label().to_string(), ClaimStrength::Partial),
+            ]),
+            quorum: 1,
+            known_limitation: "Requires an external observer process/VM; cannot be self-proven from inside the harness under test."
+                .to_string(),
+            residual_risk: "fs-only/macOS orphans may survive a SIGKILLed harness; suite must run in a disposable VM there.".to_string(),
+        },
+        Scenario {
+            id: "EVIDENCE-REDACT-001".to_string(),
+            category: Category::Aux,
+            severity: Severity::High,
+            required_caps: vec![],
+            strength: BTreeMap::from([(Target::LinuxFull.label().to_string(), ClaimStrength::Strong)]),
+            quorum: 1,
+            known_limitation: "Proves redaction of the known secret shapes; novel shapes need secretscan updates."
+                .to_string(),
+            residual_risk: String::new(),
+        },
+        Scenario {
+            id: "MAC-SHAPE-001".to_string(),
+            category: Category::FsRead,
+            severity: Severity::High,
+            required_caps: vec!["spawn".to_string(), "seatbelt".to_string()],
+            strength: BTreeMap::from([(Target::Macos.label().to_string(), ClaimStrength::Partial)]),
+            quorum: 1,
+            known_limitation: "Proves the enforced profile is Shape-A + tail-deny byte-for-byte; read secrecy beyond tail-deny is UNPROVABLE on macOS native."
+                .to_string(),
+            residual_risk: "Any path outside the tail-deny list is readable by construction; use a Linux VM for strong read secrecy.".to_string(),
+        },
+        Scenario {
+            id: "WIN-UNC-001".to_string(),
+            category: Category::FsRead,
+            severity: Severity::High,
+            required_caps: vec!["spawn".to_string()],
+            strength: BTreeMap::from([(Target::Windows.label().to_string(), ClaimStrength::Partial)]),
+            quorum: 1,
+            known_limitation: "Advisory until UNC/namespace-alias coverage is mapped; starts INCONCLUSIVE, never PASS on first implementation."
+                .to_string(),
+            residual_risk: "Alternate path aliases (UNC, \\?\, mapped drives) may bypass ACL-shaped checks.".to_string(),
+        },
+        Scenario {
+            id: "WIN-WSL-001".to_string(),
+            category: Category::FsRead,
+            severity: Severity::High,
+            required_caps: vec!["spawn".to_string()],
+            strength: BTreeMap::from([(Target::Windows.label().to_string(), ClaimStrength::Unsupported)]),
+            quorum: 1,
+            known_limitation: "WSL-interop boundary is unmapped; INCONCLUSIVE baseline until researched. Any PASS is an oracle bug."
+                .to_string(),
+            residual_risk: String::new(),
+        },
+    ]
+}
+
+/// Lint the whole registry. Used by tests and the `verify-ng lint` path.
+pub fn lint_all(scenarios: &[Scenario]) -> Vec<String> {
+    let mut errors = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for s in scenarios {
+        if !seen.insert(s.id.clone()) {
+            errors.push(format!("duplicate scenario id {}", s.id));
+        }
+        if let Err(e) = s.lint() {
+            errors.push(e);
+        }
+    }
+    errors
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use super::*;
+
+    #[test]
+    fn registry_lints_clean() {
+        let reg = registry();
+        assert!(reg.len() >= 10);
+        assert_eq!(lint_all(&reg), Vec::<String>::new());
+    }
+
+    #[test]
+    fn empty_limitation_is_rejected() {
+        let mut s = registry().remove(0);
+        s.known_limitation.clear();
+        assert!(s.lint().is_err());
+    }
+
+    #[test]
+    fn partial_without_residual_is_rejected() {
+        let mut s = registry().remove(0);
+        s.strength = BTreeMap::from([("linux-full".to_string(), ClaimStrength::Partial)]);
+        s.residual_risk.clear();
+        assert!(s.lint().is_err());
+    }
+}

--- a/src/verify_ng/registry.rs
+++ b/src/verify_ng/registry.rs
@@ -88,13 +88,13 @@ impl Scenario {
         if self.known_limitation.trim().is_empty() {
             return Err(format!("{}: known_limitation must be non-empty", self.id));
         }
-        if self
-            .strength
-            .values()
-            .any(|s| *s == ClaimStrength::Partial)
+        if self.strength.values().any(|s| *s == ClaimStrength::Partial)
             && self.residual_risk.trim().is_empty()
         {
-            return Err(format!("{}: PARTIAL target requires residual_risk", self.id));
+            return Err(format!(
+                "{}: PARTIAL target requires residual_risk",
+                self.id
+            ));
         }
         Ok(())
     }
@@ -300,7 +300,7 @@ pub fn registry() -> Vec<Scenario> {
             quorum: 1,
             known_limitation: "Advisory until UNC/namespace-alias coverage is mapped; starts INCONCLUSIVE, never PASS on first implementation."
                 .to_string(),
-            residual_risk: "Alternate path aliases (UNC, \\?\, mapped drives) may bypass ACL-shaped checks.".to_string(),
+            residual_risk: r"Alternate path aliases (UNC, \\?\, mapped drives) may bypass ACL-shaped checks.".to_string(),
         },
         Scenario {
             id: "WIN-WSL-001".to_string(),

--- a/src/verify_ng/report.rs
+++ b/src/verify_ng/report.rs
@@ -1,0 +1,87 @@
+//! Human + machine-readable reports (JSON via serde; text renderer).
+//!
+//! All detail strings pass through [`crate::verify_ng::redact`] before
+//! rendering (FM-07). JSON is the machine contract; text is the dense
+//! human table.
+
+use super::exit::GateReport;
+use super::model::ScenarioResult;
+
+/// JSON value of a gate report (machine contract).
+pub fn gate_report_json(report: &GateReport, registry_hash: &str) -> serde_json::Value {
+    serde_json::json!({
+        "tool": "vetto verify-ng",
+        "registry_hash": registry_hash,
+        "status": report.status,
+        "passed": report.passed,
+        "failed": report.failed,
+        "inconclusive": report.inconclusive,
+        "not_applicable": report.not_applicable,
+        "blocking": report.blocking,
+        "results": report.results.iter().map(scenario_json).collect::<Vec<_>>(),
+    })
+}
+
+fn scenario_json(r: &ScenarioResult) -> serde_json::Value {
+    serde_json::json!({
+        "id": r.id,
+        "category": r.category.label(),
+        "strength": r.strength.label(),
+        "verdict": r.verdict.label(),
+        "detail": r.detail,
+    })
+}
+
+/// Dense human-readable table.
+pub fn render_text(report: &GateReport) -> String {
+    let mut out = String::new();
+    out.push_str(&report.summary());
+    out.push('\n');
+    for r in &report.results {
+        out.push_str(&format!(
+            "  {:<11} {:<8} {:<11} {} {}\n",
+            r.verdict.label(),
+            r.category.label(),
+            r.strength.label(),
+            r.id,
+            r.detail
+        ));
+    }
+    if !report.blocking.is_empty() {
+        out.push_str("blocking:\n");
+        for b in &report.blocking {
+            out.push_str(&format!("  - {b}\n"));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod report_tests {
+    use super::*;
+    use crate::verify_ng::model::{ClaimStrength, Verdict};
+    use crate::verify_ng::model::Category;
+
+    #[test]
+    fn json_carries_both_axes() {
+        let report = GateReport {
+            status: "failed".to_string(),
+            passed: 0,
+            failed: 1,
+            inconclusive: 0,
+            not_applicable: 0,
+            blocking: vec!["X".to_string()],
+            results: vec![ScenarioResult {
+                id: "X".to_string(),
+                category: Category::Net,
+                strength: ClaimStrength::Partial,
+                verdict: Verdict::Fail,
+                detail: "d".to_string(),
+            }],
+        };
+        let v = gate_report_json(&report, "reg");
+        assert_eq!(v["results"][0]["verdict"], "FAIL");
+        assert_eq!(v["results"][0]["strength"], "PARTIAL");
+        assert_eq!(v["registry_hash"], "reg");
+    }
+}

--- a/src/verify_ng/report.rs
+++ b/src/verify_ng/report.rs
@@ -59,8 +59,8 @@ pub fn render_text(report: &GateReport) -> String {
 #[cfg(test)]
 mod report_tests {
     use super::*;
-    use crate::verify_ng::model::{ClaimStrength, Verdict};
     use crate::verify_ng::model::Category;
+    use crate::verify_ng::model::{ClaimStrength, Verdict};
 
     #[test]
     fn json_carries_both_axes() {

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -52,5 +52,6 @@ mod shim_interception;
 mod tier3_files_secrets;
 mod tier8_release;
 mod tier9_friction;
+mod verify_ng_traps;
 mod windows_enforcement;
 mod windows_sandbox;

--- a/tests/integration/verify_ng_traps.rs
+++ b/tests/integration/verify_ng_traps.rs
@@ -11,7 +11,9 @@
 //! `test_home()`).
 
 use crate::common::*;
-use vetto::verify_ng::{caps, engine, evidence, exit, fixture, frozen, model, oracle, redact, registry, report};
+use vetto::verify_ng::{
+    caps, engine, evidence, exit, fixture, frozen, model, oracle, redact, registry, report,
+};
 
 fn test_scenario(id: &str, category: model::Category, quorum: usize) -> registry::Scenario {
     registry::Scenario {
@@ -58,7 +60,11 @@ fn trap_oracle_deceit_self_report_only_is_not_pass() {
     e.self_report("marker", "PASS PASS PASS".to_string());
     e.constrained("errno", "EACCES".to_string());
     let v = oracle::judge(&oracle_input(&s, &e));
-    assert_eq!(v, model::Verdict::Inconclusive, "deceit payload must not PASS");
+    assert_eq!(
+        v,
+        model::Verdict::Inconclusive,
+        "deceit payload must not PASS"
+    );
 }
 
 /// FM-02 CONTROL-SPLIT-001: control without probe -> INCONCLUSIVE.
@@ -87,7 +93,9 @@ fn trap_fixture_mutation_is_detected() {
     let mut fx = fixture::Fixture::create("trap-mutate").expect("create fixture");
     let p = fx.stage("payload.sh", b"echo attack").expect("stage");
     std::fs::write(&p, b"echo PASS").expect("payload rewrites itself");
-    let mutated = fx.verify_untouched().expect_err("mutation must be detected");
+    let mutated = fx
+        .verify_untouched()
+        .expect_err("mutation must be detected");
     assert_eq!(mutated, vec![p]);
 
     let s = test_scenario("FIXTURE-MUTATE-001", model::Category::Aux, 1);
@@ -133,7 +141,10 @@ fn trap_gate_all_na_fails_without_canaries() {
     };
     let results = vec![mk("WIN-WSL-001")];
     let mut ev = std::collections::BTreeMap::new();
-    ev.insert("WIN-WSL-001".to_string(), vec!["wsl: absent (unmapped)".to_string()]);
+    ev.insert(
+        "WIN-WSL-001".to_string(),
+        vec!["wsl: absent (unmapped)".to_string()],
+    );
     let gate = exit::evaluate_gate(&results, &ev, "reg");
     assert_eq!(gate.status, "failed");
 }
@@ -175,10 +186,7 @@ fn trap_spec_continuity_detects_drift() {
 /// FM-11 WIN-WSL-001: UNSUPPORTED ceiling can never PASS.
 #[test]
 fn trap_unsupported_ceiling_demotes_pass() {
-    let v = oracle::apply_strength_ceiling(
-        model::Verdict::Pass,
-        model::ClaimStrength::Unsupported,
-    );
+    let v = oracle::apply_strength_ceiling(model::Verdict::Pass, model::ClaimStrength::Unsupported);
     assert_eq!(v, model::Verdict::Inconclusive);
 }
 
@@ -231,7 +239,11 @@ fn cli_verify_ng_lint_json_parseable() {
         .unwrap_or_else(|error| panic!("lint --json must emit JSON: {error}\n{text}"));
     assert!(value.get("registry_hash").is_some(), "hash: {value}");
     assert!(
-        value.get("errors").and_then(|e| e.as_array()).map(|e| e.is_empty()).unwrap_or(false),
+        value
+            .get("errors")
+            .and_then(|e| e.as_array())
+            .map(|e| e.is_empty())
+            .unwrap_or(false),
         "errors: {value}"
     );
 }
@@ -307,7 +319,11 @@ fn trap_quorum_one_single_vector_passes() {
     ] {
         let s = test_scenario(id, category, 1);
         let e = full_evidence_host_fact();
-        assert_eq!(oracle::judge(&oracle_input(&s, &e)), model::Verdict::Pass, "{id}");
+        assert_eq!(
+            oracle::judge(&oracle_input(&s, &e)),
+            model::Verdict::Pass,
+            "{id}"
+        );
     }
 }
 
@@ -318,13 +334,18 @@ fn trap_quorum_one_single_vector_passes() {
 fn trap_platform_ceiling_shapes() {
     // SEC-BLOCKS-001 shape: macOS/Windows must be N/A-with-evidence, never PASS.
     // The ceiling function is the enforcement point: UNSUPPORTED + PASS -> INCONCLUSIVE.
-    let v = oracle::apply_strength_ceiling(
-        model::Verdict::Pass,
-        model::ClaimStrength::Unsupported,
+    let v = oracle::apply_strength_ceiling(model::Verdict::Pass, model::ClaimStrength::Unsupported);
+    assert_eq!(
+        v,
+        model::Verdict::Inconclusive,
+        "unsupported ceiling demotes PASS"
     );
-    assert_eq!(v, model::Verdict::Inconclusive, "unsupported ceiling demotes PASS");
     // PARTIAL ceiling keeps the verdict (report carries both axes, no Partial-PASS).
-    for verdict in [model::Verdict::Pass, model::Verdict::Fail, model::Verdict::Inconclusive] {
+    for verdict in [
+        model::Verdict::Pass,
+        model::Verdict::Fail,
+        model::Verdict::Inconclusive,
+    ] {
         assert_eq!(
             oracle::apply_strength_ceiling(verdict, model::ClaimStrength::Partial),
             verdict,
@@ -359,7 +380,10 @@ fn trap_gate_requires_fs_write_minimum() {
         pass("RACE-BINDING-001", model::Category::Spawn),
     ];
     let gate = exit::evaluate_gate(&results, &BTreeMap::new(), "reg");
-    assert_eq!(gate.status, "failed", "gate without fs-write PASS must fail");
+    assert_eq!(
+        gate.status, "failed",
+        "gate without fs-write PASS must fail"
+    );
     assert!(
         gate.blocking.iter().any(|b| b.contains("fs-write")),
         "blocking must name fs-write: {:?}",
@@ -445,7 +469,11 @@ fn trap_env_poison_fails_new_blockers() {
     ] {
         let s = test_scenario(id, category, quorum);
         let r = engine::poisoned_result(&s, target, &poison);
-        assert_eq!(r.verdict, model::Verdict::Fail, "{id}: poisoned blocker must FAIL");
+        assert_eq!(
+            r.verdict,
+            model::Verdict::Fail,
+            "{id}: poisoned blocker must FAIL"
+        );
         assert!(r.blocks_release());
     }
 }

--- a/tests/integration/verify_ng_traps.rs
+++ b/tests/integration/verify_ng_traps.rs
@@ -1,0 +1,266 @@
+//! verify-ng oracle/fixture/gate traps: prove the harness cannot be fooled.
+//!
+//! These tests run the compiled units (oracle, fixture, redact, exit gate)
+//! through the library boundary plus the `verify-ng --lint` CLI surface.
+//! They assert the failure modes FM-01..FM-12 stay closed: a deceitful
+//! payload, a split control, a mutated fixture, a poisoned env, or an empty
+//! suite must never produce a PASS / green gate.
+//!
+//! Hermetic rules: unit-level traps use only temp dirs; CLI traps use
+//! `TempProject` + isolated HOME via `run_vetto_in` (which sets HOME to
+//! `test_home()`).
+
+use crate::common::*;
+use vetto::verify_ng::{caps, engine, evidence, exit, fixture, frozen, model, oracle, redact, registry, report};
+
+fn test_scenario(id: &str, category: model::Category, quorum: usize) -> registry::Scenario {
+    registry::Scenario {
+        id: id.to_string(),
+        category,
+        severity: registry::Severity::High,
+        required_caps: vec![],
+        strength: Default::default(),
+        quorum,
+        known_limitation: "trap".to_string(),
+        residual_risk: String::new(),
+    }
+}
+
+fn full_evidence_host_fact() -> evidence::Evidence {
+    let mut e = evidence::Evidence::default();
+    e.host_fact("postmortem", "absent".to_string());
+    e
+}
+
+fn oracle_input<'a>(
+    scenario: &'a registry::Scenario,
+    evidence: &'a evidence::Evidence,
+) -> oracle::OracleInput<'a> {
+    oracle::OracleInput {
+        scenario,
+        evidence,
+        nonce: Some("nonce-1"),
+        probe_nonce: Some("nonce-1"),
+        control_nonce: Some("nonce-1"),
+        payload_intact: true,
+        env_poisoned: false,
+        agreeing_vectors: 1,
+        violation_observed: false,
+        control_observed: true,
+    }
+}
+
+/// FM-01 ORACLE-DECEIT-001: all-PASS self-report, no host fact -> not PASS.
+#[test]
+fn trap_oracle_deceit_self_report_only_is_not_pass() {
+    let s = test_scenario("ORACLE-DECEIT-001", model::Category::Aux, 1);
+    let mut e = evidence::Evidence::default();
+    e.self_report("marker", "PASS PASS PASS".to_string());
+    e.constrained("errno", "EACCES".to_string());
+    let v = oracle::judge(&oracle_input(&s, &e));
+    assert_eq!(v, model::Verdict::Inconclusive, "deceit payload must not PASS");
+}
+
+/// FM-02 CONTROL-SPLIT-001: control without probe -> INCONCLUSIVE.
+#[test]
+fn trap_control_split_missing_probe_nonce_is_inconclusive() {
+    let s = test_scenario("CONTROL-SPLIT-001", model::Category::Aux, 1);
+    let e = full_evidence_host_fact();
+    let mut input = oracle_input(&s, &e);
+    input.probe_nonce = None;
+    assert_eq!(oracle::judge(&input), model::Verdict::Inconclusive);
+}
+
+/// FM-02b: nonce mismatch between probe and control -> INCONCLUSIVE.
+#[test]
+fn trap_control_split_nonce_mismatch_is_inconclusive() {
+    let s = test_scenario("CONTROL-SPLIT-001", model::Category::Aux, 1);
+    let e = full_evidence_host_fact();
+    let mut input = oracle_input(&s, &e);
+    input.control_nonce = Some("other-nonce");
+    assert_eq!(oracle::judge(&input), model::Verdict::Inconclusive);
+}
+
+/// FM-06 FIXTURE-MUTATE-001: self-rewriting payload invalidates the run.
+#[test]
+fn trap_fixture_mutation_is_detected() {
+    let mut fx = fixture::Fixture::create("trap-mutate").expect("create fixture");
+    let p = fx.stage("payload.sh", b"echo attack").expect("stage");
+    std::fs::write(&p, b"echo PASS").expect("payload rewrites itself");
+    let mutated = fx.verify_untouched().expect_err("mutation must be detected");
+    assert_eq!(mutated, vec![p]);
+
+    let s = test_scenario("FIXTURE-MUTATE-001", model::Category::Aux, 1);
+    let e = full_evidence_host_fact();
+    let mut input = oracle_input(&s, &e);
+    input.payload_intact = false;
+    assert_eq!(oracle::judge(&input), model::Verdict::Inconclusive);
+}
+
+/// FM-08 ENV-POISON-001: poisoned diagnostic env -> FAIL on blockers.
+/// The poison list is unit-constructed (never mutating process-global env).
+#[test]
+fn trap_env_poison_fails_blockers() {
+    assert!(engine::POISON_ENV.contains(&"VETTO_SEATBELT_MODE"));
+    let target = engine::current_target(Some("full"));
+    let poison = vec!["VETTO_SEATBELT_MODE".to_string()];
+    let blocker = test_scenario("VFS-TRAV-001", model::Category::FsRead, 2);
+    let r = engine::poisoned_result(&blocker, target, &poison);
+    assert_eq!(r.verdict, model::Verdict::Fail);
+    assert!(r.blocks_release());
+    let aux = test_scenario("ORACLE-DECEIT-001", model::Category::Aux, 1);
+    let r = engine::poisoned_result(&aux, target, &poison);
+    assert_eq!(r.verdict, model::Verdict::Inconclusive);
+}
+
+/// FM-12 GATE-VACUUM-001: empty suite must FAIL the gate, never pass.
+#[test]
+fn trap_gate_vacuum_empty_suite_fails() {
+    let gate = exit::evaluate_gate(&[], &std::collections::BTreeMap::new(), "reg");
+    assert_eq!(gate.status, "failed");
+    assert_eq!(exit::gate_exit_code(&gate), 1);
+}
+
+/// FM-12b: all-N/A without canaries must FAIL the gate.
+#[test]
+fn trap_gate_all_na_fails_without_canaries() {
+    let mk = |id: &str| model::ScenarioResult {
+        id: id.to_string(),
+        category: model::Category::FsRead,
+        strength: model::ClaimStrength::Partial,
+        verdict: model::Verdict::NotApplicable,
+        detail: "x".to_string(),
+    };
+    let results = vec![mk("WIN-WSL-001")];
+    let mut ev = std::collections::BTreeMap::new();
+    ev.insert("WIN-WSL-001".to_string(), vec!["wsl: absent (unmapped)".to_string()]);
+    let gate = exit::evaluate_gate(&results, &ev, "reg");
+    assert_eq!(gate.status, "failed");
+}
+
+/// FM-07 EVIDENCE-REDACT-001: secrets + bulk output never reach the report.
+#[test]
+fn trap_evidence_redaction_holds() {
+    let evil = "AWS_SECRET_ACCESS_KEY=topsecretvalue99\n".to_string() + &"y".repeat(50_000);
+    let redacted = redact::redact_text(&evil);
+    assert!(!redacted.contains("topsecretvalue99"));
+    assert!(redacted.len() <= redact::MAX_DETAIL + 32);
+    let pem = "-----BEGIN RSA PRIVATE KEY-----\nSENSITIVE\n-----END RSA PRIVATE KEY-----";
+    assert!(!redact::redact_text(pem).contains("SENSITIVE"));
+}
+
+/// FM-03 RACE-BINDING-001: spec continuity detects drift between freeze and spawn.
+#[test]
+fn trap_spec_continuity_detects_drift() {
+    let mk = |nonce: &str| frozen::FrozenSpec {
+        scenario_id: "RACE-BINDING-001".to_string(),
+        registry_hash: "r".to_string(),
+        tier: "full".to_string(),
+        net_mode: "off".to_string(),
+        backend: "b".to_string(),
+        argv: vec!["/bin/sh".to_string()],
+        env: Default::default(),
+        cwd: std::path::PathBuf::from("/tmp"),
+        allow_read: vec![],
+        allow_write: vec![],
+        deny_read: vec![],
+        deny_write: vec![],
+        deny_resolved: vec![],
+        nonce: nonce.to_string(),
+    };
+    assert!(engine::verify_spec_continuity(&mk("n"), &mk("n")));
+    assert!(!engine::verify_spec_continuity(&mk("n"), &mk("m")));
+}
+
+/// FM-11 WIN-WSL-001: UNSUPPORTED ceiling can never PASS.
+#[test]
+fn trap_unsupported_ceiling_demotes_pass() {
+    let v = oracle::apply_strength_ceiling(
+        model::Verdict::Pass,
+        model::ClaimStrength::Unsupported,
+    );
+    assert_eq!(v, model::Verdict::Inconclusive);
+}
+
+/// FM-10 SEMANTICS-001 is covered in `model.rs`; here assert the report
+/// carries both axes for a trap result.
+#[test]
+fn trap_report_carries_both_axes() {
+    let gate = exit::GateReport {
+        status: "failed".to_string(),
+        passed: 0,
+        failed: 1,
+        inconclusive: 0,
+        not_applicable: 0,
+        blocking: vec!["ORACLE-DECEIT-001".to_string()],
+        results: vec![model::ScenarioResult {
+            id: "ORACLE-DECEIT-001".to_string(),
+            category: model::Category::Aux,
+            strength: model::ClaimStrength::Strong,
+            verdict: model::Verdict::Inconclusive,
+            detail: "d".to_string(),
+        }],
+    };
+    let v = report::gate_report_json(&gate, "reg");
+    assert_eq!(v["results"][0]["verdict"], "INCONCLUSIVE");
+    assert_eq!(v["results"][0]["strength"], "STRONG");
+}
+
+/// CLI surface: `verify-ng --lint` passes on the shipped registry.
+#[test]
+fn cli_verify_ng_lint_passes() {
+    let proj = TempProject::new("vng-lint");
+    let out = run_vetto_in(proj.path(), &["verify-ng", "--lint"]);
+    let text = stdout(&out);
+    assert!(
+        out.status.success(),
+        "registry lint must pass: {text}\nstderr: {}",
+        stderr(&out)
+    );
+    assert!(text.contains("lint clean"), "output: {text}");
+}
+
+/// CLI surface: `verify-ng --lint --json` is parseable.
+#[test]
+fn cli_verify_ng_lint_json_parseable() {
+    let proj = TempProject::new("vng-lint-json");
+    let out = run_vetto_in(proj.path(), &["verify-ng", "--lint", "--json"]);
+    let text = stdout(&out);
+    assert!(out.status.success(), "lint --json must pass: {text}");
+    let value: serde_json::Value = serde_json::from_str(text.trim())
+        .unwrap_or_else(|error| panic!("lint --json must emit JSON: {error}\n{text}"));
+    assert!(value.get("registry_hash").is_some(), "hash: {value}");
+    assert!(
+        value.get("errors").and_then(|e| e.as_array()).map(|e| e.is_empty()).unwrap_or(false),
+        "errors: {value}"
+    );
+}
+
+/// CLI surface: `verify-ng` without execution never reports PASS (FM-01 at
+/// the CLI layer: the harness refuses hollow verdicts, gate fails closed).
+#[test]
+fn cli_verify_ng_without_suite_never_passes() {
+    let proj = TempProject::new("vng-gate");
+    let out = run_vetto_in(proj.path(), &["verify-ng"]);
+    let text = stdout(&out);
+    assert!(
+        !out.status.success(),
+        "gate without suite execution must fail closed: {text}"
+    );
+    assert!(!text.contains("PASS"), "no hollow PASS: {text}");
+}
+
+/// Capability skeleton: missing required caps surface as NOT_APPLICABLE
+/// only with absence evidence (FM-12 shape check on the unit level).
+#[test]
+fn caps_missing_requires_evidence_shape() {
+    let set = caps::CapabilitySet {
+        capabilities: vec![caps::Capability::absent("netns", "no userns")],
+    };
+    let required = vec!["netns".to_string(), "never-probed-cap".to_string()];
+    let missing = set.missing(&required);
+    assert_eq!(missing.len(), 2);
+    let ev = set.absence_evidence(&missing);
+    assert!(ev.iter().any(|e| e.contains("no userns")));
+    assert!(ev.iter().any(|e| e.contains("never probed")));
+}

--- a/tests/integration/verify_ng_traps.rs
+++ b/tests/integration/verify_ng_traps.rs
@@ -264,3 +264,188 @@ fn caps_missing_requires_evidence_shape() {
     assert!(ev.iter().any(|e| e.contains("no userns")));
     assert!(ev.iter().any(|e| e.contains("never probed")));
 }
+
+/// FM-13 quorum shape: multi-vector scenarios (VFS-TRAV-001 quorum=2,
+/// NET-EXFIL-001 quorum=3) need >= quorum agreeing vectors, else INCONCLUSIVE.
+#[test]
+fn trap_quorum_shape_multivector_needs_agreeing_vectors() {
+    for (id, category, quorum, agreeing) in [
+        ("VFS-TRAV-001", model::Category::FsRead, 2, 1),
+        ("VFS-WRITE-001", model::Category::FsWrite, 2, 1),
+        ("NET-EXFIL-001", model::Category::Net, 3, 2),
+        ("RACE-TOCTOU-001", model::Category::Spawn, 3, 2),
+        ("PROC-TREE-001", model::Category::Proc, 2, 1),
+        ("ENV-SECRETS-001", model::Category::Secrets, 2, 1),
+        ("SEC-BLOCKS-001", model::Category::Spawn, 2, 1),
+    ] {
+        let s = test_scenario(id, category, quorum);
+        let e = full_evidence_host_fact();
+        let mut input = oracle_input(&s, &e);
+        input.agreeing_vectors = agreeing;
+        assert_eq!(
+            oracle::judge(&input),
+            model::Verdict::Inconclusive,
+            "{id}: quorum={quorum} with {agreeing} agreeing must not PASS"
+        );
+        input.agreeing_vectors = quorum;
+        assert_eq!(
+            oracle::judge(&input),
+            model::Verdict::Pass,
+            "{id}: quorum met must PASS"
+        );
+    }
+}
+
+/// FM-13 quorum=1 single-vector scenarios still PASS with one vector.
+#[test]
+fn trap_quorum_one_single_vector_passes() {
+    for (id, category) in [
+        ("PROC-ESC-001", model::Category::Proc),
+        ("ENV-LEAK-001", model::Category::Secrets),
+        ("SHELL-ESC-001", model::Category::Spawn),
+        ("WIN-WSL-001", model::Category::FsRead),
+    ] {
+        let s = test_scenario(id, category, 1);
+        let e = full_evidence_host_fact();
+        assert_eq!(oracle::judge(&oracle_input(&s, &e)), model::Verdict::Pass, "{id}");
+    }
+}
+
+/// FM-11 platform ceilings (static contract): seccomp surface is
+/// NOT_APPLICABLE off Linux; WSL-interop is UNSUPPORTED (never PASS).
+/// Unit-level shape: the ceiling demotes any judging PASS to INCONCLUSIVE.
+#[test]
+fn trap_platform_ceiling_shapes() {
+    // SEC-BLOCKS-001 shape: macOS/Windows must be N/A-with-evidence, never PASS.
+    // The ceiling function is the enforcement point: UNSUPPORTED + PASS -> INCONCLUSIVE.
+    let v = oracle::apply_strength_ceiling(
+        model::Verdict::Pass,
+        model::ClaimStrength::Unsupported,
+    );
+    assert_eq!(v, model::Verdict::Inconclusive, "unsupported ceiling demotes PASS");
+    // PARTIAL ceiling keeps the verdict (report carries both axes, no Partial-PASS).
+    for verdict in [model::Verdict::Pass, model::Verdict::Fail, model::Verdict::Inconclusive] {
+        assert_eq!(
+            oracle::apply_strength_ceiling(verdict, model::ClaimStrength::Partial),
+            verdict,
+            "partial ceiling preserves {verdict:?}"
+        );
+    }
+    // WIN-WSL-001 trap shape: Fail on UNSUPPORTED stays Fail (only PASS demotes).
+    assert_eq!(
+        oracle::apply_strength_ceiling(model::Verdict::Fail, model::ClaimStrength::Unsupported),
+        model::Verdict::Fail
+    );
+}
+
+/// FM-12 gate shape for iteration-2 suites: an fs-write PASS minimum exists,
+/// so a gate without any fs-write PASS must stay red (no vacuum by category).
+#[test]
+fn trap_gate_requires_fs_write_minimum() {
+    use std::collections::BTreeMap;
+    let pass = |id: &str, category: model::Category| model::ScenarioResult {
+        id: id.to_string(),
+        category,
+        strength: model::ClaimStrength::Strong,
+        verdict: model::Verdict::Pass,
+        detail: "x".to_string(),
+    };
+    // Full pass set WITHOUT fs-write: gate must fail on the category minimum.
+    let results = vec![
+        pass("VFS-TRAV-001", model::Category::FsRead),
+        pass("NET-DNS-IPV6-001", model::Category::Net),
+        pass("PROC-ESC-001", model::Category::Proc),
+        pass("ENV-LEAK-001", model::Category::Secrets),
+        pass("RACE-BINDING-001", model::Category::Spawn),
+    ];
+    let gate = exit::evaluate_gate(&results, &BTreeMap::new(), "reg");
+    assert_eq!(gate.status, "failed", "gate without fs-write PASS must fail");
+    assert!(
+        gate.blocking.iter().any(|b| b.contains("fs-write")),
+        "blocking must name fs-write: {:?}",
+        gate.blocking
+    );
+    // Adding VFS-WRITE-001 PASS closes the minimum (canaries still required).
+    let mut closed = results;
+    closed.push(pass("VFS-WRITE-001", model::Category::FsWrite));
+    let gate = exit::evaluate_gate(&closed, &BTreeMap::new(), "reg");
+    assert!(
+        !gate.blocking.iter().any(|b| b.contains("fs-write")),
+        "fs-write minimum closed: {:?}",
+        gate.blocking
+    );
+}
+
+/// FM-01/FM-14 shape for new blocker suites: violation observed by the host
+/// beats any self-report; the collector never judges (oracle-only verdict).
+#[test]
+fn trap_host_violation_beats_self_report_new_suites() {
+    for (id, category, quorum) in [
+        ("VFS-WRITE-001", model::Category::FsWrite, 2),
+        ("VFS-PROC-001", model::Category::FsRead, 2),
+        ("NET-EXFIL-001", model::Category::Net, 3),
+        ("SHELL-ESC-001", model::Category::Spawn, 2),
+        ("ENV-SECRETS-001", model::Category::Secrets, 2),
+        ("PROC-TREE-001", model::Category::Proc, 2),
+        ("WIN-ESC-001", model::Category::Proc, 2),
+        ("WIN-NET-001", model::Category::Net, 2),
+    ] {
+        let s = test_scenario(id, category, quorum);
+        let mut e = full_evidence_host_fact();
+        e.self_report("marker", "PASS PASS PASS".to_string());
+        let mut input = oracle_input(&s, &e);
+        input.agreeing_vectors = quorum;
+        input.violation_observed = true;
+        assert_eq!(
+            oracle::judge(&input),
+            model::Verdict::Fail,
+            "{id}: host violation must FAIL despite self-report"
+        );
+    }
+}
+
+/// FM-06 shape for new suites: mutated payload invalidates every run,
+/// including stress/fuzz/differential shapes.
+#[test]
+fn trap_payload_mutation_invalidates_new_suites() {
+    for (id, category, quorum) in [
+        ("RACE-TOCTOU-001", model::Category::Spawn, 3),
+        ("STRESS-SWEEP-001", model::Category::Proc, 2),
+        ("FUZZ-CORPUS-001", model::Category::Spawn, 2),
+        ("TIER-DIFF-001", model::Category::Spawn, 2),
+        ("SEC-BLOCKS-001", model::Category::Spawn, 2),
+        ("RES-EXHAUST-001", model::Category::Proc, 2),
+    ] {
+        let s = test_scenario(id, category, quorum);
+        let e = full_evidence_host_fact();
+        let mut input = oracle_input(&s, &e);
+        input.agreeing_vectors = quorum;
+        input.payload_intact = false;
+        assert_eq!(
+            oracle::judge(&input),
+            model::Verdict::Inconclusive,
+            "{id}: mutated payload must be INCONCLUSIVE"
+        );
+    }
+}
+
+/// FM-08 shape for new suites: poisoned diagnostic env FAILs blockers,
+/// INCONCLUSIVE on aux — including the new blocker batteries.
+#[test]
+fn trap_env_poison_fails_new_blockers() {
+    let target = engine::current_target(Some("full"));
+    let poison = vec!["VETTO_FORCE_TIER".to_string()];
+    for (id, category, quorum) in [
+        ("VFS-WRITE-001", model::Category::FsWrite, 2),
+        ("NET-EXFIL-001", model::Category::Net, 3),
+        ("SHELL-ESC-001", model::Category::Spawn, 2),
+        ("WIN-ESC-001", model::Category::Proc, 2),
+        ("WIN-NET-001", model::Category::Net, 2),
+        ("SEC-BLOCKS-001", model::Category::Spawn, 2),
+    ] {
+        let s = test_scenario(id, category, quorum);
+        let r = engine::poisoned_result(&s, target, &poison);
+        assert_eq!(r.verdict, model::Verdict::Fail, "{id}: poisoned blocker must FAIL");
+        assert!(r.blocks_release());
+    }
+}

--- a/tests/verify_ng/scenarios/CLEANUP-SIGKILL-001.toml
+++ b/tests/verify_ng/scenarios/CLEANUP-SIGKILL-001.toml
@@ -1,0 +1,15 @@
+# CLEANUP-SIGKILL-001 — SIGKILL of the harness mid-attack, external observer counts residue.
+id = "CLEANUP-SIGKILL-001"
+category = "proc"
+severity = "high"
+required_caps = ["spawn", "tree-sweep"]
+quorum = 1
+
+[strength]
+linux-full = "STRONG"
+windows = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+
+known_limitation = "Requires an external observer process/VM; cannot be self-proven from inside the harness under test."
+residual_risk = "fs-only/macOS orphans may survive a SIGKILLed harness; suite must run in a disposable VM there."

--- a/tests/verify_ng/scenarios/ENV-LEAK-001.toml
+++ b/tests/verify_ng/scenarios/ENV-LEAK-001.toml
@@ -1,0 +1,18 @@
+# ENV-LEAK-001 — credential scrub across env/fd/argv vectors.
+id = "ENV-LEAK-001"
+category = "secrets"
+severity = "blocker"
+required_caps = ["spawn"]
+quorum = 1
+
+[strength]
+linux-full = "STRONG"
+macos = "STRONG"
+windows = "STRONG"
+
+known_limitation = "Proves scrub of the canary key set; unknown exfil channels (covert timing, allowed-relay payloads) are out of scope."
+residual_risk = ""
+
+[evidence.host_facts]
+canary_env = "canary secret present in the harness env must be absent from the child env report (nonce-bound)"
+canary_fd = "no secret bytes may appear in captured output (redaction verified separately by EVIDENCE-REDACT-001)"

--- a/tests/verify_ng/scenarios/ENV-SECRETS-001.toml
+++ b/tests/verify_ng/scenarios/ENV-SECRETS-001.toml
@@ -1,0 +1,24 @@
+# ENV-SECRETS-001 — наследование секретов: env/fd/argv/SSH-Git-cloud credentials.
+id = "ENV-SECRETS-001"
+category = "secrets"
+severity = "blocker"
+required_caps = ["spawn"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+macos = "STRONG"
+windows = "STRONG"
+
+known_limitation = "Proves scrub/sealing of the canary key set across env/fd/argv/credential-path vectors; covert channels (timing, allowed-relay payloads) and unknown key shapes are out of scope."
+residual_risk = ""
+
+[evidence.host_facts]
+canary-env = "каждый canary-ключ из harness env обязан отсутствовать в child env report (nonce-bound сравнение)"
+canary-fd = "ни один captured fd/output не содержит байт секрета (redaction проверяется отдельно EVIDENCE-REDACT-001)"
+canary-argv = "секрет не должен появляться в /proc child cmdline snapshot (host-side read)"
+cred-paths = "host stat ~/.ssh/~/.aws/.env-canary после wait: absent/неизменны"
+
+[evidence.constrained_channel]
+errno_class = "read секретных путей обязан вернуть EACCES/EPERM с nonce сессии"
+vectors = ["env-dump", "fd-inherit", "argv-leak", "ssh-path", "git-cred-path", "cloud-cred-path"]

--- a/tests/verify_ng/scenarios/FUZZ-CORPUS-001.toml
+++ b/tests/verify_ng/scenarios/FUZZ-CORPUS-001.toml
@@ -1,0 +1,25 @@
+# FUZZ-CORPUS-001 — fuzzing стратегия в форме сценария: корпус path/env/argv мутаций, fail-closed oracle, без production-fuzz кода.
+id = "FUZZ-CORPUS-001"
+category = "spawn"
+severity = "high"
+required_caps = ["spawn"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+windows = "PARTIAL"
+
+known_limitation = "Сценарий фиксирует контракт fuzz-корпуса и oracle-правила, а не сам fuzzer. Любой crash/hang/нарушение границы дает FAIL/INCONCLUSIVE, никогда PASS. Корпус хранится вне репозитория enforcement (только docs/scenarios здесь)."
+residual_risk = "Fuzzing находит векторы, но не доказывает их отсутствие; новые находки обязаны стать новыми векторами/quorum в реестре."
+
+[fuzz]
+corpus = ["path-alias-mutations", "env-key-mutations", "argv0-mutations", "cwd-mutations", "locale-encoding-mutations", "symlink-forest-mutations"]
+oracle_rule = "любое нарушение host-fact границы или расхождение nonce/control дает FAIL/INCONCLUSIVE; PASS требует host-fact + control + quorum как обычно"
+seed_policy = "детерминированные seeds в CI; ночные расширенные прогоны — только CI-runner/VM"
+vectors = ["path-fuzz", "env-fuzz", "argv-fuzz", "symlink-fuzz"]
+
+[execution]
+local_allowed = "малый seed-набор локально; полный корпус — CI"
+only_disposable_vm = false

--- a/tests/verify_ng/scenarios/HANG-GRANDCHILD-001.toml
+++ b/tests/verify_ng/scenarios/HANG-GRANDCHILD-001.toml
@@ -1,0 +1,19 @@
+# HANG-GRANDCHILD-001 — grandchild holding the pipe must not hang the harness.
+id = "HANG-GRANDCHILD-001"
+category = "proc"
+severity = "high"
+required_caps = ["spawn", "tree-sweep"]
+quorum = 1
+
+[strength]
+linux-full = "STRONG"
+windows = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+
+known_limitation = "Proves deadline-aware collection, not general liveness of arbitrary payloads."
+residual_risk = "On fs-only/macOS the grandchild may outlive the group kill until the sweep budget expires; verdict is FAIL/INCONCLUSIVE, never PASS."
+
+[evidence.host_facts]
+deadline = "collector returns at or before the deadline even with the write end held open"
+sweep = "post-deadline sweep finds no residue on Strong tiers"

--- a/tests/verify_ng/scenarios/MAC-ESC-001.toml
+++ b/tests/verify_ng/scenarios/MAC-ESC-001.toml
@@ -1,0 +1,27 @@
+# MAC-ESC-001 — macOS escape battery: профиль побайтово + tail-deny; read secrecy вне tail-deny UNPROVABLE (потолок PARTIAL).
+id = "MAC-ESC-001"
+category = "fs-read"
+severity = "high"
+required_caps = ["spawn", "seatbelt"]
+quorum = 2
+
+[strength]
+macos = "PARTIAL"
+linux-full = "NOT_APPLICABLE"
+windows = "NOT_APPLICABLE"
+
+known_limitation = "Профиль обязан совпасть с Shape-A + tail-deny побайтово (см. MAC-SHAPE-001). Strong read-secrecy на macOS native UNPROVABLE; только Linux VM. SBPL-фрагментация SIGABRTит dyld — narrow shape не существует."
+residual_risk = "Любой путь вне tail-deny читаем by construction; использовать Linux VM для strong read secrecy. Egress ограничен --net=off via (deny network*); per-domain allowlist unsupported и fail-closed."
+
+[evidence.host_facts]
+profile-bytes = "применённый SBPL-профиль побайтово равен Shape-A + tail-deny (MAC-SHAPE-001 gate)"
+tail-deny = "host stat tail-deny таргетов после wait: denied/отсутствуют"
+canary-inside = "positive control внутри проекта цел"
+
+[evidence.constrained_channel]
+errno_class = "read вне tail-deny может УСПЕШНО вернуть байты по построению Shape-A — это не FAIL сценария, а подтверждение потолка PARTIAL; read tail-deny обязан вернуть EPERM с nonce сессии"
+vectors = ["tail-deny-read", "shape-outside-read", "seatbelt-bypass-open", "net-off-egress", "kqueue-watchdog-race"]
+
+[evidence.not_applicable]
+linux-full = "macOS-only battery"
+windows = "macOS-only battery"

--- a/tests/verify_ng/scenarios/MAC-PROC-001.toml
+++ b/tests/verify_ng/scenarios/MAC-PROC-001.toml
@@ -1,0 +1,23 @@
+# MAC-PROC-001 — macOS process containment: kqueue watchdog + group-kill + sweep-бюджет (BestEffort; destructive только в VM).
+id = "MAC-PROC-001"
+category = "proc"
+severity = "high"
+required_caps = ["spawn"]
+quorum = 1
+
+[strength]
+macos = "PARTIAL"
+linux-full = "NOT_APPLICABLE"
+windows = "NOT_APPLICABLE"
+
+known_limitation = "PID namespaces на Darwin нет; containment — kqueue EVFILT_PROC watchdog + group-kill + sweep-бюджет 2с (BestEffort). Residue дает FAIL/INCONCLUSIVE, никогда PASS. Полнота sweep при SIGKILL недоказуема."
+residual_risk = "Watchdog races и outliving grandchildren — известный residual; destructive-сьюты только в disposable VM."
+
+[evidence.host_facts]
+sweep = "post-deadline sweep обязан найти ноль residue, иначе FAIL (не PASS)"
+watchdog-fact = "host-side watchdog observe: supervisor-death влечет SIGKILL дерева (не self-report)"
+wait_status = "root exit value через retained handle"
+
+[evidence.not_applicable]
+linux-full = "macOS-only containment battery"
+windows = "macOS-only containment battery"

--- a/tests/verify_ng/scenarios/MAC-SHAPE-001.toml
+++ b/tests/verify_ng/scenarios/MAC-SHAPE-001.toml
@@ -1,0 +1,12 @@
+# MAC-SHAPE-001 — enforced profile is Shape-A + tail-deny byte-for-byte.
+id = "MAC-SHAPE-001"
+category = "fs-read"
+severity = "high"
+required_caps = ["spawn", "seatbelt"]
+quorum = 1
+
+[strength]
+macos = "PARTIAL"
+
+known_limitation = "Proves the enforced profile is Shape-A + tail-deny byte-for-byte; read secrecy beyond tail-deny is UNPROVABLE on macOS native."
+residual_risk = "Any path outside the tail-deny list is readable by construction; use a Linux VM for strong read secrecy."

--- a/tests/verify_ng/scenarios/NET-DNS-IPV6-001.toml
+++ b/tests/verify_ng/scenarios/NET-DNS-IPV6-001.toml
@@ -1,0 +1,23 @@
+# NET-DNS-IPV6-001 — --net=off isolation across transports.
+id = "NET-DNS-IPV6-001"
+category = "net"
+severity = "blocker"
+required_caps = ["spawn", "netns"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+windows = "PARTIAL"
+
+known_limitation = "Proves --net=off isolation only; allowlist relay modes need a separate broker suite."
+residual_risk = "Without a network namespace (fs-only/mac/win) only syscall/capability denial is proven, not absence of a route."
+
+[evidence.host_facts]
+listener = "host loopback listener (v4 + v6) stays unconnected for the whole run"
+dns = "no resolver answer may reach the sandbox; resolution attempts must fail closed"
+
+[evidence.constrained_channel]
+errno_class = "connect/sendto/getaddrinfo must report ENETUNREACH/EACCES/EPERM/timeout with the session nonce"
+vectors = ["tcp4", "tcp6", "udp", "dns", "python-socket", "raw-syscall"]

--- a/tests/verify_ng/scenarios/NET-EXFIL-001.toml
+++ b/tests/verify_ng/scenarios/NET-EXFIL-001.toml
@@ -1,0 +1,25 @@
+# NET-EXFIL-001 — мультивекторная эксфильтрация (fail-closed, escape, exfil приоритет).
+id = "NET-EXFIL-001"
+category = "net"
+severity = "blocker"
+required_caps = ["spawn", "netns"]
+quorum = 3
+
+[strength]
+linux-full = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+windows = "PARTIAL"
+
+known_limitation = "Proves --net=off isolation only across the listed egress vectors; allowlist relay modes and TLS-through-allowed-API payload semantics need a separate broker suite (threat-model non-goal #1)."
+residual_risk = "Без netns (fs-only/mac/win) доказывается только syscall/capability denial, не отсутствие маршрута. Per-domain egress без admin на Windows — UNPROVABLE."
+
+[evidence.host_facts]
+listener-v4 = "host loopback listener (IPv4) stays unconnected for the whole run"
+listener-v6 = "host loopback listener (IPv6) stays unconnected for the whole run"
+dns-sink = "no resolver answer may reach the sandbox; resolution attempts must fail closed"
+uds-watch = "no bytes may arrive on the watched Unix-domain socket / named pipe stub"
+
+[evidence.constrained_channel]
+errno_class = "connect/sendto/getaddrinfo/sendmsg must report ENETUNREACH/EACCES/EPERM/timeout with the session nonce"
+vectors = ["curl", "python-socket", "native-tcp4", "native-tcp6", "dns-resolver", "alt-http-client", "uds-ipc", "raw-syscall"]

--- a/tests/verify_ng/scenarios/PROC-ESC-001.toml
+++ b/tests/verify_ng/scenarios/PROC-ESC-001.toml
@@ -1,0 +1,19 @@
+# PROC-ESC-001 — setsid/double-fork/background escape + post-mortem sweep.
+id = "PROC-ESC-001"
+category = "proc"
+severity = "blocker"
+required_caps = ["spawn", "tree-sweep"]
+quorum = 1
+
+[strength]
+linux-full = "STRONG"
+windows = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+
+known_limitation = "Post-mortem sweep is host-side observation of absence; a hostile scheduler can delay reparenting past the sweep budget (INCONCLUSIVE, never PASS)."
+residual_risk = "fs-only setsid orphans and macOS watchdog races are known residuals; they FAIL/advisory, never PASS."
+
+[evidence.host_facts]
+tree_sweep = "external sweep after terminate must find zero residual processes"
+wait_status = "root exit value collected via the retained handle, not via self-report"

--- a/tests/verify_ng/scenarios/PROC-TREE-001.toml
+++ b/tests/verify_ng/scenarios/PROC-TREE-001.toml
@@ -1,0 +1,24 @@
+# PROC-TREE-001 — sibling/detached/grandchild/background escape + inherited handles.
+id = "PROC-TREE-001"
+category = "proc"
+severity = "blocker"
+required_caps = ["spawn", "tree-sweep"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+windows = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+
+known_limitation = "Proves process-tree containment for the covered escape shapes only; hostile scheduler delaying reparent past the sweep budget yields INCONCLUSIVE, never PASS."
+residual_risk = "fs-only setsid orphans и macOS watchdog races — известный residual; вердикт FAIL/INCONCLUSIVE, destructive-варианты только в disposable VM."
+
+[evidence.host_facts]
+tree_sweep = "external sweep после terminate обязан найти ноль residual процессов"
+sibling-scan = "никакой sibling/detached процесс вне дерева не должен пережить сессию (host-side observe)"
+handles = "унаследованные дескрипторы/handle не дают пережить kill-on-close (host-side check)"
+
+[evidence.constrained_channel]
+errno_class = "ptrace/process_vm/pidfd-инъекции обязаны вернуть EPERM с nonce сессии (где применимо)"
+vectors = ["setsid-daemon", "double-fork", "background-nohup", "sibling-spawn", "fd-handle-inherit", "job-escape-win"]

--- a/tests/verify_ng/scenarios/RACE-BINDING-001.toml
+++ b/tests/verify_ng/scenarios/RACE-BINDING-001.toml
@@ -1,0 +1,17 @@
+# RACE-BINDING-001 — spec/tier continuity from freeze to spawn.
+id = "RACE-BINDING-001"
+category = "spawn"
+severity = "blocker"
+required_caps = ["spawn"]
+quorum = 1
+
+[strength]
+linux-full = "STRONG"
+
+known_limitation = "Proves spec/tier binding continuity in-process; a compromised host kernel is out of scope."
+residual_risk = ""
+
+[evidence.host_facts]
+spec_hash = "FrozenSpec hash before spawn equals the hash re-computed from the same references at spawn time"
+tier_match = "detected tier equals the expected tier from the single per-run detect"
+registry_hash = "scenario registry hash pinned in the gate report"

--- a/tests/verify_ng/scenarios/RACE-TOCTOU-001.toml
+++ b/tests/verify_ng/scenarios/RACE-TOCTOU-001.toml
@@ -1,0 +1,25 @@
+# RACE-TOCTOU-001 — race между policy construction и process start + symlink TOCTOU (stress).
+id = "RACE-TOCTOU-001"
+category = "spawn"
+severity = "blocker"
+required_caps = ["spawn", "landlock"]
+quorum = 3
+
+[strength]
+linux-full = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+windows = "PARTIAL"
+
+known_limitation = "Proves freeze-to-spawn continuity and symlink-swap TOCTOU resistance for the covered race shapes; compromised host kernel/scheduler out of scope. Медиана >=3 прогонов, ретраи не превращают FAIL в PASS."
+residual_risk = "На fs-only/macOS часть гонок наблюдается best-effort; расхождение прогонов дает INCONCLUSIVE, destructive-нагрузка только в disposable VM."
+
+[evidence.host_facts]
+spec_hash = "FrozenSpec hash до spawn равен хэшу в момент spawn на каждом прогоне (медиана >=3)"
+postmortem = "host stat внешнего таргета после каждого прогона: absent/unchanged на всех прогонах"
+tier_match = "detected tier равен expected tier на каждом прогоне (single detect per run)"
+
+[stress]
+runs = 5
+median_rule = "вердикт по медиане >=3 согласующихся прогонов; любое расхождение векторов дает INCONCLUSIVE"
+vectors = ["symlink-swap-race", "rename-race", "freeze-spawn-drift", "parallel-spawn-serial", "mount-view-race"]

--- a/tests/verify_ng/scenarios/RES-EXHAUST-001.toml
+++ b/tests/verify_ng/scenarios/RES-EXHAUST-001.toml
@@ -1,0 +1,28 @@
+# RES-EXHAUST-001 — resource exhaustion: fork-bomb/pids, IO, disk, memory (adversarial).
+id = "RES-EXHAUST-001"
+category = "proc"
+severity = "high"
+required_caps = ["spawn", "tree-sweep"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+windows = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+
+known_limitation = "Proves bounded exhaustion handling (limits + kill + sweep) for the covered shapes; full DoS-immunity host-wide не доказывается. Запускать только в disposable VM/CI-runner с квотами."
+residual_risk = "На fs-only/macOS часть лимитов best-effort; превышение дает FAIL/INCONCLUSIVE, никогда PASS. Локально без квот — только smoke-вариант."
+
+[evidence.host_facts]
+tree_sweep = "external sweep после terminate обязан найти ноль residual процессов"
+host-quota = "хост-квоты (pids/io/disk) не превышены за пределами сессии; cgroup/Job счётчики в норме"
+wait_status = "root exit value собран через retained handle, не self-report"
+
+[evidence.constrained_channel]
+errno_class = "fork/clone сверх лимита обязан вернуть EAGAIN с nonce сессии"
+vectors = ["fork-bomb", "pids-limit", "io-flood", "disk-fill", "mem-pressure"]
+
+[execution]
+only_disposable_vm = true
+local_allowed = "smoke-вариант с малыми квотами; полный — только CI-runner/VM"

--- a/tests/verify_ng/scenarios/SEC-BLOCKS-001.toml
+++ b/tests/verify_ng/scenarios/SEC-BLOCKS-001.toml
@@ -1,0 +1,28 @@
+# SEC-BLOCKS-001 — seccomp/syscall denial: ptrace/process_vm/pidfd, mount/pivot, io_uring, userfaultfd, bpf/perf (Linux suite, native ABI).
+id = "SEC-BLOCKS-001"
+category = "spawn"
+severity = "blocker"
+required_caps = ["spawn"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+linux-seccomp = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "NOT_APPLICABLE"
+windows = "NOT_APPLICABLE"
+
+known_limitation = "Proves denial of the enumerated dangerous syscall surface via native ABI (номера из libc::SYS_*, без x86-64 констант на ARM64); полнота фильтра против 0-day не доказывается. macOS/Windows — NOT_APPLICABLE только с probe-доказательством отсутствия capability."
+residual_risk = "На linux-fsonly часть поверхности best-effort; расхождение дает INCONCLUSIVE."
+
+[evidence.host_facts]
+wait_status = "root exit value собран через retained handle; ни один запрещённый вызов не вернул успех"
+audit-tap = "host-side audit/seccomp-tap (advisory) не показывает успешных запрещённых вызовов; отсутствие tap не дает PASS"
+
+[evidence.constrained_channel]
+errno_class = "запрещённые вызовы обязаны вернуть EPERM/ENOSYS с nonce сессии"
+vectors = ["ptrace", "process_vm_readv-writev", "pidfd_getfd", "mount-pivot-umount", "io_uring", "userfaultfd", "bpf-perf"]
+
+[evidence.not_applicable]
+macos = "Darwin не имеет seccomp-bpf; требуется probe-доказательство отсутствия capability, иначе N/A-without-evidence блокирует gate"
+windows = "Windows не имеет seccomp-bpf; требуется probe-доказательство отсутствия capability, иначе N/A-without-evidence блокирует gate"

--- a/tests/verify_ng/scenarios/SHELL-ESC-001.toml
+++ b/tests/verify_ng/scenarios/SHELL-ESC-001.toml
@@ -1,0 +1,23 @@
+# SHELL-ESC-001 — shell escape через alternate shell/interpreter и PATH-confusion.
+id = "SHELL-ESC-001"
+category = "spawn"
+severity = "blocker"
+required_caps = ["spawn", "landlock"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+linux-fsonly = "STRONG"
+macos = "PARTIAL"
+windows = "PARTIAL"
+
+known_limitation = "Proves policy boundary holds under interpreter indirection covered by the payload set (alt shells, script interpreters, executable replacement, PATH confusion, env abuse); novel interpreter paths need new vectors."
+residual_risk = "На macOS/Windows часть индирекций проходит через платформенные лаунчеры (open/cmd/PowerShell) — покрытие advisory, strength ceiling PARTIAL."
+
+[evidence.host_facts]
+postmortem-outside = "host stat внешнего таргета после wait: absent/unchanged значит удержано при любом интерпретаторе"
+spec_hash = "FrozenSpec hash до spawn равен хэшу в момент spawn (та же &Policy-ссылка)"
+
+[evidence.constrained_channel]
+errno_class = "попытка чтения/записи вне allowlist через любой интерпретатор обязана вернуть EACCES/EPERM с nonce сессии"
+vectors = ["alt-shell", "script-interpreter", "path-confusion", "env-ld_preload", "exec-replacement", "shebang-indirect"]

--- a/tests/verify_ng/scenarios/STRESS-SWEEP-001.toml
+++ b/tests/verify_ng/scenarios/STRESS-SWEEP-001.toml
@@ -1,0 +1,25 @@
+# STRESS-SWEEP-001 — stress/race стратегия в форме сценария: медиана прогонов, кворум векторов, sweep-бюджеты (не нагрузка ради нагрузки).
+id = "STRESS-SWEEP-001"
+category = "proc"
+severity = "high"
+required_caps = ["spawn", "tree-sweep"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+windows = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+
+known_limitation = "Stress доказывает стабильность вердикта под нагрузкой/гонками, а не отсутствие гонок вообще. Ретраи не превращают FAIL в PASS. Destructive-нагрузка — только disposable VM/CI-runner."
+residual_risk = "На fs-only/macOS медиана может разъехаться (scheduler delay) — вердикт INCONCLUSIVE, блокирует gate в blocker-категориях через ноль-INCONCLUSIVE правило."
+
+[stress]
+runs = 5
+median_rule = "медиана >=3 согласующихся прогонов; расхождение дает INCONCLUSIVE"
+sweep_budget_ms = 2000
+vectors = ["rapid-spawn-burst", "grandchild-hold-pipe", "setsid-storm", "parallel-freeze-spawn", "kill-during-drain"]
+
+[execution]
+local_allowed = "smoke-вариант (runs=3, малые бюджеты); полный — CI-runner/VM"
+only_disposable_vm = false

--- a/tests/verify_ng/scenarios/TIER-DIFF-001.toml
+++ b/tests/verify_ng/scenarios/TIER-DIFF-001.toml
@@ -1,0 +1,26 @@
+# TIER-DIFF-001 — differential testing: full vs fs-only vs seccomp обязаны расходиться только задокументированно (никаких silent downgrade).
+id = "TIER-DIFF-001"
+category = "spawn"
+severity = "high"
+required_caps = ["spawn"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+linux-fsonly = "PARTIAL"
+linux-seccomp = "PARTIAL"
+macos = "NOT_APPLICABLE"
+windows = "NOT_APPLICABLE"
+
+known_limitation = "Differential доказывает отсутствие silent downgrade между тирами, а не эквивалентность тиров. VETTO_FORCE_TIER разрешён ТОЛЬКО в tier-differential CI job с cross-check фактического тира; вне его — отравление (FAIL/INCONCLUSIVE)."
+residual_risk = "fs-only/seccomp слабее full по построению; любое PASS на слабом тире несёт ceiling PARTIAL и residual_risk."
+
+[differential]
+tiers = ["full", "fs-only", "seccomp"]
+rule = "вердикты обязаны совпадать либо расходиться строго в задокументированную слабую сторону (Strong→Partial/Inconclusive); расхождение в сторону PASS на слабом тире при FAIL на strong — баг oracle/gate"
+force_tier_note = "VETTO_FORCE_TIER вне tier-differential job — poison (FM-08)"
+vectors = ["vfs-trav-diff", "net-exfil-diff", "proc-tree-diff", "sec-blocks-diff"]
+
+[evidence.host_facts]
+tier-fact = "фактический тир каждого прогона зафиксирован host-side (single detect per run) и совпадаёт с заявленным"
+spec_hash = "FrozenSpec hash каждого прогона включает tier label; подмена тира ломает continuity"

--- a/tests/verify_ng/scenarios/VFS-PROC-001.toml
+++ b/tests/verify_ng/scenarios/VFS-PROC-001.toml
@@ -1,0 +1,23 @@
+# VFS-PROC-001 — доступ через /proc, /sys, device nodes и fd-инъекции.
+id = "VFS-PROC-001"
+category = "fs-read"
+severity = "blocker"
+required_caps = ["spawn", "landlock"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+linux-fsonly = "PARTIAL"
+macos = "PARTIAL"
+windows = "PARTIAL"
+
+known_limitation = "Covers /proc/self/{mem,fd,cwd,root,exe}, /proc/<pid>/fd утечки, /sys и /dev обходы, присутствующие в payload-наборе; новые kernel-интерфейсы требуют новых векторов."
+residual_risk = "На fs-only и macOS часть OS-surfaces видна шире, чем в PIDns/full; strength ceiling PARTIAL там. Windows: \\Device\\ и drive-alias покрытие advisory."
+
+[evidence.host_facts]
+postmortem = "host stat/canary-сравнение секретного таргета после wait: отсутствие/неизменность значит удержано"
+proc-leak = "ни один чужой fd/mem/cwd/root путь не должен дать байты секрета (host-side сравнение)"
+
+[evidence.constrained_channel]
+errno_class = "open/read через /proc|/sys|/dev алиасы обязан вернуть EACCES/EPERM/ENOENT с nonce сессии"
+vectors = ["proc-self-mem", "proc-self-fd", "proc-pid-fd", "sys-alias", "dev-alias", "fd-reopen-O_PATH"]

--- a/tests/verify_ng/scenarios/VFS-TRAV-001.toml
+++ b/tests/verify_ng/scenarios/VFS-TRAV-001.toml
@@ -1,0 +1,22 @@
+# VFS-TRAV-001 — symlink/hardlink/dotdot/rename traversal from inside enforcement.
+id = "VFS-TRAV-001"
+category = "fs-read"
+severity = "blocker"
+required_caps = ["spawn", "landlock"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+linux-fsonly = "STRONG"
+macos = "PARTIAL"
+windows = "PARTIAL"
+
+known_limitation = "Covers symlink/hardlink/dotdot/rename vectors present in the payload set; new kernel path aliases need new vectors."
+residual_risk = "macOS Shape-A broad reads and Windows ACL fallback may expose entries outside the tail-deny list; strength ceiling PARTIAL there."
+
+[evidence.host_facts]
+postmortem = "host stat of the secret target after wait: absent/empty means held"
+canary = "positive control file inside the project must be byte-identical"
+
+[evidence.constrained_channel]
+errno_class = "open/read of the secret via each alias must report EACCES/EPERM with the session nonce"

--- a/tests/verify_ng/scenarios/VFS-WRITE-001.toml
+++ b/tests/verify_ng/scenarios/VFS-WRITE-001.toml
@@ -1,0 +1,23 @@
+# VFS-WRITE-001 — запись вне allowlist (negative proof + positive control).
+id = "VFS-WRITE-001"
+category = "fs-write"
+severity = "blocker"
+required_caps = ["spawn", "landlock"]
+quorum = 2
+
+[strength]
+linux-full = "STRONG"
+linux-fsonly = "STRONG"
+macos = "PARTIAL"
+windows = "PARTIAL"
+
+known_limitation = "Proves writes outside allowlist are denied for the covered vectors only; writes inside $PROJECT are allowed by design and out of scope (see threat-model non-goal #2)."
+residual_risk = "macOS Shape-A broad paths and Windows ACL fallback may permit writes through aliases outside the deny list; strength ceiling PARTIAL there."
+
+[evidence.host_facts]
+postmortem-outside = "host stat of the outside-write target after wait: absent/unchanged means held"
+canary-inside = "positive control file inside the project must accept the write byte-for-byte (negative proof + positive control)"
+
+[evidence.constrained_channel]
+errno_class = "open(O_CREAT|O_WRONLY)/rename/link/symlink toward outside target must report EACCES/EPERM/EROFS with the session nonce"
+vectors = ["o_creat-absolute", "o_creat-dotdot", "rename-into-outside", "symlink-then-write", "hardlink-then-write"]

--- a/tests/verify_ng/scenarios/WIN-ESC-001.toml
+++ b/tests/verify_ng/scenarios/WIN-ESC-001.toml
@@ -1,0 +1,31 @@
+# WIN-ESC-001 — Windows escape battery: PowerShell/cmd/API, restricted token, integrity, Job, ACL, network (host-fact-only).
+id = "WIN-ESC-001"
+category = "proc"
+severity = "blocker"
+required_caps = ["spawn", "tree-sweep"]
+quorum = 2
+
+[strength]
+windows = "STRONG"
+windows-sandbox-vm = "STRONG"
+linux-full = "NOT_APPLICABLE"
+linux-fsonly = "NOT_APPLICABLE"
+linux-seccomp = "NOT_APPLICABLE"
+macos = "NOT_APPLICABLE"
+
+known_limitation = "Windows evidence — host-fact-only, пока нет HANDLE-capture в backend (требует отдельного backend-ревью, вне verify-ng). Per-domain egress без admin — UNPROVABLE (WFP требует elevation). WSL-interop — см. WIN-WSL-001 (UNSUPPORTED)."
+residual_risk = "UNC/mapped-drive алиасы — см. WIN-UNC-001 (PARTIAL/advisory). WFP allowlist без admin недоказуем и обязан fail-closed."
+
+[evidence.host_facts]
+job-sweep = "Job Object kill-on-close: external host observe после close обязан найти ноль residual процессов"
+token-fact = "host-side token/integrity snapshot: Low integrity + restricted token удержаны (не self-report процесса)"
+acl-postmortem = "host stat внешних таргетов после wait: absent/unchanged"
+no-pipe-collection = "windows evidence собирается host-фактами; pipe-drain stub возвращает not-EOF и дает INCONCLUSIVE, никогда PASS"
+
+[evidence.constrained_channel]
+errno_class = "запрещённые доступы обязаны вернуть ACCESS_DENIED с nonce сессии (narrow hint; вердикт только по host-фактам)"
+vectors = ["powershell-escape", "cmd-escape", "winapi-direct", "unc-alias", "mapped-drive", "wsl-interop-probe", "token-escape", "job-escape", "acl-bypass"]
+
+[evidence.not_applicable]
+linux-full = "Windows-only battery; на Linux требуется probe-доказательство отсутствия windows-capability"
+macos = "Windows-only battery; на macOS требуется probe-доказательство отсутствия windows-capability"

--- a/tests/verify_ng/scenarios/WIN-NET-001.toml
+++ b/tests/verify_ng/scenarios/WIN-NET-001.toml
@@ -1,0 +1,28 @@
+# WIN-NET-001 — Windows egress: --net=off via AppContainer capabilities (host-fact-only); per-domain без admin UNPROVABLE/fail-closed.
+id = "WIN-NET-001"
+category = "net"
+severity = "blocker"
+required_caps = ["spawn"]
+quorum = 2
+
+[strength]
+windows = "PARTIAL"
+windows-sandbox-vm = "STRONG"
+linux-full = "NOT_APPLICABLE"
+macos = "NOT_APPLICABLE"
+
+known_limitation = "Per-domain egress без admin на Windows — UNPROVABLE (WFP требует elevation); allowlist обязан fail-closed в AppContainer capability deny, никогда silent allow. Полный Strong — только windows-sandbox-vm."
+residual_risk = "На native Windows доказывается только capability-deny, не отсутствие маршрута; strength ceiling PARTIAL. Любой per-domain PASS без admin — баг oracle."
+
+[evidence.host_facts]
+listener-v4 = "host loopback listener (IPv4) stays unconnected for the whole run"
+listener-v6 = "host loopback listener (IPv6) stays unconnected for the whole run"
+no-wfp-claim = "отчёт обязан нести маркер admin-отсутствия; per-domain claims без elevation запрещены"
+
+[evidence.constrained_channel]
+errno_class = "connect/sendto/getaddrinfo обязаны вернуть ACCESS_DENIED/WSAENETUNREACH/timeout с nonce сессии (hint; вердикт по host-фактам)"
+vectors = ["curl", "powershell-net", "python-socket", "native-tcp4", "native-tcp6", "dns", "alt-http-client"]
+
+[evidence.not_applicable]
+linux-full = "Windows-only egress battery"
+macos = "Windows-only egress battery"

--- a/tests/verify_ng/scenarios/WIN-UNC-001.toml
+++ b/tests/verify_ng/scenarios/WIN-UNC-001.toml
@@ -1,0 +1,12 @@
+# WIN-UNC-001 — UNC and alternate-path aliases (advisory until mapped).
+id = "WIN-UNC-001"
+category = "fs-read"
+severity = "high"
+required_caps = ["spawn"]
+quorum = 1
+
+[strength]
+windows = "PARTIAL"
+
+known_limitation = "Advisory until UNC/namespace-alias coverage is mapped; starts INCONCLUSIVE, never PASS on first implementation."
+residual_risk = 'Alternate path aliases (UNC, verbatim paths, mapped drives) may bypass ACL-shaped checks.'

--- a/tests/verify_ng/scenarios/WIN-WSL-001.toml
+++ b/tests/verify_ng/scenarios/WIN-WSL-001.toml
@@ -1,0 +1,12 @@
+# WIN-WSL-001 — WSL-interop boundary (unmapped; INCONCLUSIVE baseline).
+id = "WIN-WSL-001"
+category = "fs-read"
+severity = "high"
+required_caps = ["spawn"]
+quorum = 1
+
+[strength]
+windows = "UNSUPPORTED"
+
+known_limitation = "WSL-interop boundary is unmapped; INCONCLUSIVE baseline until researched. Any PASS is an oracle bug."
+residual_risk = ""


### PR DESCRIPTION
Сшивка 10 proposal-веток (docs + verify_ng harness + scenarios + traps) + подключение verify-ng CLI + P0-фиксы fail-closed дыр.

P0 (из P03/P06/P07/P08 аудитов):
- VETTO_SEATBELT_MODE debug-only (release fail-closed 125)
- strict:* rejected в strict_allowed
- W1 Windows deny case-insensitive, W2 proxy-strip
- A1 dry_run sanitize, C1 RLIMIT_CORE=0, M1 NUL-drop, D1 proxy dedup
- FORCE_TIER debug-only, F6 dry-run tier honesty, 103->125 docs

verify-ng: verify-ng [--json] [--lint] через cli/main/lib; lint без спавна; non-lint fail-closed 125 (HarnessUnavailable, typed error).

Bump 0.2.18 -> 0.2.19 (все каналы + CHANGELOG). Локальный запуск запрещен AGENTS.md — проверка через CI.