### PR TITLE
verify-ng: harden gate and registry integrity traps

### DIFF
--- a/src/verify_ng/exit.rs
+++ b/src/verify_ng/exit.rs
@@ -4,7 +4,8 @@
 //!
 //! - No blocker-category FAIL or INCONCLUSIVE.
 //! - Zero INCONCLUSIVE in blocker categories (fail-closed).
-//! - Every NOT_APPLICABLE carries absence evidence (no silent skips).
+//! - Every NOT_APPLICABLE carries structured absence evidence.
+//! - Scenario IDs are unique (one scenario result per registry entry).
 //! - Canary scenarios (proof-of-enforcement-alive) all PASS.
 //! - Per-category PASS minimums met (no vacuum PASS: FM-12).
 //!
@@ -53,8 +54,16 @@ impl GateReport {
     }
 }
 
-/// Evaluate the gate. `na_evidence` maps scenario id -> absence evidence
-/// strings for NOT_APPLICABLE results; entries missing evidence fail the gate.
+fn valid_absence_evidence(entries: &[String]) -> bool {
+    !entries.is_empty()
+        && entries
+            .iter()
+            .all(|e| e.contains(": absent (") && e.ends_with(')'))
+}
+
+/// Evaluate the gate. `na_evidence` maps scenario id -> structured capability
+/// absence evidence for NOT_APPLICABLE results; entries missing proof, or
+/// evidence not matching the capability-absence shape, fail the gate.
 pub fn evaluate_gate(
     results: &[ScenarioResult],
     na_evidence: &BTreeMap<String, Vec<String>>,
@@ -66,9 +75,12 @@ pub fn evaluate_gate(
     let mut inconclusive = 0;
     let mut not_applicable = 0;
     let mut pass_per_category: BTreeMap<Category, usize> = BTreeMap::new();
-    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    let mut seen: BTreeSet<String> = BTreeSet::new();
 
     for r in results {
+        if !seen.insert(r.id.clone()) {
+            blocking.push(format!("{}:duplicate-result", r.id));
+        }
         match r.verdict {
             Verdict::Pass => {
                 passed += 1;
@@ -84,13 +96,12 @@ pub fn evaluate_gate(
         if r.verdict == Verdict::NotApplicable {
             let has_evidence = na_evidence
                 .get(&r.id)
-                .map(|e| !e.is_empty())
+                .map(|e| valid_absence_evidence(e))
                 .unwrap_or(false);
             if !has_evidence {
-                blocking.push(format!("{}:N/A-without-evidence", r.id));
+                blocking.push(format!("{}:N/A-without-absence-evidence", r.id));
             }
         }
-        seen.insert(r.id.as_str());
     }
 
     // Canary rule: every canary that ran must PASS; a canary that did not
@@ -208,7 +219,35 @@ mod exit_tests {
         assert!(report
             .blocking
             .iter()
-            .any(|b| b.contains("N/A-without-evidence")));
+            .any(|b| b.contains("N/A-without-absence-evidence")));
+    }
+
+    /// Arbitrary non-absence evidence must not justify NOT_APPLICABLE.
+    #[test]
+    fn malformed_na_evidence_blocks() {
+        let mut results = full_pass_set();
+        results.push(result(
+            "WIN-WSL-001",
+            Category::FsRead,
+            Verdict::NotApplicable,
+        ));
+        let mut ev = BTreeMap::new();
+        ev.insert("WIN-WSL-001".to_string(), vec!["looks absent".to_string()]);
+        let report = evaluate_gate(&results, &ev, "reg");
+        assert_eq!(report.status, "failed");
+    }
+
+    /// Duplicate scenario results cannot satisfy the gate.
+    #[test]
+    fn duplicate_result_id_blocks() {
+        let mut results = full_pass_set();
+        results.push(result("VFS-TRAV-001", Category::FsRead, Verdict::Pass));
+        let report = evaluate_gate(&results, &BTreeMap::new(), "reg");
+        assert_eq!(report.status, "failed");
+        assert!(report
+            .blocking
+            .iter()
+            .any(|b| b == "VFS-TRAV-001:duplicate-result"));
     }
 
     /// Full PASS set with N/A evidence passes.

--- a/src/verify_ng/frozen.rs
+++ b/src/verify_ng/frozen.rs
@@ -16,6 +16,8 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use super::registry::Scenario;
+
 /// Canonical, hashable snapshot of everything that defines a scenario run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FrozenSpec {
@@ -37,10 +39,10 @@ pub struct FrozenSpec {
 }
 
 impl FrozenSpec {
-    /// Canonical bytes: JSON with sorted keys over normalized strings.
+    /// Canonical bytes: deterministic struct-field order plus BTreeMap-ordered
+    /// environment keys; callers construct policy/path vectors through
+    /// `freeze_spec`, which sorts those sets before serialization.
     pub fn canonical_bytes(&self) -> Vec<u8> {
-        // BTreeMap + sorted Vecs + explicit fields make serde_json output
-        // deterministic for a fixed struct layout.
         serde_json::to_vec(self).unwrap_or_default()
     }
 
@@ -96,14 +98,17 @@ pub fn freeze_spec(
     }
 }
 
-/// Hash of the compiled scenario registry (binding scenarios to results).
-pub fn registry_hash(ids: &[String]) -> String {
-    let mut sorted = ids.to_vec();
-    sorted.sort();
+/// Hash of the compiled scenario registry (binding scenario semantics, not
+/// only their identifiers, to verifier results). The registry is canonicalized
+/// by scenario ID and each serialized record is length-delimited before hashing.
+pub fn registry_hash(scenarios: &[Scenario]) -> String {
+    let mut canonical = scenarios.to_vec();
+    canonical.sort_by(|a, b| a.id.cmp(&b.id));
     let mut hasher = Sha256::new();
-    for id in sorted {
-        hasher.update(id.as_bytes());
-        hasher.update([0u8]);
+    for scenario in canonical {
+        let bytes = serde_json::to_vec(&scenario).unwrap_or_default();
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
     }
     hex_encode(&hasher.finalize())
 }
@@ -159,5 +164,23 @@ mod frozen_tests {
         let off = crate::config::NetMode::Off.label();
         let allow = crate::config::NetMode::Allowlist(vec!["example.com".to_string()]).label();
         assert_ne!(off, allow);
+    }
+
+    #[test]
+    fn registry_hash_binds_scenario_semantics() {
+        let mut scenarios = vec![Scenario {
+            id: "A".to_string(),
+            category: crate::verify_ng::model::Category::FsRead,
+            severity: crate::verify_ng::registry::Severity::High,
+            required_caps: vec!["spawn".to_string()],
+            strength: BTreeMap::new(),
+            quorum: 1,
+            known_limitation: "x".to_string(),
+            residual_risk: String::new(),
+        }];
+        let a = registry_hash(&scenarios);
+        scenarios[0].quorum = 2;
+        let b = registry_hash(&scenarios);
+        assert_ne!(a, b);
     }
 }

--- a/src/verify_ng/mod.rs
+++ b/src/verify_ng/mod.rs
@@ -38,8 +38,7 @@ pub fn run_verify_ng(json: bool, lint: bool) -> anyhow::Result<()> {
     let scenarios = registry::registry();
     if lint {
         let errors = registry::lint_all(&scenarios);
-        let hash =
-            frozen::registry_hash(&scenarios.iter().map(|s| s.id.clone()).collect::<Vec<_>>());
+        let hash = frozen::registry_hash(&scenarios);
         if json {
             println!(
                 "{}",
@@ -73,8 +72,7 @@ pub fn run_verify_ng(json: bool, lint: bool) -> anyhow::Result<()> {
     use std::collections::BTreeMap;
     let target = engine::current_target(None);
     let poison = engine::detect_env_poison(false);
-    let ids: Vec<String> = scenarios.iter().map(|s| s.id.clone()).collect();
-    let hash = frozen::registry_hash(&ids);
+    let hash = frozen::registry_hash(&scenarios);
     let results: Vec<model::ScenarioResult> = if poison.is_empty() {
         scenarios
             .iter()


### PR DESCRIPTION
Stage 1 of verify-ng implementation.

Changes:
- reject duplicate ScenarioResult IDs in the gate;
- require structured capability-absence evidence for NOT_APPLICABLE;
- bind registry_hash to canonical serialized scenario semantics, not IDs only;
- update verify-ng CLI hashing to use the full compiled registry.

No production attack-suite runner is added in this PR. It remains intentionally absent until these verifier-integrity invariants are validated.