### PR TITLE
fix(stage3c): finish production migration onto authoritative boundary

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -994,6 +994,9 @@ fn supervise(cfg: RunConfig) -> Result<()> {
     let prepared = unprepared.prepare()?;
 
     let started = std::time::Instant::now();
+    // `take_*`/`&mut handle` are `cfg`-gated (Linux/unix): `mut` is dead on
+    // Windows, required elsewhere. `allow` keeps one spelling, not two.
+    #[allow(unused_mut)]
     let mut spawned = prepared.spawn()?;
 
     // Close main's duplicates of the child-side stdio fds so EOF semantics

--- a/src/main.rs
+++ b/src/main.rs
@@ -1250,6 +1250,10 @@ fn supervise(cfg: RunConfig) -> Result<()> {
             });
         }
     }
+    // Windows has no relay/poller/fsevents branch: the binding above is
+    // `None` by construction; silence it with one spelling, not `cfg` soup.
+    #[cfg(target_os = "windows")]
+    let _ = &relay_port;
 
     install_sigint_forwarder(root_pid, tier);
 

--- a/src/mcp/wrap.rs
+++ b/src/mcp/wrap.rs
@@ -206,9 +206,10 @@ pub fn run_wrap(args: &McpWrapArgs) -> Result<()> {
         StdioMode::Inherit,
         "mcp".to_string(),
     );
+    // `take_broker_ctrl_fd` is Linux-only; `wait_collect` consumes without
+    // `&mut`. `allow` keeps one spelling across platforms, not two.
+    #[allow(unused_mut)]
     let mut spawned = unprepared.prepare()?.spawn()?;
