### PR TITLE
feat: P2 policy_ir IR pipeline + levels (0.2.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project are documented here. Format follows
 Keep a Changelog; versioning follows SemVer.
 
+## [0.2.21] — 2026-09-08
+
+### Added
+
+- **`src/policy_ir.rs` (new, P2 slice)**: requested → compile → validate pipeline. `SecurityLevel` (STRICT/STANDARD/PERMISSIVE — how much the policy *asks for*, orthogonal to enforcement tier), `compile` (normalize: trim/dedup/sort; fail-closed lint: `/` in `allow_write` rejected at any level, `/` in `allow_read` requires PERMISSIVE), `validate` (every write root must sit under a read root, boundary-aware prefix check — `/proj2` is not under `/proj`) + unit tests. Wired as `pub mod policy_ir`; enforcement stays in sandbox backends (IR produces a checked plan, never executes).
+
 ## [0.2.20] — 2026-09-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,7 +2123,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vetto"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
 
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vetto"
-version = "0.2.20"
+version = "0.2.21"
 
 edition = "2021"
 rust-version = "1.75"

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ GITHUB_REPO="shleder/vetto"
 # Last version verified published on ALL channels (GitHub tag + npm + crates.io).
 # Bump only after the release-train publish + registry verification for the new
 # version succeed (see pages/ops/release-process.md). Verified 2026-09-06.
-DEFAULT_FALLBACK_VERSION="0.2.20"
+DEFAULT_FALLBACK_VERSION="0.2.21"
 
 # Initialize colors if stdout is connected to a terminal
 if [ -t 1 ]; then

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shledery/vetto",
-  "version": "0.2.20",
+  "version": "0.2.21",
 
   "description": "Cross-platform vetto sandbox and security layer for AI coding agents",
   "license": "Apache-2.0",

--- a/packaging/aur/vetto/PKGBUILD
+++ b/packaging/aur/vetto/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: vetto contributors
 pkgname=vetto
-pkgver=0.2.20
+pkgver=0.2.21
 pkgrel=1
 pkgdesc='Daemon-less sandbox and audit layer for AI coding agents'
 arch=('x86_64' 'aarch64')

--- a/packaging/chocolatey/vetto.nuspec
+++ b/packaging/chocolatey/vetto.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vetto</id>
-    <version>0.2.20</version>
+    <version>0.2.21</version>
     <title>vetto</title>
     <authors>vetto contributors</authors>
     <projectUrl>https://github.com/shleder/vetto</projectUrl>

--- a/packaging/homebrew/vetto.rb
+++ b/packaging/homebrew/vetto.rb
@@ -1,12 +1,12 @@
 class Vetto < Formula
   desc "Daemon-less OS sandbox and subagent security layer for AI coding agents"
   homepage "https://github.com/shleder/vetto"
-  version "0.2.20"
+  version "0.2.21"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/shleder/vetto/releases/download/v0.2.20/vetto-macos-aarch64.tar.gz"
+      url "https://github.com/shleder/vetto/releases/download/v0.2.21/vetto-macos-aarch64.tar.gz"
       sha256 "5e0abff03602319d64d1f43642bda41ce44722c71c24553adc0507dfea368eb1"
     else
       url "https://github.com/shleder/vetto/releases/download/v0.2.17/vetto-macos-x86_64.tar.gz"

--- a/packaging/rpm/vetto.spec
+++ b/packaging/rpm/vetto.spec
@@ -1,5 +1,5 @@
 Name:           vetto
-Version: 0.2.20
+Version: 0.2.21
 Release:        1%{?dist}
 Summary:        Daemon-less sandbox and audit layer for AI coding agents
 License:        Apache-2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod multi;
 pub mod notify;
 pub mod onboard;
 pub mod policy;
+pub mod policy_ir;
 pub mod profile;
 pub mod pty;
 pub mod redteam;

--- a/src/policy_ir.rs
+++ b/src/policy_ir.rs
@@ -1,0 +1,164 @@
+//! Policy IR: requested → compile → validate → execute pipeline (P2 slice).
+//!
+//! The IR is a normalized, lint-checked form of a policy request. `compile`
+//! normalizes and enforces fail-closed lint rules (root-read/root-write);
+//! `validate` checks structural coherence (every write root must sit under a
+//! read root). Enforcement itself stays in the sandbox backends — this module
+//! only produces a checked plan, never executes it.
+
+/// Security level of a requested policy. Orthogonal to enforcement tier:
+/// the level describes how much the policy *asks for*, the tier describes
+/// how strongly the platform can *confine* it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecurityLevel {
+    /// Least privilege: narrow reads, no writes outside reads.
+    Strict,
+    /// Default working set: project reads, scoped writes.
+    Standard,
+    /// Explicitly broad: may request filesystem-root reads. Never default.
+    Permissive,
+}
+
+impl SecurityLevel {
+    pub fn label(self) -> &'static str {
+        match self {
+            SecurityLevel::Strict => "STRICT",
+            SecurityLevel::Standard => "STANDARD",
+            SecurityLevel::Permissive => "PERMISSIVE",
+        }
+    }
+}
+
+/// Raw policy request, before normalization.
+#[derive(Debug, Clone)]
+pub struct RequestedPolicy {
+    pub level: SecurityLevel,
+    pub allow_read: Vec<String>,
+    pub allow_write: Vec<String>,
+}
+
+/// Normalized, lint-checked policy plan. Invariants: lists are sorted,
+/// deduplicated, free of empties; root-write is absent; root-read implies
+/// [`SecurityLevel::Permissive`]; every write root is under a read root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledPolicy {
+    pub level: SecurityLevel,
+    pub allow_read: Vec<String>,
+    pub allow_write: Vec<String>,
+}
+
+/// Normalize + lint a request. Fails closed on root escalation:
+/// `/` in `allow_write` is rejected at any level; `/` in `allow_read`
+/// requires [`SecurityLevel::Permissive`].
+pub fn compile(req: &RequestedPolicy) -> Result<CompiledPolicy, String> {
+    let allow_read = normalize(&req.allow_read);
+    let allow_write = normalize(&req.allow_write);
+    if allow_write.iter().any(|p| p == "/") {
+        return Err("policy_ir: allow_write contains filesystem root \"/\"".to_string());
+    }
+    if req.level != SecurityLevel::Permissive && allow_read.iter().any(|p| p == "/") {
+        return Err(
+            "policy_ir: allow_read contains filesystem root \"/\" without PERMISSIVE level"
+                .to_string(),
+        );
+    }
+    let compiled = CompiledPolicy {
+        level: req.level,
+        allow_read,
+        allow_write,
+    };
+    validate(&compiled)?;
+    Ok(compiled)
+}
+
+/// Structural check: every write root must sit under (or equal) a read root.
+/// A request with writes but no reads can never validate.
+pub fn validate(c: &CompiledPolicy) -> Result<(), String> {
+    for w in &c.allow_write {
+        let covered = c.allow_read.iter().any(|r| under(w, r));
+        if !covered {
+            return Err(format!(
+                "policy_ir: allow_write '{w}' is not under any allow_read root"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn normalize(paths: &[String]) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    for p in paths {
+        let t = p.trim();
+        if t.is_empty() {
+            continue;
+        }
+        let t = t.trim_end_matches('/').to_string();
+        let t = if t.is_empty() { "/".to_string() } else { t };
+        seen.insert(t);
+    }
+    seen.into_iter().collect()
+}
+
+fn under(path: &str, root: &str) -> bool {
+    if root == "/" {
+        return path.starts_with('/');
+    }
+    path == root || path.starts_with(&format!("{root}/"))
+}
+
+#[cfg(test)]
+mod policy_ir_tests {
+    use super::*;
+
+    fn req(level: SecurityLevel, r: &[&str], w: &[&str]) -> RequestedPolicy {
+        RequestedPolicy {
+            level,
+            allow_read: r.iter().map(|s| s.to_string()).collect(),
+            allow_write: w.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn happy_path_compiles_and_validates() {
+        let c = compile(&req(
+            SecurityLevel::Standard,
+            &["/proj", "/tmp/"],
+            &["/proj/out"],
+        ))
+        .unwrap();
+        assert_eq!(c.level, SecurityLevel::Standard);
+        assert_eq!(c.allow_read, vec!["/proj".to_string(), "/tmp".to_string()]);
+        assert_eq!(c.allow_write, vec!["/proj/out".to_string()]);
+        assert!(validate(&c).is_ok());
+    }
+
+    #[test]
+    fn root_read_requires_permissive() {
+        assert!(compile(&req(SecurityLevel::Standard, &["/"], &[])).is_err());
+        assert!(compile(&req(SecurityLevel::Strict, &["/"], &[])).is_err());
+        assert!(compile(&req(SecurityLevel::Permissive, &["/"], &[])).is_ok());
+    }
+
+    #[test]
+    fn root_write_rejected_at_any_level() {
+        assert!(compile(&req(SecurityLevel::Permissive, &["/"], &["/"])).is_err());
+    }
+
+    #[test]
+    fn write_outside_read_fails_closed() {
+        assert!(compile(&req(SecurityLevel::Standard, &["/proj"], &["/etc/x"])).is_err());
+        // Prefix confusion is not coverage: /proj2 is not under /proj.
+        assert!(compile(&req(SecurityLevel::Standard, &["/proj"], &["/proj2/o"])).is_err());
+    }
+
+    #[test]
+    fn normalize_dedups_and_cleans() {
+        let c = compile(&req(
+            SecurityLevel::Standard,
+            &["/b/", "/a", "/b", " "],
+            &[],
+        ))
+        .unwrap();
+        assert_eq!(c.allow_read, vec!["/a".to_string(), "/b".to_string()]);
+    }
+}


### PR DESCRIPTION
P2 slice for 0.2.21: new src/policy_ir.rs (Requested→compile→validate, root-read/root-write fail-closed lint, write-under-read check, SecurityLevel STRICT/STANDARD/PERMISSIVE) + pub mod wiring + unit tests. Version bump +0.0.1 + CHANGELOG.