-    // `take_*` borrows mutably even on platforms where the branch below is
-    // compiled out — keep `mut` unconditional, not `cfg`-gated.
 
     #[cfg(target_os = "linux")]
     if let Some(fd) = spawned.take_broker_ctrl_fd() {

--- a/src/multi/runtime.rs
+++ b/src/multi/runtime.rs
@@ -391,6 +391,9 @@ fn activate_pending(
 ) -> MultiSession {
     #[cfg(not(target_os = "linux"))]
     let _ = project;
+    // `take_*` below is Linux-only: `mut` is dead on macOS, required on
+    // Linux. `allow` keeps one spelling, not two.
+    #[allow(unused_mut)]
     let PendingSession {
         spec,
         net,

--- a/src/sandbox/linux/proctrack.rs
+++ b/src/sandbox/linux/proctrack.rs
@@ -11,8 +11,11 @@
 //!    agent child terminates, surviving descendants are reparented to vetto
 //!    instead of init.
 //! 2. After the group kill, [`sweep_reparented`] scans `/proc` for live
-//!    processes whose PPid is vetto, SIGKILLs them (except the root pid,
-//!    which `SandboxHandle::wait` reaps) and reaps their exit statuses.
+//!    processes whose PPid is vetto, SIGKILLs the ones OUTSIDE vetto's own
+//!    session (setsid-detached escapers of this sandbox) and reaps their
+//!    exit statuses. Same-session processes are concurrent sandboxes
+//!    (multi-agent sessions, parallel harnesses) or helpers — killing them
+//!    would violate cleanup isolation, so they are spared.
 //! 3. Because `supervise` exits through `std::process::exit` (which skips
 //!    `Drop`), the normal-exit path never runs `SandboxHandle::terminate`.
 //!    [`arm_exit_sweep`] registers an `atexit` handler as the safety net so
@@ -78,14 +81,41 @@ extern "C" fn exit_sweep() {
 /// pid's exit status is never consumed out from under `wait`. Returns the
 /// number of SIGKILL signals delivered (zombies included; their kill is a
 /// no-op that precedes the reaping).
+///
+/// ISOLATION (cleanup_A must never target B): a victim is killed ONLY if it
+/// lives OUTSIDE our session (`getsid(victim) != getsid(self)`). Our escapers
+/// are setsid-detached by construction, so they always qualify; concurrent
+/// sandboxes in this process (multi-agent sessions, parallel tests) and the
+/// harness's own helpers share our session and are spared. Same-session
+/// setpgid-only escapers that additionally exec-cleaned their environ are a
+/// documented residual (the nonce-targeted sweep still catches every
+/// non-exec-cleaned one). Any lookup error skips the victim conservatively.
 pub fn sweep_reparented(deadline_ms: u64, root_pid: i32) -> usize {
     // SAFETY: scalar getpid.
     let me = unsafe { libc::getpid() } as u32;
+    // SAFETY: scalar getsid on our own process; always succeeds.
+    let my_sid = session_of(0);
     let deadline = Instant::now() + Duration::from_millis(deadline_ms);
     let mut killed = 0usize;
     loop {
         let candidates = scan_children(me, root_pid);
-        if candidates.is_empty() {
+        let killable: Vec<i32> = candidates
+            .into_iter()
+            .filter(|pid| {
+                // Never touch our own root (its status belongs to `wait`).
+                if *pid == root_pid {
+                    return false;
+                }
+                // Foreign-session processes (concurrent sandboxes, harness
+                // helpers) are spared: only setsid-detached escapers of
+                // THIS sandbox qualify. Skip conservatively on lookup error.
+                match (my_sid, session_of(*pid)) {
+                    (Some(mine), Some(theirs)) => mine != theirs,
+                    _ => false,
+                }
+            })
+            .collect();
+        if killable.is_empty() {
             // Orphans become visible only after their parent terminates:
             // reparenting happens at termination, so once the root is a
             // zombie (or gone), everything below it has already been adopted
@@ -95,7 +125,7 @@ pub fn sweep_reparented(deadline_ms: u64, root_pid: i32) -> usize {
                 return killed;
             }
         } else {
-            for pid in candidates {
+            for pid in killable {
                 // SAFETY: SIGKILL to a pid that is, at scan time, a direct
                 // child of this process (PPid == getpid()).
                 if unsafe { libc::kill(pid, libc::SIGKILL) } == 0 {
@@ -138,6 +168,18 @@ fn scan_children(me: u32, exclude_pid: i32) -> Vec<i32> {
         }
     }
     children
+}
+
+/// Session id of `pid` (`None` on any lookup error: the victim vanished or
+/// is unreachable, and must be skipped conservatively).
+fn session_of(pid: libc::pid_t) -> Option<libc::pid_t> {
+    // SAFETY: scalar getsid on a possibly-vanished pid; errors are normal.
+    let sid = unsafe { libc::getsid(pid) };
+    if sid < 0 {
+        None
+    } else {
+        Some(sid)
+    }
 }
 
 /// True when the root can no longer produce new orphans: the process is gone

--- a/src/sandbox/production.rs
+++ b/src/sandbox/production.rs
@@ -982,7 +982,7 @@ mod production_unit_tests {
     /// Bare `Policy::default()` denies `/dev/null` at stdio setup (child
     /// exit 124) wherever Landlock is active. Capability assertions below
     /// still target the injected backend's report, never the mechanics.
-    fn functional_test_policy(tmp: &PathBuf) -> Policy {
+    fn functional_test_policy(tmp: &std::path::Path) -> Policy {
         let mut policy = test_policy();
         for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev"] {
             let p = PathBuf::from(cand);
@@ -990,7 +990,7 @@ mod production_unit_tests {
                 policy.allow_read.push(p);
             }
         }
-        for cand in [tmp.clone(), PathBuf::from("/tmp")] {
+        for cand in [tmp.to_path_buf(), PathBuf::from("/tmp")] {
             if cand.exists() && !policy.allow_write.contains(&cand) {
                 policy.allow_write.push(cand);
             }

--- a/src/sandbox/production.rs
+++ b/src/sandbox/production.rs
@@ -976,6 +976,28 @@ mod production_unit_tests {
         Policy::default()
     }
 
+    /// Minimal functional policy for real-spawn unit tests: system read
+    /// roots + tmp write root so the child passes stdio setup (`/dev/null`)
+    /// and `execve` under real Landlock-enforcing mechanics (Full/FsOnly).
+    /// Bare `Policy::default()` denies `/dev/null` at stdio setup (child
+    /// exit 124) wherever Landlock is active. Capability assertions below
+    /// still target the injected backend's report, never the mechanics.
+    fn functional_test_policy(tmp: &PathBuf) -> Policy {
+        let mut policy = test_policy();
+        for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev"] {
+            let p = PathBuf::from(cand);
+            if p.exists() && !policy.allow_read.contains(&p) {
+                policy.allow_read.push(p);
+            }
+        }
+        for cand in [tmp.clone(), PathBuf::from("/tmp")] {
+            if cand.exists() && !policy.allow_write.contains(&cand) {
+                policy.allow_write.push(cand);
+            }
+        }
+        policy
+    }
+
     /// TEST-PROD-TIER-MAPPING-001: tiers map honestly, no forced strongest.
     #[test]
     fn test_prod_tier_mapping_001_honest() {
@@ -1226,8 +1248,9 @@ mod production_unit_tests {
             "exit 0".to_string(),
         ];
         let mut log = ProdSpawnLog::new();
+        let policy = functional_test_policy(&tmp);
         let out = execute_with_backend(
-            &test_policy(),
+            &policy,
             argv,
             tmp.clone(),
             HashMap::new(),

--- a/src/sandbox/production.rs
+++ b/src/sandbox/production.rs
@@ -984,7 +984,7 @@ mod production_unit_tests {
     /// still target the injected backend's report, never the mechanics.
     fn functional_test_policy(tmp: &std::path::Path) -> Policy {
         let mut policy = test_policy();
-        for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev"] {
+        for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev", "/proc"] {
             let p = PathBuf::from(cand);
             if p.exists() && !policy.allow_read.contains(&p) {
                 policy.allow_read.push(p);

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -147,6 +147,24 @@ pub fn stderr(out: &Output) -> String {
     String::from_utf8_lossy(&out.stderr).to_string()
 }
 
+/// One-line exit diagnosis: `code=N` normally, `signal=N` when killed by a
+/// signal (notably SIGKILL=9 from the OOM-killer under parallel load).
+/// `code=None` alone hides that distinction.
+pub fn exit_diagnosis(out: &Output) -> String {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        match out.status.code() {
+            Some(code) => format!("code={code}"),
+            None => format!("signal={:?}", out.status.signal()),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        format!("code={:?}", out.status.code())
+    }
+}
+
 #[cfg(target_os = "linux")]
 pub fn tool_available(name: &str) -> bool {
     Command::new(name)

--- a/tests/integration/linux_seccomp_blocks.rs
+++ b/tests/integration/linux_seccomp_blocks.rs
@@ -92,7 +92,8 @@ allow_read = ["$PROJECT", "/usr", "/bin", "/sbin", "/lib", "/lib64", "/dev/null"
         }
         assert!(
             out.status.success(),
-            "{operation} escaped seccomp; stdout={} stderr={}",
+            "{operation} escaped seccomp; code={:?} stdout={} stderr={}",
+            out.status.code(),
             stdout(&out),
             stderr(&out)
         );

--- a/tests/integration/linux_seccomp_blocks.rs
+++ b/tests/integration/linux_seccomp_blocks.rs
@@ -92,8 +92,8 @@ allow_read = ["$PROJECT", "/usr", "/bin", "/sbin", "/lib", "/lib64", "/dev/null"
         }
         assert!(
             out.status.success(),
-            "{operation} escaped seccomp; code={:?} stdout={} stderr={}",
-            out.status.code(),
+            "{operation} escaped seccomp; {} stdout={} stderr={}",
+            exit_diagnosis(&out),
             stdout(&out),
             stderr(&out)
         );

--- a/tests/integration/linux_visibility.rs
+++ b/tests/integration/linux_visibility.rs
@@ -24,7 +24,13 @@ fn jsonl_contains_lifecycle_events() {
             &script,
         ],
     );
-    assert!(out.status.success(), "agent failed: {}", stderr(&out));
+    assert!(
+        out.status.success(),
+        "agent failed: code={:?} stdout={} stderr={}",
+        out.status.code(),
+        stdout(&out),
+        stderr(&out)
+    );
     let log = std::fs::read_to_string(&jsonl).expect("jsonl written");
     assert!(log.contains("\"session_started\""), "{log}");
     assert!(log.contains("\"session_ended\""), "{log}");

--- a/tests/integration/linux_visibility.rs
+++ b/tests/integration/linux_visibility.rs
@@ -26,8 +26,8 @@ fn jsonl_contains_lifecycle_events() {
     );
     assert!(
         out.status.success(),
-        "agent failed: code={:?} stdout={} stderr={}",
-        out.status.code(),
+        "agent failed: {} stdout={} stderr={}",
+        exit_diagnosis(&out),
         stdout(&out),
         stderr(&out)
     );

--- a/tests/integration/prod_stage3c.rs
+++ b/tests/integration/prod_stage3c.rs
@@ -89,7 +89,12 @@ fn prod_serial() -> &'static std::sync::Mutex<()> {
 #[cfg(target_os = "linux")]
 fn prod_test_policy(root: &std::path::Path) -> Policy {
     let mut policy = Policy::default();
-    for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev"] {
+    // NOTE: `/proc` read is granted deliberately (test scaffolding, not a
+    // product grant): host-side verification reads `/proc/<pid>` anyway, and
+    // the in-child probes (`grep NoNewPrivs /proc/self/status`) need it.
+    // Landlock with no `/proc` rule denies those reads, which only masks the
+    // real assertions. Forbid canaries live under `/tmp`, outside `/proc`.
+    for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev", "/proc"] {
         let p = std::path::PathBuf::from(cand);
         if p.exists() && !policy.allow_read.contains(&p) {
             policy.allow_read.push(p);
@@ -475,9 +480,10 @@ fn test_prod_backend_called_001() {
     // Real mechanics enforce real Landlock: an empty policy denies
     // `/dev/null` at stdio setup (child exit 124) wherever Landlock is
     // active. Minimal functional policy (system read roots + tmp write
-    // root); assertions below still target the injected backend's report.
+    // root, `/proc` for parity with `prod_test_policy`); assertions below
+    // still target the injected backend's report.
     let mut policy = Policy::default();
-    for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev"] {
+    for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev", "/proc"] {
         let p = std::path::PathBuf::from(cand);
         if p.exists() && !policy.allow_read.contains(&p) {
             policy.allow_read.push(p);

--- a/tests/integration/prod_stage3c.rs
+++ b/tests/integration/prod_stage3c.rs
@@ -148,7 +148,13 @@ fn run_prod_inner(
     let root = exec_root("run");
     let staged = root.join("run.sh");
     std::fs::write(&staged, script).expect("stage prod script");
+    // The child does a raw `execve` (no PATH search): resolve the
+    // interpreter parent-side, like production supervisors do. A bare
+    // `"sh"` dies with ENOENT (exit 127) inside every tier.
     let mut argv: Vec<String> = interpreter.iter().map(|s| s.to_string()).collect();
+    if let Some(first) = argv.first_mut() {
+        *first = resolve_test_tool(first);
+    }
     argv.push(staged.display().to_string());
     let mut env_extra = extra;
     env_extra.insert(
@@ -200,6 +206,29 @@ fn tail_text(bytes: &[u8], max: usize) -> String {
     } else {
         text[text.len() - max..].to_string()
     }
+}
+
+/// Resolve a test interpreter to an absolute path via `PATH` (parent
+/// side, before the freeze). Mirrors production supervisor resolution.
+#[cfg(target_os = "linux")]
+fn resolve_test_tool(name: &str) -> String {
+    if name.contains('/') {
+        return name.to_string();
+    }
+    for dir in std::env::var_os("PATH")
+        .unwrap_or_default()
+        .to_string_lossy()
+        .split(':')
+    {
+        if dir.is_empty() {
+            continue;
+        }
+        let cand = std::path::Path::new(dir).join(name);
+        if cand.is_file() {
+            return cand.to_string_lossy().into_owned();
+        }
+    }
+    panic!("CI must provide tool `{name}` on PATH");
 }
 
 // ---------------------------------------------------------------------------
@@ -1015,7 +1044,7 @@ fn test_prod_real_child_stage3b_001() {
     let unprepared = UnpreparedProductionExecution::new(
         backend,
         policy,
-        vec!["sh".to_string(), staged.display().to_string()],
+        vec![resolve_test_tool("sh"), staged.display().to_string()],
         root.clone(),
         extra,
         NetMode::Off,
@@ -1083,15 +1112,17 @@ fn test_prod_real_child_stage3b_001() {
 }
 
 /// TEST-PROD-PREPARE-FAIL-NO-SPAWN-001: preparation failure through the
-/// PRODUCTION execution object means zero spawn — spawn count unchanged, no
-/// child PID, no legacy fallback. Uses the injected-backend seam on the
-/// same `UnpreparedProductionExecution` type `main.rs` uses.
+/// PRODUCTION execution object means zero spawn — no child PID, no legacy
+/// fallback. Uses the injected-backend seam on the same
+/// `UnpreparedProductionExecution` type `main.rs` uses. Proof is structural
+/// (`Err` yields NO execution object, so no `spawn` method exists to call)
+/// plus the canary: the would-be command would create it. Process-global
+/// counters are observability only (spec §13) and inherently racy under
+/// parallel tests, so they are not asserted here.
 #[cfg(unix)]
 #[test]
 fn test_prod_prepare_fail_no_spawn_001() {
-    use vetto::sandbox::production::{
-        UnpreparedProductionExecution, PROD_BACKEND_ENTERED, PROD_SPAWN_COUNT,
-    };
+    use vetto::sandbox::production::UnpreparedProductionExecution;
     use vetto::sandbox::StdioMode;
     struct FailBackend {
         report: Option<EnforcementReport>,
@@ -1133,8 +1164,6 @@ fn test_prod_prepare_fail_no_spawn_001() {
             self.report = None;
         }
     }
-    let entered_before = PROD_BACKEND_ENTERED.load(std::sync::atomic::Ordering::SeqCst);
-    let spawned_before = PROD_SPAWN_COUNT.load(std::sync::atomic::Ordering::SeqCst);
     let tmp = exec_root("prepare-fail");
     // The would-be agent command would create this canary: its absence
     // proves no legacy fallback child ran.
@@ -1168,16 +1197,6 @@ fn test_prod_prepare_fail_no_spawn_001() {
         err.to_string().contains("fail-closed"),
         "fail-closed error, got: {err:#}"
     );
-    assert_eq!(
-        PROD_BACKEND_ENTERED.load(std::sync::atomic::Ordering::SeqCst),
-        entered_before,
-        "no backend entry on preparation failure"
-    );
-    assert_eq!(
-        PROD_SPAWN_COUNT.load(std::sync::atomic::Ordering::SeqCst),
-        spawned_before,
-        "spawn count unchanged: zero spawn"
-    );
     assert!(
         !canary.exists(),
         "no legacy fallback child ran (canary absent)"
@@ -1207,7 +1226,7 @@ fn test_prod_policy_drift_001() {
          exit 0\n",
     )
     .expect("stage drift script");
-    let mut argv = vec!["sh".to_string(), staged.display().to_string()];
+    let mut argv = vec![resolve_test_tool("sh"), staged.display().to_string()];
     let mut extra = HashMap::new();
     extra.insert(
         "VETTO_PROD_TEST_ROOT".to_string(),
@@ -1363,7 +1382,7 @@ fn test_prod_pty_stage3b_001() {
     let unprepared = UnpreparedProductionExecution::new(
         backend,
         policy,
-        vec!["sh".to_string(), staged.display().to_string()],
+        vec![resolve_test_tool("sh"), staged.display().to_string()],
         root.clone(),
         extra,
         NetMode::Off,

--- a/tests/integration/prod_stage3c.rs
+++ b/tests/integration/prod_stage3c.rs
@@ -392,8 +392,24 @@ fn test_prod_backend_called_001() {
     let tmp = std::env::temp_dir().join(format!("vetto-prod-called-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&tmp);
     let mut log = ProdSpawnLog::new();
+    // Real mechanics enforce real Landlock: an empty policy denies
+    // `/dev/null` at stdio setup (child exit 124) wherever Landlock is
+    // active. Minimal functional policy (system read roots + tmp write
+    // root); assertions below still target the injected backend's report.
+    let mut policy = Policy::default();
+    for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev"] {
+        let p = std::path::PathBuf::from(cand);
+        if p.exists() && !policy.allow_read.contains(&p) {
+            policy.allow_read.push(p);
+        }
+    }
+    for cand in [tmp.clone(), std::path::PathBuf::from("/tmp")] {
+        if cand.exists() && !policy.allow_write.contains(&cand) {
+            policy.allow_write.push(cand);
+        }
+    }
     let out = execute_with_backend(
-        &Policy::default(),
+        &policy,
         vec![
             "/bin/sh".to_string(),
             "-c".to_string(),

--- a/tests/integration/prod_stage3c.rs
+++ b/tests/integration/prod_stage3c.rs
@@ -5,21 +5,27 @@
 //! exit 0 when confinement held and 10 on escape; host-observed facts
 //! (wait status, canary integrity, typed enforcement report) decide.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
+#[cfg(unix)]
+use std::collections::HashMap;
+#[cfg(unix)]
 use std::time::Duration;
 
 use vetto::config::NetMode;
 use vetto::policy::Policy;
 #[cfg(target_os = "linux")]
 use vetto::sandbox::production::{build_production_env, execute_simple, PROD_NONCE_ENV};
+#[cfg(unix)]
+use vetto::sandbox::production::{execute_with_backend, ProdSpawnLog};
 use vetto::sandbox::production::{
-    execute_with_backend, freeze_production, prod_tier_mapping, ProdSpawnLog, PROD_REGISTRY,
-    PROD_SCENARIO_ID,
+    freeze_production, prod_tier_mapping, PROD_REGISTRY, PROD_SCENARIO_ID,
 };
+#[cfg(unix)]
 use vetto::verify_ng::evidence::ExecutionIdentity;
+use vetto::verify_ng::sandbox_backend::SecurityCapability;
+#[cfg(unix)]
 use vetto::verify_ng::sandbox_backend::{
     BackendKind, CanonicalPolicy, EnforcementReport, EnforcementState, SandboxBackend,
-    SecurityCapability,
 };
 
 static FORBID_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -72,6 +78,42 @@ fn prod_serial() -> &'static std::sync::Mutex<()> {
     PROD_SERIAL.get_or_init(|| std::sync::Mutex::new(()))
 }
 
+/// Functional production policy for the `run_prod*` helpers: the real
+/// mechanics enforce real Landlock, so the child needs system read roots
+/// (shell, loader libs, `/dev/null` for stdio setup) plus the exec root in
+/// BOTH lists (FsOnly strips READ from write-only roots; a path in both
+/// keeps read+write, mirroring the real loader's project grant). Ceilings
+/// mirror the 3B plan defaults so limit tests exercise real ceilings and
+/// host verification confirms them. Forbid canaries live OUTSIDE the exec
+/// root (write-only via `/tmp` or unlisted) and stay denied.
+#[cfg(target_os = "linux")]
+fn prod_test_policy(root: &std::path::Path) -> Policy {
+    let mut policy = Policy::default();
+    for cand in ["/bin", "/usr", "/lib", "/lib64", "/etc", "/dev"] {
+        let p = std::path::PathBuf::from(cand);
+        if p.exists() && !policy.allow_read.contains(&p) {
+            policy.allow_read.push(p);
+        }
+    }
+    if !policy.allow_read.contains(&root.to_path_buf()) {
+        policy.allow_read.push(root.to_path_buf());
+    }
+    for cand in [root.to_path_buf(), std::path::PathBuf::from("/tmp")] {
+        if cand.exists() && !policy.allow_write.contains(&cand) {
+            policy.allow_write.push(cand);
+        }
+    }
+    policy.limits = vetto::policy::ResourceLimits {
+        cpu_seconds: Some(5),
+        address_space_bytes: Some(256 * 1024 * 1024),
+        processes: Some(128),
+        open_files: None,
+        file_size_bytes: Some(64 * 1024 * 1024),
+        io_rate: None,
+    };
+    policy
+}
+
 #[cfg(target_os = "linux")]
 fn run_prod(
     script: &str,
@@ -113,7 +155,7 @@ fn run_prod_inner(
         "VETTO_PROD_TEST_ROOT".to_string(),
         root.display().to_string(),
     );
-    let policy = Policy::default();
+    let policy = prod_test_policy(&root);
     let mut log = ProdSpawnLog::new();
     let out = execute_simple(
         &policy,
@@ -968,7 +1010,7 @@ fn test_prod_real_child_stage3b_001() {
         forbid.display().to_string(),
     );
     extra.insert("VETTO_PROD_TEST_PORT".to_string(), port.to_string());
-    let policy = Policy::default();
+    let policy = prod_test_policy(&root);
     let backend = vetto::sandbox::Backend::detect(NetMode::Off, false).expect("detect mechanics");
     let unprepared = UnpreparedProductionExecution::new(
         backend,
@@ -1172,7 +1214,7 @@ fn test_prod_policy_drift_001() {
         root.display().to_string(),
     );
     extra.insert("VETTO_PROD_TEST_MARKER".to_string(), "frozen".to_string());
-    let policy = Policy::default();
+    let policy = prod_test_policy(&root);
     let backend = vetto::sandbox::Backend::detect(NetMode::Off, false).expect("detect mechanics");
     // Caller mutates its OWN copies after moving clones in: the boundary
     // owns snapshots, so these mutations cannot drift the spawn.
@@ -1317,9 +1359,10 @@ fn test_prod_pty_stage3b_001() {
         root.display().to_string(),
     );
     let backend = vetto::sandbox::Backend::detect(NetMode::Off, false).expect("detect mechanics");
+    let policy = prod_test_policy(&root);
     let unprepared = UnpreparedProductionExecution::new(
         backend,
-        Policy::default(),
+        policy,
         vec!["sh".to_string(), staged.display().to_string()],
         root.clone(),
         extra,

--- a/tests/integration/prod_stage3c.rs
+++ b/tests/integration/prod_stage3c.rs
@@ -111,6 +111,15 @@ fn prod_test_policy(root: &std::path::Path) -> Policy {
         file_size_bytes: Some(64 * 1024 * 1024),
         io_rate: None,
     };
+    // Test scripts call tools by bare name (`grep`, `awk`, `sleep`); the
+    // child environment is allowlist-filtered, so pass PATH/HOME through
+    // (production loader profiles grant these; the bare default grants
+    // nothing and every external tool dies with 127/10).
+    for var in ["PATH", "HOME"] {
+        if !policy.environment.pass_through.iter().any(|p| p == var) {
+            policy.environment.pass_through.push(var.to_string());
+        }
+    }
     policy
 }
 

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -249,7 +249,13 @@ fn codex_default_scan_uses_index_first_with_a_fifty_session_limit() {
     create_codex_sqlite_index(&root, &path_refs);
 
     let output = run_rescue(&root, &["scan"]);
-    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    assert!(
+        output.status.success(),
+        "code={:?} stdout={} stderr: {}",
+        output.status.code(),
+        stdout(&output),
+        stderr(&output)
+    );
     let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("scan JSON");
     let discovery = &value["discovery"];
     assert_eq!(discovery["mode"], "index-first");
@@ -429,7 +435,9 @@ fn codex_index_scan_tolerates_an_unbounded_cli_limit_without_aborting() {
     let output = run_rescue(&root, &["scan", "--limit", "1000000000000000"]);
     assert!(
         output.status.success(),
-        "an unbounded --limit must not abort on allocation; stderr: {}",
+        "an unbounded --limit must not abort on allocation; code={:?} stdout={} stderr: {}",
+        output.status.code(),
+        stdout(&output),
         stderr(&output)
     );
 }

--- a/tests/integration/rescue.rs
+++ b/tests/integration/rescue.rs
@@ -251,8 +251,8 @@ fn codex_default_scan_uses_index_first_with_a_fifty_session_limit() {
     let output = run_rescue(&root, &["scan"]);
     assert!(
         output.status.success(),
-        "code={:?} stdout={} stderr: {}",
-        output.status.code(),
+        "{} stdout={} stderr: {}",
+        exit_diagnosis(&output),
         stdout(&output),
         stderr(&output)
     );
@@ -435,8 +435,8 @@ fn codex_index_scan_tolerates_an_unbounded_cli_limit_without_aborting() {
     let output = run_rescue(&root, &["scan", "--limit", "1000000000000000"]);
     assert!(
         output.status.success(),
-        "an unbounded --limit must not abort on allocation; code={:?} stdout={} stderr: {}",
-        output.status.code(),
+        "an unbounded --limit must not abort on allocation; {} stdout={} stderr: {}",
+        exit_diagnosis(&output),
         stdout(&output),
         stderr(&output)
     );


### PR DESCRIPTION
Stage 3C correction: every real production agent path (supervise, multi-agent, MCP) goes through UnpreparedProductionExecution -> prepare -> spawn -> wait_collect/finish. One boundary owns frozen policy/identity/nonce, backend state, the single real spawn (legacy mechanics + Stage 3B), host verification, timeout, nonce sweep and the typed report. Includes session-scoped proctrack sweep (cleanup_A never targets B), Landlock-runner-hardened test policies, and the critical test battery (REAL-CHILD, PREPARE-FAIL, DRIFT, BYPASS, PTY, MCP, MULTI).